### PR TITLE
fix(telegram): type parse_mode on HTML post to green the typecheck

### DIFF
--- a/agent/channels/telegram.ts
+++ b/agent/channels/telegram.ts
@@ -1,4 +1,4 @@
-import { telegramChannel } from "eve/channels/telegram";
+import { telegramChannel, type TelegramMessageBody } from "eve/channels/telegram";
 import { appendFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -319,7 +319,13 @@ export default telegramChannel({
       const md = data.message;
       for (const part of chunkMarkdown(md)) {
         try {
-          await channel.telegram.post({ text: mdToTelegramHtml(part), parse_mode: "HTML" });
+          // eve's TelegramMessageBody type omits parse_mode, но рантайм
+          // (normalizeTelegramMessageBody) спредит тело прямо в sendMessage —
+          // поле доходит до Telegram, и от него зависит наш HTML-рендер. Расширяем тип локально.
+          await channel.telegram.post({
+            text: mdToTelegramHtml(part),
+            parse_mode: "HTML",
+          } as TelegramMessageBody & { parse_mode: "HTML" });
         } catch {
           await channel.telegram.post(part);
         }


### PR DESCRIPTION
## Проблема
`npm run typecheck` (tsgo) красный по всему репо из-за одной ошибки:

```
agent/channels/telegram.ts(322,71): error TS2353: Object literal may only specify
known properties, and 'parse_mode' does not exist in type 'TelegramMessageBody'.
```

## Почему это только типовая проблема
В рантайме всё работает: eve `normalizeTelegramMessageBody` делает `{...body, chat_id}` и шлёт тело **целиком** в Telegram `sendMessage`, так что `parse_mode` доходит до API — именно на нём держится HTML-рендер ответов бота. Просто в интерфейсе eve `TelegramMessageBody` поле `parse_mode` не объявлено.

## Фикс
Локально расширяем тип на месте вызова — `as TelegramMessageBody & { parse_mode: "HTML" }`. Поведение не меняется, рантайм тот же. `npm run typecheck` теперь **exit 0** по всему репо (CI можно гейтить на зелёном typecheck).

Отдельный PR от `main`, не связан с портовым фиксом (PR #1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)