### PR TITLE
fix(codex): store:false at build time — история инлайнится вместо item_reference

### DIFF
--- a/agent/provider.ts
+++ b/agent/provider.ts
@@ -64,6 +64,15 @@ const codexFetch: typeof fetch = async (input, init) => {
       const j = JSON.parse(body);
       j.store = false;
       delete j.previous_response_id;
+      // store:false → бэкенд ничего не персистит, поэтому любой server-side id в input — это эхо
+      // прошлого ответа, которого на сервере уже нет: item_reference (ссылка без контента) и даже
+      // echoed id у инлайн-item ловят "Item '<id>' not found. Items are not persisted...".
+      // Контент истории уже инлайнится целиком (store:false задан на этапе сборки тела, см.
+      // forceStoreFalse), поэтому ссылки режем, а id-эхо у остальных item'ов вычищаем.
+      if (Array.isArray(j.input)) {
+        j.input = j.input.filter((it: unknown) => (it as { type?: string })?.type !== "item_reference");
+        for (const it of j.input) if (it && typeof it === "object") delete (it as { id?: unknown }).id;
+      }
       body = JSON.stringify(j);
     } catch {
       /* не JSON — не трогаем */
@@ -72,10 +81,27 @@ const codexFetch: typeof fetch = async (input, init) => {
   return fetch(input, { ...init, headers, body });
 };
 
+// Форсит store:false на этапе СБОРКИ тела (не пост-фактум в codexFetch). Без этого @ai-sdk/openai
+// берёт store:true по умолчанию и реплеит прошлые ответы ассистента как item_reference (голая
+// ссылка на msg_-item, без контента); codexFetch затем ставит store:false — и stateless-бэкенд
+// подписки не находит item → сессия падает со второго запроса ("Item ... not found. Items are not
+// persisted when store is set to false"). store:false заставляет SDK инлайнить историю целиком.
+const forceStoreFalse: LanguageModelMiddleware = {
+  async transformParams({ params }) {
+    return {
+      ...params,
+      providerOptions: {
+        ...params.providerOptions,
+        openai: { ...params.providerOptions?.openai, store: false },
+      },
+    };
+  },
+};
+
 /** Строит Codex-модель (Responses API подписки). Общая для agent.ts и vision.ts. */
 export function makeCodexModel(model: string = providerConfig.textModel) {
   const openai = createOpenAI({ baseURL: CODEX_BASE_URL, apiKey: "chatgpt-subscription", fetch: codexFetch });
-  return openai.responses(model);
+  return wrapLanguageModel({ model: openai.responses(model), middleware: forceStoreFalse });
 }
 
 // --- Анти-InvalidPrompt: срезаем reasoning из вывода модели ---------------------------------


### PR DESCRIPTION
## Проблема

При `MODEL_PROVIDER=codex` (подписка ChatGPT) первый запрос проходит, а на **втором** сессия падает:

```
AI_APICallError: Item with id 'msg_...' not found.
Items are not persisted when store is set to false.
```

## Корень

Бэкенд подписки (Responses API) stateless — `codexFetch` форсит `store:false`. Но `@ai-sdk/openai@4.0.0-beta.76` при **сборке тела** берёт `store: true` по умолчанию (провайдер-опция `store` нигде не задана, `index.js:5822`). В этом режиме прошлый ответ ассистента реплеится как `{ type: "item_reference", id: "msg_..." }` — голая ссылка на server-side item **без контента** (`index.js:3627`). Затем `codexFetch` ставит верхнеуровневый `store:false` — и бэкенд не находит item, которого никогда не хранил. Первый запрос без прошлых ассистент-item'ов → работает; второй → падает.

OpenRouter не задет: он на chat/completions, историю шлёт инлайном, item id нет.

## Фикс

- `forceStoreFalse` — middleware с `transformParams`, задаёт `providerOptions.openai.store = false` на этапе сборки тела. SDK инлайнит историю целиком вместо `item_reference`.
- `codexFetch` дополнительно чистит `input`: режет уцелевшие `item_reference` и server-side `id`-эхо (страховка от строгости бэкенда; `call_id` пар function_call сохраняется).
- Единая точка — `makeCodexModel`, поэтому покрыты и eve, и vision.

## Проверка

- `npm run typecheck` — чисто.
- Юнит-самопроверка нормализации `input`: `item_reference` удалён, `id` срезан, контент ассистента и `call_id` сохранены.
- End-to-end на боевом сервере (реальный токен подписки) не гонял — нужен ручной прогон второго запроса на c1 после деплоя.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request handling for AI responses to avoid sending unsupported reference data.
  * Ensured response requests default to a stateless mode, reducing issues caused by echoed IDs in outgoing requests.
  * Made request cleanup more robust so generated requests are more reliable across different response flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->