### PR TITLE
feat: OpenAI ChatGPT subscription provider (MODEL_PROVIDER=codex)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,9 @@
 # Управляет инструкцией 05-language, локалью даты (now) и сидом CORE при init-vault.
 AGENT_LANGUAGE=ru
 
-# Провайдер модели: ollama | opencode (оба OpenAI-совместимы, работают с RU-IP).
+# Провайдер модели: ollama | opencode | codex.
+#   ollama/opencode — OpenAI-совместимы (chat/completions), статичный API-ключ ниже.
+#   codex — личная подписка OpenAI (ChatGPT): Responses API + OAuth, ключ НЕ нужен (см. ниже).
 MODEL_PROVIDER=ollama
 
 # Ollama Cloud (если MODEL_PROVIDER=ollama)
@@ -15,6 +17,12 @@ OLLAMA_CONTEXT_WINDOW=131072
 OPENCODE_API_KEY=
 OPENCODE_MODEL=opencode-go/deepseek-v4-pro
 OPENCODE_CONTEXT_WINDOW=131072
+
+# OpenAI по подписке ChatGPT (если MODEL_PROVIDER=codex). Вход: `iva login`
+# (по ссылке+коду) или `iva login --browser`. Токен → data/codex-auth.json (0600, не в .env).
+# API-ключ НЕ нужен. Модель выбирается в `iva config` из реального списка подписки.
+CODEX_MODEL=gpt-5.1
+CODEX_CONTEXT_WINDOW=272000
 
 # Браузер agent-browser: потолок вывода (защита окна контекста).
 AGENT_BROWSER_MAX_OUTPUT=24000

--- a/agent/agent.ts
+++ b/agent/agent.ts
@@ -1,21 +1,26 @@
 import { defineAgent } from "eve";
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
-// Провайдер (Ollama Cloud / OpenCode Zen) и его модели — единый источник в provider.ts,
-// тот же конфиг переиспользует agent/vision.ts (vision-модель того же провайдера).
-import { providerConfig as cfg, providerName, withReasoningStripped } from "./provider.js";
+// Провайдер и его модели — единый источник в provider.ts (тот же конфиг у agent/vision.ts).
+// codex = подписка ChatGPT (Responses API + OAuth); ollama/opencode = OpenAI-совместимый chat.
+import { providerConfig as cfg, providerName, withReasoningStripped, makeCodexModel } from "./provider.js";
 
-const provider = createOpenAICompatible({
-  name: `iva-${providerName}`,
-  baseURL: cfg.baseURL,
-  apiKey: cfg.apiKey,
-  // Без этого стрим OpenAI-совместимых провайдеров НЕ несёт usage (нет stream_options:
-  // {include_usage:true}) → событие step.completed приходит без поля usage, и учёт токенов
-  // (agent/hooks/usage.ts) пуст. Включаем, чтобы провайдер отдавал расход в финальном чанке.
-  includeUsage: true,
-});
+// Codex-подписка говорит на Responses API — отдельная модель-фабрика (@ai-sdk/openai).
+// Остальные провайдеры — OpenAI-совместимый chat/completions через openai-compatible.
+const textModel =
+  providerName === "codex"
+    ? makeCodexModel()
+    : createOpenAICompatible({
+        name: `iva-${providerName}`,
+        baseURL: cfg.baseURL,
+        apiKey: cfg.apiKey,
+        // Без этого стрим OpenAI-совместимых провайдеров НЕ несёт usage (нет stream_options:
+        // {include_usage:true}) → событие step.completed приходит без поля usage, и учёт токенов
+        // (agent/hooks/usage.ts) пуст. Включаем, чтобы провайдер отдавал расход в финальном чанке.
+        includeUsage: true,
+      })(cfg.textModel);
 
 export default defineAgent({
-  model: withReasoningStripped(provider(cfg.textModel)),
+  model: withReasoningStripped(textModel),
   // Кастомный провайдер не отдаёт метаданные окна через AI Gateway — задаём вручную.
   // ВАЖНО: значение ОБЯЗАНО быть ≤ реального окна модели, иначе запрос переполнит окно до компактации.
   modelContextWindowTokens: cfg.contextWindow,

--- a/agent/hooks/usage.ts
+++ b/agent/hooks/usage.ts
@@ -14,9 +14,11 @@ import { appendUsage } from "../../scripts/lib/usage.mjs";
 const PROVIDER = process.env.MODEL_PROVIDER ?? "ollama";
 // Модель/провайдер не приходят в событие — берём из env (та же логика, что в agent/agent.ts).
 const MODEL =
-  PROVIDER === "opencode"
-    ? (process.env.OPENCODE_MODEL ?? "deepseek-v4-pro").replace(/^opencode-go\//, "")
-    : (process.env.OLLAMA_MODEL ?? "deepseek-v4-pro");
+  PROVIDER === "codex"
+    ? (process.env.CODEX_MODEL ?? "gpt-5.1")
+    : PROVIDER === "opencode"
+      ? (process.env.OPENCODE_MODEL ?? "deepseek-v4-pro").replace(/^opencode-go\//, "")
+      : (process.env.OLLAMA_MODEL ?? "deepseek-v4-pro");
 
 interface StepData {
   stepIndex: number;

--- a/agent/provider.ts
+++ b/agent/provider.ts
@@ -1,10 +1,13 @@
 import { wrapLanguageModel, type LanguageModelMiddleware } from "ai";
+import { createOpenAI } from "@ai-sdk/openai";
+import { CODEX_BASE_URL, codexAuthHeaders } from "../scripts/lib/codex-oauth.mjs";
 
 type WrappableModel = Parameters<typeof wrapLanguageModel>[0]["model"];
 
 // Единый источник конфигурации провайдера модели (выбор раз при старте через MODEL_PROVIDER).
-// Обе площадки OpenAI-совместимы; ключи — из .env. Здесь же зашита vision-модель ТОГО ЖЕ
-// провайдера (один ключ, без доп-подписок) — её зовёт agent/vision.ts для распознавания картинок.
+// ollama/opencode — OpenAI-совместимы (chat/completions, статичный ключ из .env).
+// codex — личная подписка OpenAI (ChatGPT): Responses API + OAuth-токен (data/codex-auth.json,
+// `iva login`). Здесь же зашита vision-модель провайдера — её зовёт agent/vision.ts.
 const PROVIDER = process.env.MODEL_PROVIDER ?? "ollama";
 
 const PROVIDERS = {
@@ -24,10 +27,45 @@ const PROVIDERS = {
     contextWindow: Number(process.env.OPENCODE_CONTEXT_WINDOW ?? 131072),
     visionModel: "gemini-3-flash",
   },
+  codex: {
+    baseURL: CODEX_BASE_URL,
+    apiKey: undefined, // авторизация — OAuth-токен подписки, не статичный ключ (см. codexFetch)
+    textModel: process.env.CODEX_MODEL ?? "gpt-5.1",
+    contextWindow: Number(process.env.CODEX_CONTEXT_WINDOW ?? 272000),
+    // gpt-5* мультимодальны — картинки идут через ту же подписку (см. agent/vision.ts).
+    visionModel: process.env.CODEX_MODEL ?? "gpt-5.1",
+  },
 } as const;
 
 export const providerName = PROVIDER;
 export const providerConfig = PROVIDERS[PROVIDER as keyof typeof PROVIDERS] ?? PROVIDERS.ollama;
+
+// --- Codex (подписка ChatGPT): Responses API через @ai-sdk/openai ----------------------------
+// Кастомный fetch: перед КАЖДЫМ запросом подставляет свежий Bearer + ChatGPT-Account-ID
+// (getAccessToken рефрешит истёкший токен) и форсит store:false — бэкенд подписки stateless,
+// историю eve шлёт целиком каждый ход. Тело патчим здесь же (точка правки, если бэкенд строже).
+const codexFetch: typeof fetch = async (input, init) => {
+  const headers = new Headers(init?.headers);
+  for (const [k, v] of Object.entries(await codexAuthHeaders())) headers.set(k, v);
+  let body = init?.body;
+  if (typeof body === "string" && String((input as Request).url ?? input).endsWith("/responses")) {
+    try {
+      const j = JSON.parse(body);
+      j.store = false;
+      delete j.previous_response_id;
+      body = JSON.stringify(j);
+    } catch {
+      /* не JSON — не трогаем */
+    }
+  }
+  return fetch(input, { ...init, headers, body });
+};
+
+/** Строит Codex-модель (Responses API подписки). Общая для agent.ts и vision.ts. */
+export function makeCodexModel(model: string = providerConfig.textModel) {
+  const openai = createOpenAI({ baseURL: CODEX_BASE_URL, apiKey: "chatgpt-subscription", fetch: codexFetch });
+  return openai.responses(model);
+}
 
 // --- Анти-InvalidPrompt: срезаем reasoning из вывода модели ---------------------------------
 // deepseek (openai-compatible) иногда отдаёт reasoning-часть без поля `text`. eve хранит reasoning

--- a/agent/vision.ts
+++ b/agent/vision.ts
@@ -1,13 +1,32 @@
-import { providerConfig } from "./provider.js";
+import { generateText } from "ai";
+import { providerConfig, providerName, makeCodexModel } from "./provider.js";
 
 const PROMPT =
   "Опиши изображение детально и по делу: что на нём, дословный текст (OCR), важные детали и цифры. " +
   "Без преамбул и воды — только содержимое.";
 
-// Распознаёт картинку vision-моделью ТОГО ЖЕ провайдера (на существующем ключе, без доп-подписок).
+// Распознаёт картинку vision-моделью ТОГО ЖЕ провайдера (на существующем доступе, без доп-подписок).
 // Возвращает текстовое описание, либо "" если распознать нечем (нет ключа/vision-модели).
 // Сетевые/HTTP-ошибки бросает — вызывающий ловит и продолжает ход без зрения (graceful).
 export async function describeImage(bytes: ArrayBuffer, mimeType?: string): Promise<string> {
+  // codex-подписка: Responses API мультимодален — гоним картинку через ту же модель/токен.
+  if (providerName === "codex") {
+    const { text } = await generateText({
+      model: makeCodexModel(providerConfig.visionModel),
+      providerOptions: { openai: { store: false } },
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: PROMPT },
+            { type: "image", image: new Uint8Array(bytes), mediaType: mimeType || "image/jpeg" },
+          ],
+        },
+      ],
+    });
+    return (text ?? "").trim();
+  }
+
   const { baseURL, apiKey, visionModel } = providerConfig;
   if (!apiKey || !visionModel) return "";
   const b64 = Buffer.from(bytes).toString("base64");

--- a/bin/iva.mjs
+++ b/bin/iva.mjs
@@ -58,6 +58,13 @@ function readEnv() {
   return env;
 }
 
+// Абсолютный путь к каталогу data (тот же, что видит агент из cwd=ROOT). Абсолютный
+// ASSISTANT_DATA_DIR берём как есть, относительный — от ROOT (как vault-путь ниже).
+function dataDirAbs(env = readEnv()) {
+  const d = env.ASSISTANT_DATA_DIR || "data";
+  return d.startsWith("/") ? d : join(ROOT, d);
+}
+
 async function confirm(question, def = false) {
   if (!process.stdin.isTTY) return def;
   const rl = createInterface({ input: process.stdin, output: process.stdout });
@@ -347,14 +354,15 @@ function cmdDoctor() {
   if (!existsSync(ENV_PATH)) (bad(".env missing — run: iva config"), badN++);
   else {
     const prov = env.MODEL_PROVIDER || "ollama";
-    const REQUIRED = [
-      prov === "opencode" ? "OPENCODE_API_KEY" : "OLLAMA_API_KEY",
-      prov === "opencode" ? "OPENCODE_MODEL" : "OLLAMA_MODEL",
-      "DEEPGRAM_API_KEY",
-      "TELEGRAM_BOT_TOKEN",
-      "TELEGRAM_ALLOWED_USER_IDS",
-    ];
+    // codex — доступ по OAuth-токену (data/codex-auth.json), у ollama/opencode — API-ключ в .env.
+    const PROV_KEYS = {
+      ollama: ["OLLAMA_API_KEY", "OLLAMA_MODEL"],
+      opencode: ["OPENCODE_API_KEY", "OPENCODE_MODEL"],
+      codex: ["CODEX_MODEL"],
+    };
+    const REQUIRED = [...(PROV_KEYS[prov] || PROV_KEYS.ollama), "DEEPGRAM_API_KEY", "TELEGRAM_BOT_TOKEN", "TELEGRAM_ALLOWED_USER_IDS"];
     const missing = REQUIRED.filter((k) => !(env[k] || "").trim());
+    if (prov === "codex" && !existsSync(join(dataDirAbs(env), "codex-auth.json"))) missing.push("OpenAI sign-in (iva login)");
     if (!missing.length) (ok(`.env filled in (provider: ${prov})`), okN++);
     else (bad(`.env incomplete, missing: ${missing.join(", ")} — run: iva config`), badN++);
     // old .env without IVA_PORT (or with :3000) — migrate right here
@@ -544,6 +552,26 @@ async function cmdUsage(args) {
   console.log(formatUsageReport(agg));
 }
 
+// OpenAI subscription (ChatGPT) login — device code by default, --browser for the PKCE flow.
+// Writes an OAuth token to data/codex-auth.json (0600); used when MODEL_PROVIDER=codex.
+async function cmdLogin(args) {
+  const { runDeviceCodeLogin, runBrowserLogin } = await import("../scripts/lib/codex-oauth.mjs");
+  const dataDir = dataDirAbs();
+  const browser = args.includes("--browser");
+  step(browser ? "OpenAI sign-in (browser)…" : "OpenAI sign-in (device code)…");
+  try {
+    const auth = browser
+      ? await runBrowserLogin({ dataDir, log: (m) => console.log(m) })
+      : await runDeviceCodeLogin({ dataDir, log: (m) => console.log(m) });
+    ok(`Signed in${auth.planType ? ` — plan: ${auth.planType}` : ""}${auth.accountId ? ` · account ${auth.accountId}` : ""}`);
+    console.log(`${C.d}Token stored: ${join(dataDir, "codex-auth.json")} (chmod 600)${C.x}`);
+    if (readEnv().MODEL_PROVIDER !== "codex") warn("Set MODEL_PROVIDER=codex to use it: iva config (then iva restart)");
+  } catch (e) {
+    bad(`Sign-in failed: ${e.message}`);
+    process.exit(1);
+  }
+}
+
 function cmdHelp() {
   console.log(`
 ${C.b}Iva CLI${C.x} — manage your personal agent
@@ -551,6 +579,7 @@ ${C.b}Iva CLI${C.x} — manage your personal agent
 ${C.b}Commands:${C.x}
   ${C.c}iva update${C.x}         update: git pull + build + restart
   ${C.c}iva config${C.x}         configure: model, Telegram, Deepgram, TZ, vault
+  ${C.c}iva login${C.x} [--browser]  sign in to an OpenAI subscription (ChatGPT) for MODEL_PROVIDER=codex
   ${C.c}iva doctor${C.x}         diagnose and safely auto-repair the install
   ${C.c}iva status${C.x}         status of services and memory timers
   ${C.c}iva restart${C.x}        restart the agent and Telegram bridge
@@ -570,6 +599,7 @@ const [, , cmd, ...rest] = process.argv;
 const cmds = {
   update: cmdUpdate,
   config: cmdConfig,
+  login: cmdLogin,
   doctor: cmdDoctor,
   status: cmdStatus,
   restart: cmdRestart,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -38,6 +38,7 @@ The installer puts `iva` in `~/.local/bin`. Commands that touch systemd need a L
 |---|---|
 | `iva update [--force]` | git fetch + fast-forward (hard-reset if upstream was force-pushed), `npm ci` when package files changed, `eve build`, restart. `--force` rebuilds with no new commits. A failed build never restarts the service — the old build keeps running |
 | `iva config` | The 5-step setup wizard, then offers a restart to apply |
+| `iva login [--browser]` | Sign in to an OpenAI (ChatGPT) subscription for `MODEL_PROVIDER=codex`. Default is device code (a link + one-time code, works on a headless VPS); `--browser` runs the local PKCE flow. Token → `data/codex-auth.json` (chmod 600) |
 | `iva doctor` | Checks Node ≥ 24, `.env` keys, build, units, both services, 5 memory timers, vault git origin — auto-repairs what's safe |
 | `iva status` | Status of both services + the memory-timer schedule |
 | `iva restart` | Regenerates units (keeps the port in sync with `IVA_PORT`), restarts agent + bridge |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,17 +12,21 @@ No rebuild. Swapping a model, key or provider is edit → restart.
 
 ## Model provider
 
-Two providers, both OpenAI-compatible. Pick one with `MODEL_PROVIDER` and fill only that block. Prices and full model lists: [providers.md](./providers.md).
+Three providers. Pick one with `MODEL_PROVIDER` and fill only that block. `ollama`/`opencode` are OpenAI-compatible API keys; `codex` rides your OpenAI (ChatGPT) subscription via OAuth — no key. Prices and full model lists: [providers.md](./providers.md).
 
 | Variable | Default | Notes |
 |---|---|---|
-| `MODEL_PROVIDER` | `ollama` | `ollama` (Ollama Cloud) or `opencode` (OpenCode Zen). |
+| `MODEL_PROVIDER` | `ollama` | `ollama` (Ollama Cloud), `opencode` (OpenCode Zen) or `codex` (OpenAI ChatGPT subscription). |
 | `OLLAMA_API_KEY` | — | Key from ollama.com. |
 | `OLLAMA_MODEL` | `deepseek-v4-pro` | Any model on your Ollama Cloud plan. |
 | `OLLAMA_CONTEXT_WINDOW` | `131072` | See warning below. |
 | `OPENCODE_API_KEY` | — | Key from opencode.ai/auth. |
 | `OPENCODE_MODEL` | `opencode-go/deepseek-v4-pro` | Any Zen Go model. |
 | `OPENCODE_CONTEXT_WINDOW` | `131072` | Same warning. |
+| `CODEX_MODEL` | `gpt-5.1` | Model from your OpenAI plan. `iva config` lists what your subscription actually exposes. |
+| `CODEX_CONTEXT_WINDOW` | `272000` | Same warning — set the real window of the model you picked. |
+
+For `codex` there is no API key in `.env`: run `iva login` (device code, headless-friendly) or `iva login --browser`. The OAuth token lives in `data/codex-auth.json` (chmod 600, gitignored) and is auto-refreshed before it expires. Full flow: [providers.md](./providers.md#openai-by-chatgpt-subscription-codex).
 
 **Don't inflate the context window.** Compaction triggers at 70% of this number. Set it above the model's real window and the compactor fires too late — the request overflows before history gets trimmed. When you switch models, enter the new model's actual window, not a rounder bigger one.
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -8,18 +8,32 @@ Iva runs on your server with your keys. Here is every external service it talks 
 |---|---|---|---|
 | **OpenCode Zen Go** | ~$5/mo | `deepseek-v4-pro` (default), `deepseek-v4-flash`, `kimi-k2.7-code`, `glm-5.2`, `qwen3.7` | `gemini-3-flash` |
 | **Ollama Cloud** | ~$20/mo | `deepseek-v4-pro` (default) | `gemma3:12b` |
+| **OpenAI (ChatGPT subscription)** | your existing Plus/Pro/Team | the models your plan exposes (`gpt-5.x`, `-codex`), fetched live | same subscription (multimodal) |
 
-From Iva's side the two are interchangeable:
+The first two are plain API keys; the third rides your personal OpenAI subscription:
 
-- 🔌 **OpenAI-compatible** — same wire format on both, so switching is one line in `.env`
-- 🌍 **Any IP** — both endpoints answer from any server location, no region blocks
+- 🔌 **OpenAI-compatible** — Zen and Ollama share the same wire format, so switching is one line in `.env`
+- 🌍 **Any IP** — all three answer from any server location, no region blocks
 - 💸 **No markup** — you pay the provider directly; Iva adds nothing on top
 
 ```bash
-MODEL_PROVIDER=opencode   # or ollama, then `iva restart`
+MODEL_PROVIDER=opencode   # or ollama / codex, then `iva restart`
 ```
 
 Start with Zen: a quarter of the price, five models to switch between. Keys, model pick and context-window settings live in [configuration.md](configuration.md).
+
+### OpenAI by ChatGPT subscription (`codex`)
+
+Use the OpenAI subscription you already pay for — no separate API key, no per-token bill. Iva signs in the same way the official `codex` CLI does (OAuth against `auth.openai.com`), stores a refreshable token in `data/codex-auth.json` (chmod 600), and calls the subscription's Responses backend directly. The access token is refreshed automatically before it expires.
+
+```bash
+iva login              # device code: opens a link + one-time code (works on a headless VPS)
+iva login --browser    # PKCE flow: opens a browser on this machine
+iva config             # pick the provider (option 3) and a model from your plan's live list
+iva restart
+```
+
+Notes: the model list is pulled from your subscription at setup time, so you always see exactly what your plan allows. Set `CODEX_CONTEXT_WINDOW` to the real window of the model you picked (compaction derives its threshold from it). Routing a self-hosted assistant through the ChatGPT subscription backend is a grey area under OpenAI's terms — you are using your own subscription on your own server, but weigh that yourself.
 
 ## Vision
 

--- a/docs/ru/configuration.md
+++ b/docs/ru/configuration.md
@@ -15,17 +15,21 @@ iva restart
 
 ## Провайдер модели
 
-Два провайдера, оба совместимы с OpenAI. Выберите один через `MODEL_PROVIDER` и заполните только его блок. Цены и полные списки моделей: [providers.md](../providers.md).
+Три провайдера. Выберите один через `MODEL_PROVIDER` и заполните только его блок. `ollama`/`opencode` — API-ключ (OpenAI-совместимы); `codex` — личная подписка OpenAI (ChatGPT) по OAuth, без ключа. Цены и полные списки моделей: [providers.md](../providers.md).
 
 | Переменная | По умолчанию | Заметки |
 |---|---|---|
-| `MODEL_PROVIDER` | `ollama` | `ollama` (Ollama Cloud) или `opencode` (OpenCode Zen). |
+| `MODEL_PROVIDER` | `ollama` | `ollama` (Ollama Cloud), `opencode` (OpenCode Zen) или `codex` (подписка OpenAI ChatGPT). |
 | `OLLAMA_API_KEY` | — | Ключ с ollama.com. |
 | `OLLAMA_MODEL` | `deepseek-v4-pro` | Любая модель вашего тарифа Ollama Cloud. |
 | `OLLAMA_CONTEXT_WINDOW` | `131072` | См. предупреждение ниже. |
 | `OPENCODE_API_KEY` | — | Ключ с opencode.ai/auth. |
 | `OPENCODE_MODEL` | `opencode-go/deepseek-v4-pro` | Любая модель Zen Go. |
 | `OPENCODE_CONTEXT_WINDOW` | `131072` | То же предупреждение. |
+| `CODEX_MODEL` | `gpt-5.1` | Модель вашего тарифа OpenAI. `iva config` покажет реальный список подписки. |
+| `CODEX_CONTEXT_WINDOW` | `272000` | То же предупреждение — впишите реальное окно выбранной модели. |
+
+Для `codex` ключа в `.env` нет: выполните `iva login` (по ссылке+коду, годится для headless-VPS) или `iva login --browser`. OAuth-токен лежит в `data/codex-auth.json` (chmod 600, в gitignore) и автоматически обновляется до истечения. Полный сценарий: [providers.md](../providers.md#openai-by-chatgpt-subscription-codex).
 
 **Не завышайте контекстное окно.** Сжатие истории срабатывает на 70% этого числа. Поставите больше реального окна модели — компактор включится слишком поздно: запрос переполнится раньше, чем история будет подрезана. Меняете модель — вписывайте её настоящее окно, а не круглое число побольше.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iva",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iva",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/openai": "4.0.0-beta.76",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "iva",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iva",
-      "version": "0.1.7",
+      "version": "0.2.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@ai-sdk/openai": "4.0.0-beta.76",
         "@ai-sdk/openai-compatible": "^3.0.0-beta.57",
         "@vercel/connect": "0.2.2",
         "ai": "7.0.0-beta.178",
@@ -52,6 +53,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 20"
+      }
+    },
+    "node_modules/@ai-sdk/openai": {
+      "version": "4.0.0-beta.76",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-4.0.0-beta.76.tgz",
+      "integrity": "sha512-hi5s1clmdqPWS2xjeXTRvkPIxqnJAeJIOXYjjf/B4ZlkDIsvyn6asvDL81OvsOF2/FtxfparuHrrWYDvN5yHog==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.0-beta.19",
+        "@ai-sdk/provider-utils": "5.0.0-beta.49"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/openai-compatible": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iva",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "bin": {
     "iva": "bin/iva.mjs"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "postinstall": "patch-package"
   },
   "dependencies": {
+    "@ai-sdk/openai": "4.0.0-beta.76",
     "@ai-sdk/openai-compatible": "^3.0.0-beta.57",
     "@vercel/connect": "0.2.2",
     "ai": "7.0.0-beta.178",

--- a/scripts/lib/codex-oauth.d.mts
+++ b/scripts/lib/codex-oauth.d.mts
@@ -1,0 +1,32 @@
+// Типы для codex-oauth.mjs (чистый ESM) — чтобы tsgo-потребители (agent/provider.ts,
+// agent/vision.ts) не ловили TS7016. Формат хранилища data/codex-auth.json.
+export interface CodexAuth {
+  id_token?: string;
+  access_token: string;
+  refresh_token?: string;
+  accountId: string | null;
+  planType: string | null;
+}
+
+export interface LoginOptions {
+  dataDir?: string;
+  log?: (msg: string) => void;
+  open?: boolean;
+}
+
+export const ISSUER: string;
+export const CLIENT_ID: string;
+export const CODEX_BASE_URL: string;
+
+export function authFilePath(dataDir?: string): string;
+export function readAuth(dataDir?: string): CodexAuth | null;
+export function writeAuth(auth: CodexAuth, dataDir?: string): void;
+export function parseJwt(jwt: string): Record<string, unknown>;
+export function jwtExp(jwt: string): number;
+export function accountFromIdToken(idToken: string): { accountId: string | null; planType: string | null };
+export function getAccessToken(dataDir?: string): Promise<{ accessToken: string; accountId: string | null }>;
+export function codexAuthHeaders(dataDir?: string): Promise<Record<string, string>>;
+export function runDeviceCodeLogin(opts?: LoginOptions): Promise<CodexAuth>;
+export function runBrowserLogin(opts?: LoginOptions): Promise<CodexAuth>;
+export function login(mode?: "device" | "browser", opts?: LoginOptions): Promise<CodexAuth>;
+export function listCodexModels(opts?: { dataDir?: string }): Promise<string[]>;

--- a/scripts/lib/codex-oauth.mjs
+++ b/scripts/lib/codex-oauth.mjs
@@ -210,9 +210,13 @@ export async function runDeviceCodeLogin({ dataDir = defaultDir(), log = console
 
 // ── browser-PKCE flow (локальный сервер + авто-открытие браузера) ───────────
 function openBrowser(url) {
-  const cmd = process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open";
+  const win = process.platform === "win32";
+  const cmd = process.platform === "darwin" ? "open" : win ? "start" : "xdg-open";
+  // win32: `start` берёт первый аргумент как заголовок окна, а в authorize-URL есть `&` →
+  // передаём пустой заголовок "" перед URL, иначе cmd.exe не откроет ссылку.
+  const args = win ? ["", url] : [url];
   try {
-    spawn(cmd, [url], { stdio: "ignore", detached: true, shell: process.platform === "win32" }).unref();
+    spawn(cmd, args, { stdio: "ignore", detached: true, shell: win }).unref();
   } catch {
     /* нет графики (headless) — пользователь откроет ссылку сам */
   }

--- a/scripts/lib/codex-oauth.mjs
+++ b/scripts/lib/codex-oauth.mjs
@@ -1,0 +1,326 @@
+// OAuth-ядро для входа по подписке OpenAI (ChatGPT Plus/Pro/Team) — как в официальном codex CLI.
+// ЕДИНЫЙ источник правды: импортируется и из bare-node (bin/iva.mjs, scripts/setup.mjs),
+// и из бандла eve (agent/provider.ts, agent/vision.ts) — как scripts/lib/usage.mjs.
+// Чистый ESM, только node-builtins (crypto/fs/http/child_process). Типы — в codex-oauth.d.mts.
+//
+// Протокол (reverse-engineered из openai/codex, публичный client_id):
+//   auth-домен  https://auth.openai.com     device-code + browser-PKCE + refresh
+//   API-домен   https://chatgpt.com/backend-api/codex   Responses API (/responses, /models)
+// Токен (access_token — JWT, живёт ~1 ч) кладём в data/codex-auth.json (0600, gitignored).
+// Перед каждым запросом getAccessToken() рефрешит токен при подходе к exp (refresh_token одноразовый).
+import { createHash, randomBytes } from "node:crypto";
+import { chmodSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
+import { spawn } from "node:child_process";
+import { dirname, join } from "node:path";
+
+export const ISSUER = "https://auth.openai.com";
+export const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"; // публичный client_id Codex CLI
+export const CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex";
+const TOKEN_URL = `${ISSUER}/oauth/token`;
+const SCOPE = "openid profile email offline_access";
+const ORIGINATOR = "codex_cli_rs";
+const CLIENT_VERSION = "0.20.0"; // для ?client_version= у /models и User-Agent (мимикрия под codex CLI)
+const REFRESH_SKEW_S = 300; // рефрешим за 5 мин до exp (как окно codex CLI)
+const DEVICE_PORT = 1455; // codex-совместимый redirect-порт (fallback 1457)
+const FALLBACK_PORT = 1457;
+
+const b64url = (buf) => Buffer.from(buf).toString("base64url");
+const defaultDir = () => process.env.ASSISTANT_DATA_DIR || "data";
+
+// ── хранилище токенов ─────────────────────────────────────────────────────
+export function authFilePath(dataDir = defaultDir()) {
+  return join(dataDir, "codex-auth.json");
+}
+
+export function readAuth(dataDir = defaultDir()) {
+  try {
+    return JSON.parse(readFileSync(authFilePath(dataDir), "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+// Атомарная запись 0600 (temp + rename) — секрет не должен мелькнуть с широкими правами,
+// а конкурентный read не должен поймать полу-записанный файл.
+export function writeAuth(auth, dataDir = defaultDir()) {
+  const file = authFilePath(dataDir);
+  mkdirSync(dirname(file), { recursive: true });
+  const tmp = `${file}.${process.pid}.tmp`;
+  writeFileSync(tmp, JSON.stringify(auth, null, 2), { mode: 0o600 });
+  chmodSync(tmp, 0o600);
+  renameSync(tmp, file);
+}
+
+// ── JWT / PKCE (без внешних зависимостей) ──────────────────────────────────
+export function parseJwt(jwt) {
+  const payload = String(jwt).split(".")[1];
+  if (!payload) throw new Error("malformed JWT");
+  return JSON.parse(Buffer.from(payload, "base64url").toString("utf8"));
+}
+
+// exp (unix-секунды) из access_token; 0 если нет клейма.
+export function jwtExp(jwt) {
+  try {
+    return Number(parseJwt(jwt).exp) || 0;
+  } catch {
+    return 0;
+  }
+}
+
+// Из id_token достаём account_id и план подписки (клейм https://api.openai.com/auth).
+export function accountFromIdToken(idToken) {
+  let auth = {};
+  try {
+    auth = parseJwt(idToken)["https://api.openai.com/auth"] || {};
+  } catch {
+    /* нет клейма — вернём пустое */
+  }
+  return { accountId: auth.chatgpt_account_id || null, planType: auth.chatgpt_plan_type || null };
+}
+
+function pkce() {
+  const verifier = b64url(randomBytes(64));
+  const challenge = b64url(createHash("sha256").update(verifier).digest());
+  return { verifier, challenge };
+}
+
+// ── обмен кода и refresh (общий /oauth/token) ──────────────────────────────
+async function exchangeCode({ code, verifier, redirectUri }) {
+  const body = new URLSearchParams({
+    grant_type: "authorization_code",
+    code,
+    redirect_uri: redirectUri,
+    client_id: CLIENT_ID,
+    code_verifier: verifier,
+  });
+  const res = await fetch(TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+  if (!res.ok) throw new Error(`token exchange failed: ${res.status} ${(await res.text()).slice(0, 300)}`);
+  return res.json(); // { id_token, access_token, refresh_token }
+}
+
+async function refresh(refreshToken) {
+  const res = await fetch(TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ client_id: CLIENT_ID, grant_type: "refresh_token", refresh_token: refreshToken }),
+  });
+  if (!res.ok) throw new Error(`token refresh failed: ${res.status} ${(await res.text()).slice(0, 300)}`);
+  return res.json(); // { id_token?, access_token, refresh_token? }
+}
+
+// Собирает объект хранилища из ответа токен-эндпоинта.
+function toAuth(tokens, prev = {}) {
+  const idToken = tokens.id_token || prev.id_token;
+  const { accountId, planType } = idToken ? accountFromIdToken(idToken) : { accountId: prev.accountId, planType: prev.planType };
+  return {
+    id_token: idToken,
+    access_token: tokens.access_token,
+    refresh_token: tokens.refresh_token || prev.refresh_token,
+    accountId,
+    planType,
+  };
+}
+
+// ── getAccessToken: свежий токен для каждого запроса ────────────────────────
+// Дедуп рефреша в пределах процесса (модель зовётся конкурентно). Кросс-процессный
+// рейс (CLI login + сервер) маловероятен и самолечится: при провале рефреша
+// перечитываем файл — вдруг другой процесс уже обновил.
+let refreshInFlight = null;
+export async function getAccessToken(dataDir = defaultDir()) {
+  let auth = readAuth(dataDir);
+  if (!auth?.access_token) throw new Error("not logged in — run `iva login`");
+  const fresh = jwtExp(auth.access_token) - REFRESH_SKEW_S > Math.floor(Date.now() / 1000);
+  if (fresh) return { accessToken: auth.access_token, accountId: auth.accountId };
+
+  if (!refreshInFlight) {
+    refreshInFlight = (async () => {
+      try {
+        const next = toAuth(await refresh(auth.refresh_token), auth);
+        writeAuth(next, dataDir);
+        return next;
+      } catch (err) {
+        const reread = readAuth(dataDir); // мог обновить другой процесс
+        if (reread?.access_token && jwtExp(reread.access_token) - REFRESH_SKEW_S > Math.floor(Date.now() / 1000)) return reread;
+        throw err;
+      } finally {
+        refreshInFlight = null;
+      }
+    })();
+  }
+  auth = await refreshInFlight;
+  return { accessToken: auth.access_token, accountId: auth.accountId };
+}
+
+// Заголовки авторизации для вызова Codex-бэкенда (/responses, /models).
+export async function codexAuthHeaders(dataDir = defaultDir()) {
+  const { accessToken, accountId } = await getAccessToken(dataDir);
+  const h = {
+    Authorization: `Bearer ${accessToken}`,
+    originator: ORIGINATOR,
+    "User-Agent": `${ORIGINATOR}/${CLIENT_VERSION}`,
+  };
+  if (accountId) h["ChatGPT-Account-ID"] = accountId;
+  return h;
+}
+
+// ── device-code flow (headless-friendly, по ссылке) ────────────────────────
+export async function runDeviceCodeLogin({ dataDir = defaultDir(), log = console.log } = {}) {
+  const api = `${ISSUER}/api/accounts`;
+  const uc = await fetch(`${api}/deviceauth/usercode`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ client_id: CLIENT_ID }),
+  });
+  if (!uc.ok) throw new Error(`device usercode failed: ${uc.status} ${(await uc.text()).slice(0, 200)}`);
+  const { device_auth_id, user_code, interval } = await uc.json();
+
+  log(`\n  1. Открой в браузере (на любом устройстве):  ${ISSUER}/codex/device`);
+  log(`  2. Введи одноразовый код (живёт 15 минут):   ${user_code}\n`);
+  log("  Жду подтверждения…");
+
+  const pollMs = Math.max(Number(interval) || 5, 1) * 1000;
+  const deadline = Date.now() + 15 * 60 * 1000;
+  for (;;) {
+    if (Date.now() > deadline) throw new Error("device auth timed out (15 min)");
+    const r = await fetch(`${api}/deviceauth/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ device_auth_id, user_code }),
+    });
+    if (r.ok) {
+      const { authorization_code, code_verifier } = await r.json();
+      const tokens = await exchangeCode({
+        code: authorization_code,
+        verifier: code_verifier,
+        redirectUri: `${ISSUER}/deviceauth/callback`,
+      });
+      const auth = toAuth(tokens);
+      writeAuth(auth, dataDir);
+      return auth;
+    }
+    if (r.status !== 403 && r.status !== 404) throw new Error(`device auth failed: ${r.status}`);
+    await new Promise((res) => setTimeout(res, pollMs));
+  }
+}
+
+// ── browser-PKCE flow (локальный сервер + авто-открытие браузера) ───────────
+function openBrowser(url) {
+  const cmd = process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open";
+  try {
+    spawn(cmd, [url], { stdio: "ignore", detached: true, shell: process.platform === "win32" }).unref();
+  } catch {
+    /* нет графики (headless) — пользователь откроет ссылку сам */
+  }
+}
+
+export async function runBrowserLogin({ dataDir = defaultDir(), log = console.log, open = true } = {}) {
+  const { verifier, challenge } = pkce();
+  const state = b64url(randomBytes(32));
+  const port = await listenFirstFree([DEVICE_PORT, FALLBACK_PORT]);
+  const redirectUri = `http://localhost:${port.port}/auth/callback`;
+  const authorizeUrl =
+    `${ISSUER}/oauth/authorize?` +
+    new URLSearchParams({
+      response_type: "code",
+      client_id: CLIENT_ID,
+      redirect_uri: redirectUri,
+      scope: SCOPE,
+      code_challenge: challenge,
+      code_challenge_method: "S256",
+      id_token_add_organizations: "true",
+      codex_cli_simplified_flow: "true",
+      state,
+      originator: ORIGINATOR,
+    }).toString();
+
+  log(`\n  Открой в браузере и войди в OpenAI:\n  ${authorizeUrl}\n`);
+  if (open) openBrowser(authorizeUrl);
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      port.server.close();
+      reject(new Error("browser login timed out (10 min)"));
+    }, 10 * 60 * 1000);
+
+    port.server.on("request", async (req, res) => {
+      const url = new URL(req.url, `http://localhost:${port.port}`);
+      if (url.pathname !== "/auth/callback") {
+        res.writeHead(404).end("Not found");
+        return;
+      }
+      const done = (code, msg) => {
+        res.writeHead(code, { "Content-Type": "text/html; charset=utf-8" }).end(`<h3>${msg}</h3>`);
+      };
+      try {
+        if (url.searchParams.get("state") !== state) throw new Error("state mismatch");
+        const err = url.searchParams.get("error");
+        if (err) throw new Error(`OAuth error: ${err}`);
+        const code = url.searchParams.get("code");
+        if (!code) throw new Error("missing authorization code");
+        const auth = toAuth(await exchangeCode({ code, verifier, redirectUri }));
+        writeAuth(auth, dataDir);
+        done(200, "Готово — вход выполнен. Можно закрыть вкладку и вернуться в терминал.");
+        clearTimeout(timer);
+        port.server.close();
+        resolve(auth);
+      } catch (e) {
+        done(400, `Ошибка входа: ${e.message}`);
+        clearTimeout(timer);
+        port.server.close();
+        reject(e);
+      }
+    });
+  });
+}
+
+// Пытается слушать порты по списку, возвращает первый свободный { server, port }.
+function listenFirstFree(ports) {
+  return new Promise((resolve, reject) => {
+    const tryPort = (i) => {
+      if (i >= ports.length) return reject(new Error("no free login port (1455/1457 busy)"));
+      const server = createServer();
+      server.once("error", () => tryPort(i + 1));
+      server.listen(ports[i], "127.0.0.1", () => resolve({ server, port: ports[i] }));
+    };
+    tryPort(0);
+  });
+}
+
+export async function login(mode = "device", opts = {}) {
+  return mode === "browser" ? runBrowserLogin(opts) : runDeviceCodeLogin(opts);
+}
+
+// ── список моделей подписки (для мастера) ──────────────────────────────────
+export async function listCodexModels({ dataDir = defaultDir() } = {}) {
+  const headers = await codexAuthHeaders(dataDir);
+  const res = await fetch(`${CODEX_BASE_URL}/models?client_version=${CLIENT_VERSION}`, { headers });
+  if (!res.ok) throw new Error(`list models failed: ${res.status} ${(await res.text()).slice(0, 200)}`);
+  const json = await res.json();
+  const arr = Array.isArray(json) ? json : json.data || json.models || [];
+  return arr.map((m) => (typeof m === "string" ? m : m.id || m.slug || m.name)).filter(Boolean);
+}
+
+// ── self-check (node scripts/lib/codex-oauth.mjs) — без сети ────────────────
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const assert = (c, m) => {
+    if (!c) throw new Error(`self-check FAIL: ${m}`);
+  };
+  // PKCE: challenge = base64url(sha256(verifier))
+  const { verifier, challenge } = pkce();
+  assert(challenge === b64url(createHash("sha256").update(verifier).digest()), "pkce S256");
+  assert(!/[+/=]/.test(challenge), "challenge is base64url");
+  // JWT parse: собираем фейковый id_token с клеймом auth
+  const header = b64url(JSON.stringify({ alg: "none" }));
+  const payload = b64url(JSON.stringify({ exp: 9999999999, "https://api.openai.com/auth": { chatgpt_account_id: "acc_1", chatgpt_plan_type: "pro" } }));
+  const jwt = `${header}.${payload}.sig`;
+  assert(jwtExp(jwt) === 9999999999, "jwtExp");
+  assert(accountFromIdToken(jwt).accountId === "acc_1", "accountId");
+  assert(accountFromIdToken(jwt).planType === "pro", "planType");
+  assert(accountFromIdToken("garbage").accountId === null, "bad id_token → null");
+  console.log("codex-oauth self-check ok");
+}

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -245,7 +245,8 @@ async function main() {
   const prov0 = existing.MODEL_PROVIDER || "ollama";
   const provModel = { opencode: "OPENCODE_MODEL", codex: "CODEX_MODEL" }[prov0] || "OLLAMA_MODEL";
   // codex — доступ по OAuth-токену (data/codex-auth.json), у ollama/opencode — API-ключ в .env.
-  const provKey = { opencode: "OPENCODE_API_KEY", codex: null }[prov0] ?? "OLLAMA_API_KEY";
+  // ollama задан явно: `null ?? default` вернул бы ключ и для codex (null нуллиш) → мастер зацикливался бы.
+  const provKey = { ollama: "OLLAMA_API_KEY", opencode: "OPENCODE_API_KEY", codex: null }[prov0];
   const REQUIRED = [provModel, "DEEPGRAM_API_KEY", "TELEGRAM_BOT_TOKEN", "TELEGRAM_ALLOWED_USER_IDS", ...(provKey ? [provKey] : [])];
   const loggedInCodex = prov0 !== "codex" || existsSync(authFilePath(dataDirAbs(existing)));
   const isComplete = loggedInCodex && REQUIRED.every((k) => (existing[k] || "").trim());

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -4,15 +4,21 @@
 // the script will NOT exit until every required secret is entered.
 // No external dependencies.
 import { createInterface } from "node:readline/promises";
-import { createReadStream } from "node:fs";
+import { createReadStream, existsSync } from "node:fs";
 import { readFile, writeFile, access } from "node:fs/promises";
 import { randomBytes } from "node:crypto";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { defaultChecker, PortSelector } from "./lib/ports.mjs";
+import { authFilePath, readAuth, runDeviceCodeLogin, runBrowserLogin, listCodexModels } from "./lib/codex-oauth.mjs";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const ENV_PATH = join(ROOT, ".env");
+// Абсолютный каталог data (тот же, что видит агент из cwd=ROOT). Хранит codex-auth.json (OAuth).
+const dataDirAbs = (env) => {
+  const d = (env && env.ASSISTANT_DATA_DIR) || "data";
+  return d.startsWith("/") ? d : join(ROOT, d);
+};
 const OLLAMA_BASE = "https://ollama.com/v1";
 const OPENCODE_BASE = "https://opencode.ai/zen/go/v1";
 // OpenCode Go models — bare ID without the "opencode-go/" prefix: that's exactly what the
@@ -127,6 +133,7 @@ async function writeEnv(out) {
     "MODEL_PROVIDER",
     "OLLAMA_API_KEY", "OLLAMA_MODEL", "OLLAMA_CONTEXT_WINDOW",
     "OPENCODE_API_KEY", "OPENCODE_MODEL", "OPENCODE_CONTEXT_WINDOW",
+    "CODEX_MODEL", "CODEX_CONTEXT_WINDOW",
     "TELEGRAM_BOT_TOKEN", "TELEGRAM_BOT_USERNAME", "TELEGRAM_WEBHOOK_SECRET_TOKEN",
     "TELEGRAM_ALLOWED_USER_IDS", "TELEGRAM_DIGEST_CHAT_ID",
     "DEEPGRAM_API_KEY", "DEEPGRAM_LANGUAGE",
@@ -236,10 +243,12 @@ async function main() {
 
   // Already configured? Don't walk every step — ask once.
   const prov0 = existing.MODEL_PROVIDER || "ollama";
-  const provKey = prov0 === "opencode" ? "OPENCODE_API_KEY" : "OLLAMA_API_KEY";
-  const provModel = prov0 === "opencode" ? "OPENCODE_MODEL" : "OLLAMA_MODEL";
-  const REQUIRED = [provKey, provModel, "DEEPGRAM_API_KEY", "TELEGRAM_BOT_TOKEN", "TELEGRAM_ALLOWED_USER_IDS"];
-  const isComplete = REQUIRED.every((k) => (existing[k] || "").trim());
+  const provModel = { opencode: "OPENCODE_MODEL", codex: "CODEX_MODEL" }[prov0] || "OLLAMA_MODEL";
+  // codex — доступ по OAuth-токену (data/codex-auth.json), у ollama/opencode — API-ключ в .env.
+  const provKey = { opencode: "OPENCODE_API_KEY", codex: null }[prov0] ?? "OLLAMA_API_KEY";
+  const REQUIRED = [provModel, "DEEPGRAM_API_KEY", "TELEGRAM_BOT_TOKEN", "TELEGRAM_ALLOWED_USER_IDS", ...(provKey ? [provKey] : [])];
+  const loggedInCodex = prov0 !== "codex" || existsSync(authFilePath(dataDirAbs(existing)));
+  const isComplete = loggedInCodex && REQUIRED.every((k) => (existing[k] || "").trim());
   if (isComplete) {
     console.log(`\n${C.b}${C.g}  ${t("Iva is already configured:", "Iva уже настроена:")}${C.x}`);
     console.log(`  • ${t("Provider", "Провайдер")}: ${prov0}`);
@@ -265,8 +274,10 @@ async function main() {
   console.log(`  ${t("Who to reach the model through:", "Через кого ходить к модели:")}`);
   console.log(`    1) Ollama Cloud — ${C.c}https://ollama.com${C.x} ${t("(~$20/mo, higher limits)", "(~$20/мес, лимиты побольше)")}`);
   console.log(`    2) OpenCode Zen — ${C.c}https://opencode.ai${C.x} ${t("(Go ~$5/mo, cheaper)", "(Go ~$5/мес, дешевле)")}`);
-  const provChoice = await ask(`  ${t("Provider", "Провайдер")} (1/2)`, prov0 === "opencode" ? "2" : "1");
-  const provider = provChoice.trim() === "2" ? "opencode" : "ollama";
+  console.log(`    3) OpenAI ${t("(ChatGPT subscription)", "(подписка ChatGPT)")} — ${C.c}chatgpt.com${C.x} ${t("(sign in, no API key)", "(вход по подписке, без API-ключа)")}`);
+  const provDef = { opencode: "2", codex: "3" }[prov0] || "1";
+  const provChoice = (await ask(`  ${t("Provider", "Провайдер")} (1/2/3)`, provDef)).trim();
+  const provider = provChoice === "2" ? "opencode" : provChoice === "3" ? "codex" : "ollama";
   out.MODEL_PROVIDER = provider;
 
   if (provider === "ollama") {
@@ -289,7 +300,7 @@ async function main() {
     out.OLLAMA_MODEL = await pickFromList(models, out.OLLAMA_MODEL, "deepseek-v4-pro");
     out.OLLAMA_CONTEXT_WINDOW = out.OLLAMA_CONTEXT_WINDOW || "131072";
     console.log(`  → ${t("model", "модель")}: ${C.g}${out.OLLAMA_MODEL}${C.x}`);
-  } else {
+  } else if (provider === "opencode") {
     console.log(`\n  ${t("OpenCode key", "Ключ OpenCode")}: ${C.c}https://opencode.ai/auth${C.x} ${t("(subscribe to Go → copy the API key).", "(подпишитесь на Go → скопируйте API key).")}`);
     out.OPENCODE_API_KEY = await askRequired(`  ${t("Paste the OpenCode API key", "Вставьте OpenCode API key")}`, {
       existing: process.env.OPENCODE_API_KEY || existing.OPENCODE_API_KEY || "",
@@ -301,6 +312,47 @@ async function main() {
     out.OPENCODE_MODEL = await pickFromList(OPENCODE_MODELS, curModel, OPENCODE_MODELS[0]);
     out.OPENCODE_CONTEXT_WINDOW = out.OPENCODE_CONTEXT_WINDOW || "131072";
     console.log(`  → ${t("model", "модель")}: ${C.g}${out.OPENCODE_MODEL}${C.x}`);
+  } else {
+    // codex — вход по подписке OpenAI (OAuth), без API-ключа. Токен → data/codex-auth.json.
+    const dataDir = dataDirAbs({ ...existing, ...out });
+    let auth = readAuth(dataDir);
+    if (auth) {
+      console.log(`\n  ${C.g}${t("Already signed in", "Вход уже выполнен")}${auth.planType ? ` (${t("plan", "план")}: ${auth.planType})` : ""}.${C.x} ${t("Re-login: iva login", "Перелогиниться: iva login")}`);
+    } else {
+      console.log(`\n  ${t("Sign in to your OpenAI (ChatGPT) subscription. No API key — auth like the codex CLI.", "Вход по подписке OpenAI (ChatGPT). Без API-ключа — авторизация как у codex CLI.")}`);
+      const useBrowser = await askYesNo(
+        `  ${t("Sign in via a browser on THIS machine? (No = by link + code, best for a headless VPS)", "Войти через браузер на ЭТОЙ машине? (Нет = по ссылке и коду, для headless-VPS)")}`,
+        false,
+      );
+      while (!auth) {
+        try {
+          auth = useBrowser
+            ? await runBrowserLogin({ dataDir, log: (m) => console.log(m) })
+            : await runDeviceCodeLogin({ dataDir, log: (m) => console.log(m) });
+          console.log(`  ${C.g}${t("signed in", "вход выполнен")}${auth.planType ? ` — ${t("plan", "план")}: ${auth.planType}` : ""}${C.x}`);
+        } catch (e) {
+          console.log(`  ${C.r}${t("sign-in failed", "не удалось войти")}: ${e.message}${C.x}`);
+          if (!(await askYesNo(`  ${t("Try again?", "Попробовать снова?")}`, true))) break;
+        }
+      }
+    }
+    // Список моделей подписки — тянем с бэкенда (как ollama/opencode). Fallback — ручной ввод.
+    let models = [];
+    if (auth) {
+      try {
+        models = await listCodexModels({ dataDir });
+      } catch (e) {
+        console.log(`  ${C.y}${t("couldn't fetch the model list", "не смог получить список моделей")}: ${e.message}${C.x}`);
+      }
+    }
+    if (models.length) {
+      console.log(`\n  ${t("Models available", "Доступно моделей")}: ${models.length}.`);
+      out.CODEX_MODEL = await pickFromList(models, out.CODEX_MODEL || "", models[0]);
+    } else {
+      out.CODEX_MODEL = await ask(`  ${t("Codex model id", "ID модели Codex")}`, out.CODEX_MODEL || "gpt-5.1");
+    }
+    out.CODEX_CONTEXT_WINDOW = out.CODEX_CONTEXT_WINDOW || "272000";
+    console.log(`  → ${t("model", "модель")}: ${C.g}${out.CODEX_MODEL}${C.x}`);
   }
   console.log(
     `  ${C.y}${t("Don't inflate the context window:", "Окно контекста не завышайте:")}${C.x} ${t("compaction computes its threshold from it; an inflated window risks overflow.", "компактация считает порог от него; завышенное окно = риск переполнения.")}`,
@@ -457,7 +509,7 @@ async function main() {
   // ── Write .env ────────────────────────────────────────────────────
   await writeEnv(out);
 
-  const chosenModel = provider === "opencode" ? out.OPENCODE_MODEL : out.OLLAMA_MODEL;
+  const chosenModel = { opencode: out.OPENCODE_MODEL, codex: out.CODEX_MODEL }[provider] || out.OLLAMA_MODEL;
   console.log();
   hr();
   console.log(`${C.g}${C.b}  ✓ ${t("Done — everything written to .env", "Готово — всё записано в .env")}${C.x}`);


### PR DESCRIPTION
## What

Adds a third model provider — **`codex`** — that runs Iva on an existing **OpenAI (ChatGPT Plus/Pro/Team) subscription** instead of a per-token API key, the same way the official `codex` CLI authenticates.

## Why

Today both providers (Ollama Cloud, OpenCode Zen) are OpenAI-compatible endpoints behind a static `Bearer` key. Many users already pay for a ChatGPT subscription and want to reuse it — no second bill, no key management.

## How it works

- **Auth** — OAuth against `auth.openai.com` (public Codex `client_id`), two flows:
  - `iva login` — **device code**: prints a link (`auth.openai.com/codex/device`) + one-time code. Works on a headless VPS.
  - `iva login --browser` — **PKCE**: local `127.0.0.1:1455` server + auto-opened browser.
- **Token** — stored in `data/codex-auth.json` (chmod 600, gitignored), **auto-refreshed** before expiry; the rotating `refresh_token` is persisted atomically.
- **Calls** — the subscription backend `chatgpt.com/backend-api/codex` speaks the **Responses API** only, so the codex provider builds a model via `@ai-sdk/openai` (`openai.responses(...)`) with a custom `fetch` that injects a fresh `Bearer` + `ChatGPT-Account-ID` and forces `store:false` (the backend is stateless; eve already replays full history).
- **Models** — pulled live from the subscription (`GET .../models`) so `iva config` shows exactly what the plan exposes.
- **Vision** — image recognition routes through the same subscription (gpt-5 is multimodal).

## Files

- `scripts/lib/codex-oauth.mjs` (+`.d.mts`) — OAuth core, shared by the bare-node CLI and the bundled eve agent (same pattern as `usage.mjs`). Pure ESM, node built-ins only, with a no-network self-check.
- `agent/provider.ts`, `agent/agent.ts`, `agent/vision.ts`, `agent/hooks/usage.ts` — wire the codex provider.
- `bin/iva.mjs` — `iva login` command + doctor check; `scripts/setup.mjs` — wizard provider option 3.
- `.env.example` + `docs/` (EN + RU mirror).

## Verification

- `npm run typecheck` (tsgo) — clean
- `npm run build` (eve) — clean; codex path + OAuth core bundled
- `node scripts/lib/codex-oauth.mjs` — PKCE S256 + JWT-claim self-check passes
- ⚠️ **Not yet exercised against a live subscription token.** The Responses request body may need small tweaks if the subscription backend is stricter than the public OpenAI API — the custom `fetch` is the single patch point. See risk notes in the PR discussion.

## Note

Routing a self-hosted assistant through the ChatGPT subscription backend is a grey area under OpenAI's terms (you use your own subscription on your own server). Flagged in `docs/providers.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new **Codex / ChatGPT subscription** model provider with OAuth login, provider-specific model selection, and vision/image support.
  * Introduced `iva login` with device-code (default) and `--browser` PKCE sign-in flows.
  * Extended setup/config/docs to support **three** providers, including `CODEX_MODEL` and `CODEX_CONTEXT_WINDOW`.
* **Bug Fixes**
  * Improved provider/model resolution so usage tracking reflects the active provider.
* **Documentation**
  * Updated CLI reference plus configuration/provider guides to cover Codex authentication and token storage workflow.
* **Chores**
  * Bumped package version to 0.2.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->