### PR TITLE
fix(codex): correct client_version + stream-only calls (verified live)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,7 +21,7 @@ OPENCODE_CONTEXT_WINDOW=131072
 # OpenAI по подписке ChatGPT (если MODEL_PROVIDER=codex). Вход: `iva login`
 # (по ссылке+коду) или `iva login --browser`. Токен → data/codex-auth.json (0600, не в .env).
 # API-ключ НЕ нужен. Модель выбирается в `iva config` из реального списка подписки.
-CODEX_MODEL=gpt-5.1
+CODEX_MODEL=gpt-5.5
 CODEX_CONTEXT_WINDOW=272000
 
 # Браузер agent-browser: потолок вывода (защита окна контекста).

--- a/agent/hooks/usage.ts
+++ b/agent/hooks/usage.ts
@@ -15,7 +15,7 @@ const PROVIDER = process.env.MODEL_PROVIDER ?? "ollama";
 // Модель/провайдер не приходят в событие — берём из env (та же логика, что в agent/agent.ts).
 const MODEL =
   PROVIDER === "codex"
-    ? (process.env.CODEX_MODEL ?? "gpt-5.1")
+    ? (process.env.CODEX_MODEL ?? "gpt-5.5")
     : PROVIDER === "opencode"
       ? (process.env.OPENCODE_MODEL ?? "deepseek-v4-pro").replace(/^opencode-go\//, "")
       : (process.env.OLLAMA_MODEL ?? "deepseek-v4-pro");

--- a/agent/provider.ts
+++ b/agent/provider.ts
@@ -30,10 +30,10 @@ const PROVIDERS = {
   codex: {
     baseURL: CODEX_BASE_URL,
     apiKey: undefined, // авторизация — OAuth-токен подписки, не статичный ключ (см. codexFetch)
-    textModel: process.env.CODEX_MODEL ?? "gpt-5.1",
+    textModel: process.env.CODEX_MODEL ?? "gpt-5.5",
     contextWindow: Number(process.env.CODEX_CONTEXT_WINDOW ?? 272000),
     // gpt-5* мультимодальны — картинки идут через ту же подписку (см. agent/vision.ts).
-    visionModel: process.env.CODEX_MODEL ?? "gpt-5.1",
+    visionModel: process.env.CODEX_MODEL ?? "gpt-5.5",
   },
 } as const;
 

--- a/agent/vision.ts
+++ b/agent/vision.ts
@@ -1,4 +1,4 @@
-import { generateText } from "ai";
+import { streamText } from "ai";
 import { providerConfig, providerName, makeCodexModel } from "./provider.js";
 
 const PROMPT =
@@ -10,21 +10,24 @@ const PROMPT =
 // Сетевые/HTTP-ошибки бросает — вызывающий ловит и продолжает ход без зрения (graceful).
 export async function describeImage(bytes: ArrayBuffer, mimeType?: string): Promise<string> {
   // codex-подписка: Responses API мультимодален — гоним картинку через ту же модель/токен.
+  // ВАЖНО: бэкенд подписки принимает ТОЛЬКО stream:true → streamText, не generateText (иначе 400).
   if (providerName === "codex") {
-    const { text } = await generateText({
+    const result = streamText({
       model: makeCodexModel(providerConfig.visionModel),
-      providerOptions: { openai: { store: false } },
       messages: [
         {
           role: "user",
           content: [
             { type: "text", text: PROMPT },
-            { type: "image", image: new Uint8Array(bytes), mediaType: mimeType || "image/jpeg" },
+            // file-part (не устаревший image-part): AI SDK кодирует его в input_image для Responses.
+            { type: "file", data: new Uint8Array(bytes), mediaType: mimeType || "image/jpeg" },
           ],
         },
       ],
     });
-    return (text ?? "").trim();
+    let out = "";
+    for await (const chunk of result.textStream) out += chunk;
+    return out.trim();
   }
 
   const { baseURL, apiKey, visionModel } = providerConfig;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,7 +23,7 @@ Three providers. Pick one with `MODEL_PROVIDER` and fill only that block. `ollam
 | `OPENCODE_API_KEY` | — | Key from opencode.ai/auth. |
 | `OPENCODE_MODEL` | `opencode-go/deepseek-v4-pro` | Any Zen Go model. |
 | `OPENCODE_CONTEXT_WINDOW` | `131072` | Same warning. |
-| `CODEX_MODEL` | `gpt-5.1` | Model from your OpenAI plan. `iva config` lists what your subscription actually exposes. |
+| `CODEX_MODEL` | `gpt-5.5` | Model from your OpenAI plan. `iva config` lists what your subscription actually exposes. |
 | `CODEX_CONTEXT_WINDOW` | `272000` | Same warning — set the real window of the model you picked. |
 
 For `codex` there is no API key in `.env`: run `iva login` (device code, headless-friendly) or `iva login --browser`. The OAuth token lives in `data/codex-auth.json` (chmod 600, gitignored) and is auto-refreshed before it expires. Full flow: [providers.md](./providers.md#openai-by-chatgpt-subscription-codex).

--- a/docs/ru/configuration.md
+++ b/docs/ru/configuration.md
@@ -26,7 +26,7 @@ iva restart
 | `OPENCODE_API_KEY` | — | Ключ с opencode.ai/auth. |
 | `OPENCODE_MODEL` | `opencode-go/deepseek-v4-pro` | Любая модель Zen Go. |
 | `OPENCODE_CONTEXT_WINDOW` | `131072` | То же предупреждение. |
-| `CODEX_MODEL` | `gpt-5.1` | Модель вашего тарифа OpenAI. `iva config` покажет реальный список подписки. |
+| `CODEX_MODEL` | `gpt-5.5` | Модель вашего тарифа OpenAI. `iva config` покажет реальный список подписки. |
 | `CODEX_CONTEXT_WINDOW` | `272000` | То же предупреждение — впишите реальное окно выбранной модели. |
 
 Для `codex` ключа в `.env` нет: выполните `iva login` (по ссылке+коду, годится для headless-VPS) или `iva login --browser`. OAuth-токен лежит в `data/codex-auth.json` (chmod 600, в gitignore) и автоматически обновляется до истечения. Полный сценарий: [providers.md](../providers.md#openai-by-chatgpt-subscription-codex).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iva",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iva",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/openai": "4.0.0-beta.76",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iva",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "module",
   "bin": {
     "iva": "bin/iva.mjs"

--- a/scripts/lib/codex-oauth.mjs
+++ b/scripts/lib/codex-oauth.mjs
@@ -20,7 +20,9 @@ export const CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex";
 const TOKEN_URL = `${ISSUER}/oauth/token`;
 const SCOPE = "openid profile email offline_access";
 const ORIGINATOR = "codex_cli_rs";
-const CLIENT_VERSION = "0.20.0"; // для ?client_version= у /models и User-Agent (мимикрия под codex CLI)
+// Для ?client_version= у /models и User-Agent. ВАЖНО: /models гейтит список по версии —
+// слишком старая (напр. 0.20/0.42) → бэкенд отдаёт {"models":[]}. Держим на актуальном релизе codex.
+const CLIENT_VERSION = "0.142.5";
 const REFRESH_SKEW_S = 300; // рефрешим за 5 мин до exp (как окно codex CLI)
 const DEVICE_PORT = 1455; // codex-совместимый redirect-порт (fallback 1457)
 const FALLBACK_PORT = 1457;


### PR DESCRIPTION
Follow-up to #11. **Verified end-to-end against a live ChatGPT Pro subscription** (chat `gpt-5.5`/`gpt-5.4` reply + usage, vision on a real image, model list, token refresh).

- **`client_version` was `0.20.0`** — the `/models` endpoint gates the list on it and returned `{"models":[]}` for anything that old (confirmed: `0.42.0` → empty, `0.142.5` → 5 models). Bumped to `0.142.5`. The subscription now lists its real models (`gpt-5.5, gpt-5.4, gpt-5.4-mini, gpt-5.3-codex-spark, codex-auto-review`).
- **Responses backend requires `stream:true`** (non-stream → `400 "Stream must be set to true"`). `vision.ts` used `generateText` → switched to `streamText`. The main agent already streams via eve.
- Vision image part: deprecated `image` type → `file`.
- Default model `gpt-5.1` → `gpt-5.5` (5.1 isn't exposed on current plans).

Ships as v0.2.3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Codex-backed vision responses now return text more smoothly, improving image description handling.
* **Bug Fixes**
  * Updated the default Codex model to a newer version across app settings and runtime fallbacks.
  * Improved model listing/auth compatibility for Codex clients.
* **Documentation**
  * Refreshed configuration docs to match the new default model.
* **Chores**
  * Bumped the package version to `0.2.3`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->