### PR TITLE
feat: add OpenRouter provider with live model check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,8 @@
 # Управляет инструкцией 05-language, локалью даты (now) и сидом CORE при init-vault.
 AGENT_LANGUAGE=ru
 
-# Провайдер модели: ollama | opencode | codex.
-#   ollama/opencode — OpenAI-совместимы (chat/completions), статичный API-ключ ниже.
+# Провайдер модели: ollama | opencode | openrouter | codex.
+#   ollama/opencode/openrouter — OpenAI-совместимы (chat/completions), статичный API-ключ ниже.
 #   codex — личная подписка OpenAI (ChatGPT): Responses API + OAuth, ключ НЕ нужен (см. ниже).
 MODEL_PROVIDER=ollama
 
@@ -17,6 +17,14 @@ OLLAMA_CONTEXT_WINDOW=131072
 OPENCODE_API_KEY=
 OPENCODE_MODEL=opencode-go/deepseek-v4-pro
 OPENCODE_CONTEXT_WINDOW=131072
+
+# OpenRouter (если MODEL_PROVIDER=openrouter) — один ключ на 300+ моделей.
+# Ключ: https://openrouter.ai/keys. Слаг модели скопируй с https://openrouter.ai/models
+# в виде vendor/model (напр. anthropic/claude-sonnet-4.5). `iva config` проверит его живым запросом.
+OPENROUTER_API_KEY=
+OPENROUTER_MODEL=openai/gpt-5.1
+# Окно контекста — впиши реальное окно выбранной модели (компактация считает порог от него).
+OPENROUTER_CONTEXT_WINDOW=131072
 
 # OpenAI по подписке ChatGPT (если MODEL_PROVIDER=codex). Вход: `iva login`
 # (по ссылке+коду) или `iva login --browser`. Токен → data/codex-auth.json (0600, не в .env).

--- a/agent/hooks/usage.ts
+++ b/agent/hooks/usage.ts
@@ -16,9 +16,11 @@ const PROVIDER = process.env.MODEL_PROVIDER ?? "ollama";
 const MODEL =
   PROVIDER === "codex"
     ? (process.env.CODEX_MODEL ?? "gpt-5.5")
-    : PROVIDER === "opencode"
-      ? (process.env.OPENCODE_MODEL ?? "deepseek-v4-pro").replace(/^opencode-go\//, "")
-      : (process.env.OLLAMA_MODEL ?? "deepseek-v4-pro");
+    : PROVIDER === "openrouter"
+      ? (process.env.OPENROUTER_MODEL ?? "openai/gpt-5.1")
+      : PROVIDER === "opencode"
+        ? (process.env.OPENCODE_MODEL ?? "deepseek-v4-pro").replace(/^opencode-go\//, "")
+        : (process.env.OLLAMA_MODEL ?? "deepseek-v4-pro");
 
 interface StepData {
   stepIndex: number;

--- a/agent/provider.ts
+++ b/agent/provider.ts
@@ -5,7 +5,7 @@ import { CODEX_BASE_URL, codexAuthHeaders } from "../scripts/lib/codex-oauth.mjs
 type WrappableModel = Parameters<typeof wrapLanguageModel>[0]["model"];
 
 // Единый источник конфигурации провайдера модели (выбор раз при старте через MODEL_PROVIDER).
-// ollama/opencode — OpenAI-совместимы (chat/completions, статичный ключ из .env).
+// ollama/opencode/openrouter — OpenAI-совместимы (chat/completions, статичный ключ из .env).
 // codex — личная подписка OpenAI (ChatGPT): Responses API + OAuth-токен (data/codex-auth.json,
 // `iva login`). Здесь же зашита vision-модель провайдера — её зовёт agent/vision.ts.
 const PROVIDER = process.env.MODEL_PROVIDER ?? "ollama";
@@ -26,6 +26,17 @@ const PROVIDERS = {
     textModel: (process.env.OPENCODE_MODEL ?? "deepseek-v4-pro").replace(/^opencode-go\//, ""),
     contextWindow: Number(process.env.OPENCODE_CONTEXT_WINDOW ?? 131072),
     visionModel: "gemini-3-flash",
+  },
+  openrouter: {
+    baseURL: "https://openrouter.ai/api/v1",
+    apiKey: process.env.OPENROUTER_API_KEY,
+    // Слаг модели вида vendor/model (напр. anthropic/claude-sonnet-4.5) — задаётся мастером.
+    // Дефолт — лишь заглушка на случай ручного .env; мастер всегда перезапишет живой проверкой.
+    textModel: process.env.OPENROUTER_MODEL ?? "openai/gpt-5.1",
+    contextWindow: Number(process.env.OPENROUTER_CONTEXT_WINDOW ?? 131072),
+    // Дешёвая гарантированно-мультимодальная модель для картинок (как gemini-3-flash у opencode):
+    // vision работает независимо от выбранной текстовой модели (та может быть text-only).
+    visionModel: "google/gemini-2.5-flash",
   },
   codex: {
     baseURL: CODEX_BASE_URL,

--- a/bin/iva.mjs
+++ b/bin/iva.mjs
@@ -358,6 +358,7 @@ function cmdDoctor() {
     const PROV_KEYS = {
       ollama: ["OLLAMA_API_KEY", "OLLAMA_MODEL"],
       opencode: ["OPENCODE_API_KEY", "OPENCODE_MODEL"],
+      openrouter: ["OPENROUTER_API_KEY", "OPENROUTER_MODEL"],
       codex: ["CODEX_MODEL"],
     };
     const REQUIRED = [...(PROV_KEYS[prov] || PROV_KEYS.ollama), "DEEPGRAM_API_KEY", "TELEGRAM_BOT_TOKEN", "TELEGRAM_ALLOWED_USER_IDS"];

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,17 +12,20 @@ No rebuild. Swapping a model, key or provider is edit → restart.
 
 ## Model provider
 
-Three providers. Pick one with `MODEL_PROVIDER` and fill only that block. `ollama`/`opencode` are OpenAI-compatible API keys; `codex` rides your OpenAI (ChatGPT) subscription via OAuth — no key. Prices and full model lists: [providers.md](./providers.md).
+Four providers. Pick one with `MODEL_PROVIDER` and fill only that block. `ollama`/`opencode`/`openrouter` are OpenAI-compatible API keys; `codex` rides your OpenAI (ChatGPT) subscription via OAuth — no key. Prices and full model lists: [providers.md](./providers.md).
 
 | Variable | Default | Notes |
 |---|---|---|
-| `MODEL_PROVIDER` | `ollama` | `ollama` (Ollama Cloud), `opencode` (OpenCode Zen) or `codex` (OpenAI ChatGPT subscription). |
+| `MODEL_PROVIDER` | `ollama` | `ollama` (Ollama Cloud), `opencode` (OpenCode Zen), `openrouter` (OpenRouter) or `codex` (OpenAI ChatGPT subscription). |
 | `OLLAMA_API_KEY` | — | Key from ollama.com. |
 | `OLLAMA_MODEL` | `deepseek-v4-pro` | Any model on your Ollama Cloud plan. |
 | `OLLAMA_CONTEXT_WINDOW` | `131072` | See warning below. |
 | `OPENCODE_API_KEY` | — | Key from opencode.ai/auth. |
 | `OPENCODE_MODEL` | `opencode-go/deepseek-v4-pro` | Any Zen Go model. |
 | `OPENCODE_CONTEXT_WINDOW` | `131072` | Same warning. |
+| `OPENROUTER_API_KEY` | — | Key from [openrouter.ai/keys](https://openrouter.ai/keys) (starts with `sk-or-`). |
+| `OPENROUTER_MODEL` | `openai/gpt-5.1` | The model **slug** from [openrouter.ai/models](https://openrouter.ai/models), form `vendor/model` (e.g. `anthropic/claude-sonnet-4.5`). `iva config` sends a live test request so a wrong slug can't slip through. |
+| `OPENROUTER_CONTEXT_WINDOW` | `131072` | Same warning — set the real window of the model you picked. |
 | `CODEX_MODEL` | `gpt-5.5` | Model from your OpenAI plan. `iva config` lists what your subscription actually exposes. |
 | `CODEX_CONTEXT_WINDOW` | `272000` | Same warning — set the real window of the model you picked. |
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -8,16 +8,17 @@ Iva runs on your server with your keys. Here is every external service it talks 
 |---|---|---|---|
 | **OpenCode Zen Go** | ~$5/mo | `deepseek-v4-pro` (default), `deepseek-v4-flash`, `kimi-k2.7-code`, `glm-5.2`, `qwen3.7` | `gemini-3-flash` |
 | **Ollama Cloud** | ~$20/mo | `deepseek-v4-pro` (default) | `gemma3:12b` |
+| **OpenRouter** | pay-as-you-go | 300+ models across vendors — pick any slug (`vendor/model`) | `google/gemini-2.5-flash` |
 | **OpenAI (ChatGPT subscription)** | your existing Plus/Pro/Team | the models your plan exposes (`gpt-5.x`, `-codex`), fetched live | same subscription (multimodal) |
 
-The first two are plain API keys; the third rides your personal OpenAI subscription:
+The first three are plain API keys; the last rides your personal OpenAI subscription:
 
-- 🔌 **OpenAI-compatible** — Zen and Ollama share the same wire format, so switching is one line in `.env`
-- 🌍 **Any IP** — all three answer from any server location, no region blocks
+- 🔌 **OpenAI-compatible** — Zen, Ollama and OpenRouter share the same wire format, so switching is one line in `.env`
+- 🌍 **Any IP** — all answer from any server location, no region blocks
 - 💸 **No markup** — you pay the provider directly; Iva adds nothing on top
 
 ```bash
-MODEL_PROVIDER=opencode   # or ollama / codex, then `iva restart`
+MODEL_PROVIDER=opencode   # or ollama / openrouter / codex, then `iva restart`
 ```
 
 Start with Zen: a quarter of the price, five models to switch between. Keys, model pick and context-window settings live in [configuration.md](configuration.md).
@@ -34,6 +35,16 @@ iva restart
 ```
 
 Notes: the model list is pulled from your subscription at setup time, so you always see exactly what your plan allows. Set `CODEX_CONTEXT_WINDOW` to the real window of the model you picked (compaction derives its threshold from it). Routing a self-hosted assistant through the ChatGPT subscription backend is a grey area under OpenAI's terms — you are using your own subscription on your own server, but weigh that yourself.
+
+### OpenRouter (`openrouter`)
+
+One key, [300+ models](https://openrouter.ai/models) from every major vendor (Anthropic, OpenAI, Google, DeepSeek, Meta…), billed pay-as-you-go straight by OpenRouter. Because there are hundreds of models, setup doesn't show a picker — you paste the model **slug** yourself:
+
+1. Grab a key at [openrouter.ai/keys](https://openrouter.ai/keys) (`sk-or-…`).
+2. Open [openrouter.ai/models](https://openrouter.ai/models), pick a model, copy its slug — the `vendor/model` id shown under the name (e.g. `anthropic/claude-sonnet-4.5`, `openai/gpt-5.1`, `google/gemini-2.5-pro`). Optional routing suffixes like `:free`/`:nitro` are allowed.
+3. `iva config` → provider `4` → paste the key, then the slug. **It sends a live test request** and only moves on once the model actually answers — so a mistyped slug can't slip through and leave the bot silent.
+
+Set `OPENROUTER_CONTEXT_WINDOW` to the real window of the model you picked. Images are described through `google/gemini-2.5-flash` (cheap, always multimodal) regardless of your text model, so vision works even if the text model you chose is text-only — those image calls bill to your OpenRouter credit too.
 
 ## Vision
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -41,8 +41,8 @@ Notes: the model list is pulled from your subscription at setup time, so you alw
 One key, [300+ models](https://openrouter.ai/models) from every major vendor (Anthropic, OpenAI, Google, DeepSeek, Meta…), billed pay-as-you-go straight by OpenRouter. Because there are hundreds of models, setup doesn't show a picker — you paste the model **slug** yourself:
 
 1. Grab a key at [openrouter.ai/keys](https://openrouter.ai/keys) (`sk-or-…`).
-2. Open [openrouter.ai/models](https://openrouter.ai/models), pick a model, copy its slug — the `vendor/model` id shown under the name (e.g. `anthropic/claude-sonnet-4.5`, `openai/gpt-5.1`, `google/gemini-2.5-pro`). Optional routing suffixes like `:free`/`:nitro` are allowed.
-3. `iva config` → provider `4` → paste the key, then the slug. **It sends a live test request** and only moves on once the model actually answers — so a mistyped slug can't slip through and leave the bot silent.
+2. Open [openrouter.ai/models](https://openrouter.ai/models), pick a model, copy its slug — the `vendor/model` id shown under the name (e.g. `anthropic/claude-sonnet-4.5`, `openai/gpt-5.1`, `google/gemini-2.5-pro`). Optional routing suffixes like `:free`/`:nitro` are allowed. The model must support **tool / function calling** — Iva is an agent and sends tools every turn (image-only or chat-only models won't work).
+3. `iva config` → provider `4` → paste the key, then the slug. **It sends a live test request that includes a tool call** and only moves on once the model actually answers with tools enabled — so a mistyped slug, or a model that can't do function calling, can't slip through and leave the bot silent.
 
 Set `OPENROUTER_CONTEXT_WINDOW` to the real window of the model you picked. Images are described through `google/gemini-2.5-flash` (cheap, always multimodal) regardless of your text model, so vision works even if the text model you chose is text-only — those image calls bill to your OpenRouter credit too.
 

--- a/docs/ru/configuration.md
+++ b/docs/ru/configuration.md
@@ -15,17 +15,20 @@ iva restart
 
 ## Провайдер модели
 
-Три провайдера. Выберите один через `MODEL_PROVIDER` и заполните только его блок. `ollama`/`opencode` — API-ключ (OpenAI-совместимы); `codex` — личная подписка OpenAI (ChatGPT) по OAuth, без ключа. Цены и полные списки моделей: [providers.md](../providers.md).
+Четыре провайдера. Выберите один через `MODEL_PROVIDER` и заполните только его блок. `ollama`/`opencode`/`openrouter` — API-ключ (OpenAI-совместимы); `codex` — личная подписка OpenAI (ChatGPT) по OAuth, без ключа. Цены и полные списки моделей: [providers.md](../providers.md).
 
 | Переменная | По умолчанию | Заметки |
 |---|---|---|
-| `MODEL_PROVIDER` | `ollama` | `ollama` (Ollama Cloud), `opencode` (OpenCode Zen) или `codex` (подписка OpenAI ChatGPT). |
+| `MODEL_PROVIDER` | `ollama` | `ollama` (Ollama Cloud), `opencode` (OpenCode Zen), `openrouter` (OpenRouter) или `codex` (подписка OpenAI ChatGPT). |
 | `OLLAMA_API_KEY` | — | Ключ с ollama.com. |
 | `OLLAMA_MODEL` | `deepseek-v4-pro` | Любая модель вашего тарифа Ollama Cloud. |
 | `OLLAMA_CONTEXT_WINDOW` | `131072` | См. предупреждение ниже. |
 | `OPENCODE_API_KEY` | — | Ключ с opencode.ai/auth. |
 | `OPENCODE_MODEL` | `opencode-go/deepseek-v4-pro` | Любая модель Zen Go. |
 | `OPENCODE_CONTEXT_WINDOW` | `131072` | То же предупреждение. |
+| `OPENROUTER_API_KEY` | — | Ключ с [openrouter.ai/keys](https://openrouter.ai/keys) (начинается с `sk-or-`). |
+| `OPENROUTER_MODEL` | `openai/gpt-5.1` | **Слаг** модели с [openrouter.ai/models](https://openrouter.ai/models), вид `vendor/model` (напр. `anthropic/claude-sonnet-4.5`). `iva config` шлёт живой тест-запрос, чтобы кривой слаг не проскочил. |
+| `OPENROUTER_CONTEXT_WINDOW` | `131072` | То же предупреждение — впишите реальное окно выбранной модели. |
 | `CODEX_MODEL` | `gpt-5.5` | Модель вашего тарифа OpenAI. `iva config` покажет реальный список подписки. |
 | `CODEX_CONTEXT_WINDOW` | `272000` | То же предупреждение — впишите реальное окно выбранной модели. |
 

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -21,6 +21,7 @@ const dataDirAbs = (env) => {
 };
 const OLLAMA_BASE = "https://ollama.com/v1";
 const OPENCODE_BASE = "https://opencode.ai/zen/go/v1";
+const OPENROUTER_BASE = "https://openrouter.ai/api/v1";
 // OpenCode Go models — bare ID without the "opencode-go/" prefix: that's exactly what the
 // /v1 endpoint expects in the request body (with the prefix it answers "Model ... is not supported").
 const OPENCODE_MODELS = [
@@ -133,6 +134,7 @@ async function writeEnv(out) {
     "MODEL_PROVIDER",
     "OLLAMA_API_KEY", "OLLAMA_MODEL", "OLLAMA_CONTEXT_WINDOW",
     "OPENCODE_API_KEY", "OPENCODE_MODEL", "OPENCODE_CONTEXT_WINDOW",
+    "OPENROUTER_API_KEY", "OPENROUTER_MODEL", "OPENROUTER_CONTEXT_WINDOW",
     "CODEX_MODEL", "CODEX_CONTEXT_WINDOW",
     "TELEGRAM_BOT_TOKEN", "TELEGRAM_BOT_USERNAME", "TELEGRAM_WEBHOOK_SECRET_TOKEN",
     "TELEGRAM_ALLOWED_USER_IDS", "TELEGRAM_DIGEST_CHAT_ID",
@@ -167,6 +169,51 @@ async function opencodeCheck(key) {
     return null; // 200/404 — key is at least well-formed
   } catch {
     return null; // network flaky — don't block
+  }
+}
+// OpenRouter: ключ проверяем через GET /key (требует auth, токенов не тратит).
+async function openrouterKeyCheck(key) {
+  try {
+    const res = await fetch(`${OPENROUTER_BASE}/key`, { headers: { Authorization: `Bearer ${key}` } });
+    if (res.status === 401 || res.status === 403) {
+      return t(
+        "OpenRouter rejected the key (401/403). Copy it in full from https://openrouter.ai/keys (starts with sk-or-).",
+        "OpenRouter не принял ключ (401/403). Скопируйте целиком с https://openrouter.ai/keys (начинается с sk-or-).",
+      );
+    }
+    return null; // 200 (или иной не-401) — ключ well-formed
+  } catch {
+    return null; // сеть флапнула — не блокируем
+  }
+}
+// OpenRouter: ЖИВОЙ тест модели — реальный вызов chat/completions выбранным слагом.
+// Кривой слаг → бэкенд 400 "not a valid model id" → возвращаем строку → мастер зациклит ввод.
+// Именно это ловит «слаг вписан криво, всё принято, а агент молчит».
+async function openrouterModelCheck(key, model) {
+  try {
+    const res = await fetch(`${OPENROUTER_BASE}/chat/completions`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${key}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ model, messages: [{ role: "user", content: "ping" }], max_tokens: 16 }),
+    });
+    const j = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      const msg = j?.error?.message || `HTTP ${res.status}`;
+      return t(
+        `the model didn't answer: ${msg}. Check the slug on https://openrouter.ai/models (form vendor/model).`,
+        `модель не ответила: ${msg}. Проверьте слаг на https://openrouter.ai/models (вид vendor/model).`,
+      );
+    }
+    // 200, но пустой контент — не блокируем (reasoning-модель могла упереться в max_tokens), лишь предупреждаем.
+    const content = j?.choices?.[0]?.message?.content;
+    if (!content || !content.trim()) {
+      console.log(
+        `${C.y}${t("(model replied empty — maybe a reasoning model / max_tokens; proceeding)", "(модель ответила пусто — возможно reasoning-модель / max_tokens; продолжаю)")}${C.x}`,
+      );
+    }
+    return null; // ответила — слаг валиден
+  } catch (e) {
+    return t(`request failed: ${e.message}`, `запрос не прошёл: ${e.message}`);
   }
 }
 async function deepgramCheck(key) {
@@ -243,10 +290,10 @@ async function main() {
 
   // Already configured? Don't walk every step — ask once.
   const prov0 = existing.MODEL_PROVIDER || "ollama";
-  const provModel = { opencode: "OPENCODE_MODEL", codex: "CODEX_MODEL" }[prov0] || "OLLAMA_MODEL";
-  // codex — доступ по OAuth-токену (data/codex-auth.json), у ollama/opencode — API-ключ в .env.
+  const provModel = { opencode: "OPENCODE_MODEL", openrouter: "OPENROUTER_MODEL", codex: "CODEX_MODEL" }[prov0] || "OLLAMA_MODEL";
+  // codex — доступ по OAuth-токену (data/codex-auth.json), у ollama/opencode/openrouter — API-ключ в .env.
   // ollama задан явно: `null ?? default` вернул бы ключ и для codex (null нуллиш) → мастер зацикливался бы.
-  const provKey = { ollama: "OLLAMA_API_KEY", opencode: "OPENCODE_API_KEY", codex: null }[prov0];
+  const provKey = { ollama: "OLLAMA_API_KEY", opencode: "OPENCODE_API_KEY", openrouter: "OPENROUTER_API_KEY", codex: null }[prov0];
   const REQUIRED = [provModel, "DEEPGRAM_API_KEY", "TELEGRAM_BOT_TOKEN", "TELEGRAM_ALLOWED_USER_IDS", ...(provKey ? [provKey] : [])];
   const loggedInCodex = prov0 !== "codex" || existsSync(authFilePath(dataDirAbs(existing)));
   const isComplete = loggedInCodex && REQUIRED.every((k) => (existing[k] || "").trim());
@@ -276,9 +323,11 @@ async function main() {
   console.log(`    1) Ollama Cloud — ${C.c}https://ollama.com${C.x} ${t("(~$20/mo, higher limits)", "(~$20/мес, лимиты побольше)")}`);
   console.log(`    2) OpenCode Zen — ${C.c}https://opencode.ai${C.x} ${t("(Go ~$5/mo, cheaper)", "(Go ~$5/мес, дешевле)")}`);
   console.log(`    3) OpenAI ${t("(ChatGPT subscription)", "(подписка ChatGPT)")} — ${C.c}chatgpt.com${C.x} ${t("(sign in, no API key)", "(вход по подписке, без API-ключа)")}`);
-  const provDef = { opencode: "2", codex: "3" }[prov0] || "1";
-  const provChoice = (await ask(`  ${t("Provider", "Провайдер")} (1/2/3)`, provDef)).trim();
-  const provider = provChoice === "2" ? "opencode" : provChoice === "3" ? "codex" : "ollama";
+  console.log(`    4) OpenRouter — ${C.c}https://openrouter.ai${C.x} ${t("(one key → 300+ models, pay-as-you-go)", "(один ключ → 300+ моделей, оплата по факту)")}`);
+  const provDef = { opencode: "2", codex: "3", openrouter: "4" }[prov0] || "1";
+  const provChoice = (await ask(`  ${t("Provider", "Провайдер")} (1/2/3/4)`, provDef)).trim();
+  const provider =
+    provChoice === "2" ? "opencode" : provChoice === "3" ? "codex" : provChoice === "4" ? "openrouter" : "ollama";
   out.MODEL_PROVIDER = provider;
 
   if (provider === "ollama") {
@@ -313,6 +362,34 @@ async function main() {
     out.OPENCODE_MODEL = await pickFromList(OPENCODE_MODELS, curModel, OPENCODE_MODELS[0]);
     out.OPENCODE_CONTEXT_WINDOW = out.OPENCODE_CONTEXT_WINDOW || "131072";
     console.log(`  → ${t("model", "модель")}: ${C.g}${out.OPENCODE_MODEL}${C.x}`);
+  } else if (provider === "openrouter") {
+    console.log(`\n  ${t("OpenRouter key", "Ключ OpenRouter")}: ${C.c}https://openrouter.ai/keys${C.x} ${t("(Create Key → copy sk-or-…).", "(Create Key → скопируйте sk-or-…).")}`);
+    out.OPENROUTER_API_KEY = await askRequired(`  ${t("Paste the OpenRouter key", "Вставьте ключ OpenRouter")}`, {
+      existing: process.env.OPENROUTER_API_KEY || existing.OPENROUTER_API_KEY || "",
+      validate: openrouterKeyCheck,
+    });
+    // 300+ моделей — пикер не подходит. Инструкция: откуда взять слаг и в каком виде, + живой тест.
+    console.log(`\n  ${t("Now the model.", "Теперь модель.")} ${t("Open", "Откройте")} ${C.c}https://openrouter.ai/models${C.x}, ${t("pick a model and copy its slug", "выберите модель и скопируйте её слаг")}`);
+    console.log(`  ${t("— the id under the name, form", "— id под названием, вид")} ${C.g}vendor/model${C.x} (${t("e.g.", "напр.")} ${C.g}anthropic/claude-sonnet-4.5${C.x}, ${C.g}openai/gpt-5.1${C.x}, ${C.g}google/gemini-2.5-pro${C.x}).`);
+    console.log(`  ${C.y}${t("I'll send a test request right away — so a wrong slug can't slip through and leave the bot mute.", "Сразу отправлю тестовый запрос — чтобы кривой слаг не проскочил и бот не остался немым.")}${C.x}`);
+    for (;;) {
+      const m = (await ask(`  ${t("OpenRouter model slug", "Слаг модели OpenRouter")}`, out.OPENROUTER_MODEL || "")).trim();
+      if (!m) {
+        console.log(`${C.y}  ⚠ ${t("Required — paste a slug from openrouter.ai/models.", "Обязательно — вставьте слаг с openrouter.ai/models.")}${C.x}\n`);
+        continue;
+      }
+      process.stdout.write(`  ${t("testing the model answers…", "проверяю, что модель отвечает…")} `);
+      const err = await openrouterModelCheck(out.OPENROUTER_API_KEY, m);
+      if (err) {
+        console.log(`${C.r}${t("not ok", "не ок")}${C.x}\n${C.y}  ⚠ ${err}${C.x}\n`);
+        continue;
+      }
+      console.log(`${C.g}${t("ok — the model answered", "ок — модель ответила")}${C.x}`);
+      out.OPENROUTER_MODEL = m;
+      break;
+    }
+    out.OPENROUTER_CONTEXT_WINDOW = out.OPENROUTER_CONTEXT_WINDOW || "131072";
+    console.log(`  → ${t("model", "модель")}: ${C.g}${out.OPENROUTER_MODEL}${C.x}`);
   } else {
     // codex — вход по подписке OpenAI (OAuth), без API-ключа. Токен → data/codex-auth.json.
     const dataDir = dataDirAbs({ ...existing, ...out });
@@ -510,7 +587,8 @@ async function main() {
   // ── Write .env ────────────────────────────────────────────────────
   await writeEnv(out);
 
-  const chosenModel = { opencode: out.OPENCODE_MODEL, codex: out.CODEX_MODEL }[provider] || out.OLLAMA_MODEL;
+  const chosenModel =
+    { opencode: out.OPENCODE_MODEL, openrouter: out.OPENROUTER_MODEL, codex: out.CODEX_MODEL }[provider] || out.OLLAMA_MODEL;
   console.log();
   hr();
   console.log(`${C.g}${C.b}  ✓ ${t("Done — everything written to .env", "Готово — всё записано в .env")}${C.x}`);

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -187,31 +187,41 @@ async function openrouterKeyCheck(key) {
   }
 }
 // OpenRouter: ЖИВОЙ тест модели — реальный вызов chat/completions выбранным слагом.
-// Кривой слаг → бэкенд 400 "not a valid model id" → возвращаем строку → мастер зациклит ввод.
-// Именно это ловит «слаг вписан криво, всё принято, а агент молчит».
+// Запрос НЕСЁТ минимальный tools-блок: Iva — агент, каждый ход шлёт tool-definitions, поэтому
+// chat-only модель (без function calling) сломается на первом же ходе. Один запрос ловит всё:
+//   кривой слаг → 400 "not a valid model id";  битый ключ → 401;
+//   модель без tool-эндпоинта → 404 "No endpoints found that support tool use".
+// Не-200 → возвращаем строку → мастер зациклит ввод. Именно это ловит «принято, а агент молчит».
 async function openrouterModelCheck(key, model) {
   try {
     const res = await fetch(`${OPENROUTER_BASE}/chat/completions`, {
       method: "POST",
       headers: { Authorization: `Bearer ${key}`, "Content-Type": "application/json" },
-      body: JSON.stringify({ model, messages: [{ role: "user", content: "ping" }], max_tokens: 16 }),
+      body: JSON.stringify({
+        model,
+        messages: [{ role: "user", content: "Call the ping tool." }],
+        tools: [{ type: "function", function: { name: "ping", description: "health check", parameters: { type: "object", properties: {} } } }],
+        tool_choice: "auto",
+        max_tokens: 32,
+      }),
     });
     const j = await res.json().catch(() => ({}));
     if (!res.ok) {
       const msg = j?.error?.message || `HTTP ${res.status}`;
       return t(
-        `the model didn't answer: ${msg}. Check the slug on https://openrouter.ai/models (form vendor/model).`,
-        `модель не ответила: ${msg}. Проверьте слаг на https://openrouter.ai/models (вид vendor/model).`,
+        `the model can't be used: ${msg}. Iva needs a chat model with tool/function calling — pick one on https://openrouter.ai/models (form vendor/model).`,
+        `модель не подходит: ${msg}. Iva нужна chat-модель с поддержкой инструментов (function calling) — выберите такую на https://openrouter.ai/models (вид vendor/model).`,
       );
     }
-    // 200, но пустой контент — не блокируем (reasoning-модель могла упереться в max_tokens), лишь предупреждаем.
-    const content = j?.choices?.[0]?.message?.content;
-    if (!content || !content.trim()) {
+    // 200 = ключ+слаг+tools ок. «Ответила» = есть content ИЛИ tool_calls (модель могла сразу дёрнуть tool).
+    const msg = j?.choices?.[0]?.message;
+    const answered = (msg?.content && msg.content.trim()) || (Array.isArray(msg?.tool_calls) && msg.tool_calls.length);
+    if (!answered) {
       console.log(
         `${C.y}${t("(model replied empty — maybe a reasoning model / max_tokens; proceeding)", "(модель ответила пусто — возможно reasoning-модель / max_tokens; продолжаю)")}${C.x}`,
       );
     }
-    return null; // ответила — слаг валиден
+    return null; // слаг валиден и tool-совместим
   } catch (e) {
     return t(`request failed: ${e.message}`, `запрос не прошёл: ${e.message}`);
   }
@@ -371,7 +381,7 @@ async function main() {
     // 300+ моделей — пикер не подходит. Инструкция: откуда взять слаг и в каком виде, + живой тест.
     console.log(`\n  ${t("Now the model.", "Теперь модель.")} ${t("Open", "Откройте")} ${C.c}https://openrouter.ai/models${C.x}, ${t("pick a model and copy its slug", "выберите модель и скопируйте её слаг")}`);
     console.log(`  ${t("— the id under the name, form", "— id под названием, вид")} ${C.g}vendor/model${C.x} (${t("e.g.", "напр.")} ${C.g}anthropic/claude-sonnet-4.5${C.x}, ${C.g}openai/gpt-5.1${C.x}, ${C.g}google/gemini-2.5-pro${C.x}).`);
-    console.log(`  ${C.y}${t("I'll send a test request right away — so a wrong slug can't slip through and leave the bot mute.", "Сразу отправлю тестовый запрос — чтобы кривой слаг не проскочил и бот не остался немым.")}${C.x}`);
+    console.log(`  ${C.y}${t("I'll send a live test (incl. tool/function calling, which Iva needs) — so a wrong or chat-only model can't slip through and leave the bot mute.", "Сразу отправлю живой тест (включая поддержку инструментов — она нужна Iva) — чтобы кривая или chat-only модель не проскочила и бот не остался немым.")}${C.x}`);
     for (;;) {
       const m = (await ask(`  ${t("OpenRouter model slug", "Слаг модели OpenRouter")}`, out.OPENROUTER_MODEL || "")).trim();
       if (!m) {


### PR DESCRIPTION
## Что

Четвёртый провайдер модели — **OpenRouter** (`MODEL_PROVIDER=openrouter`): один ключ → 300+ моделей (Anthropic, OpenAI, Google, DeepSeek…) через единый OpenAI-совместимый API, оплата pay-as-you-go напрямую OpenRouter.

## Почему дёшево

OpenRouter — обычный OpenAI-совместимый chat/completions, поэтому **рантайм переиспользуется как есть**: `agent/agent.ts` (не-codex ветка через `createOpenAICompatible` + `includeUsage`) и `agent/vision.ts` подхватывают его автоматически. Новый код — только конфиг провайдера, ветка мастера и доки. Ноль новых зависимостей.

## Ключевое: живая проверка модели

У OpenRouter сотни моделей — пикер-список не годится. Вместо него мастер (`iva config` → провайдер `4`):
1. Показывает **откуда скопировать слаг и в каком виде** — `vendor/model` с `openrouter.ai/models` (напр. `anthropic/claude-sonnet-4.5`).
2. Сразу шлёт **живой тест-запрос** выбранным слагом. Кривой слаг → OpenRouter отдаёт `400 "... is not a valid model ID"` → мастер показывает ошибку и повторяет ввод.

Это закрывает футган «слаг вписан криво → всё принято → агент молчит в треде».

## Изменения

- `agent/provider.ts` — запись `openrouter` в `PROVIDERS` (baseURL, ключ, модель, дешёвая vision-модель `google/gemini-2.5-flash`).
- `scripts/setup.mjs` — пункт «4) OpenRouter»: проверка ключа (`GET /key`) + живой тест модели (`POST /chat/completions`).
- `agent/hooks/usage.ts`, `bin/iva.mjs` (doctor) — учёт openrouter.
- `.env.example`, `docs/configuration.md`, `docs/ru/configuration.md`, `docs/providers.md` — документация провайдера и формата слага.

## Проверено вживую (реальный ключ)

- `GET /key`: валидный → 200, битый → 401.
- Валидный слаг → 200 + непустой ответ; слаг `foo/bar` → 400 (hard-block сработал).
- Рантайм: `createOpenAICompatible` + `includeUsage` + `streamText` → текст + полный `usage` + `finishReason:stop` (стрим и учёт токенов работают).
- `npm run typecheck` — чисто.

## Решения по умолчанию

- **Vision** — хардкод `google/gemini-2.5-flash` (как `gemini-3-flash` у opencode): картинки работают, даже если текстовая модель text-only. Идут на кредиты OpenRouter — отмечено в доке.
- **Hard-block только на не-200**; пустой контент на 200 (reasoning-модель / `max_tokens`) → warning, не блок.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenRouter as a supported model provider.
  * Setup now supports OpenRouter API key, model slug (`vendor/model`), and context window configuration.
  * Configuration can validate the OpenRouter key/model during setup.

* **Bug Fixes**
  * Improved provider selection and required-key checks to include OpenRouter consistently.

* **Documentation**
  * Updated configuration/provider docs (including Russian) to cover OpenRouter setup, validation behavior, and vision handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->