### PR TITLE
fix(codex): bump client_version 0.142.5 → 0.144.0 — модели gpt-5.6 в списке

### DIFF
--- a/scripts/lib/codex-oauth.mjs
+++ b/scripts/lib/codex-oauth.mjs
@@ -21,8 +21,10 @@ const TOKEN_URL = `${ISSUER}/oauth/token`;
 const SCOPE = "openid profile email offline_access";
 const ORIGINATOR = "codex_cli_rs";
 // Для ?client_version= у /models и User-Agent. ВАЖНО: /models гейтит список по версии —
-// слишком старая (напр. 0.20/0.42) → бэкенд отдаёт {"models":[]}. Держим на актуальном релизе codex.
-const CLIENT_VERSION = "0.142.5";
+// слишком старая (напр. 0.20/0.42) → бэкенд отдаёт {"models":[]}, а модель прячется, если её
+// minimal_client_version выше нашей (напр. gpt-5.6-* требуют ≥0.144.0). Держим на актуальном релизе
+// codex, иначе свежие модели не появятся в списке. Проверено: 0.144.0 отдаёт gpt-5.6-{sol,terra,luna}.
+const CLIENT_VERSION = "0.144.0";
 const REFRESH_SKEW_S = 300; // рефрешим за 5 мин до exp (как окно codex CLI)
 const DEVICE_PORT = 1455; // codex-совместимый redirect-порт (fallback 1457)
 const FALLBACK_PORT = 1457;


### PR DESCRIPTION
## Проблема

Мастер `iva setup` (провайдер OpenAI/codex) показывает **старые 5 моделей** — `gpt-5.6` (вышла сегодня) в списке нет.

## Корень

Эндпоинт подписки `/models` гейтит выдачу по `client_version` и **прячет модель, у которой `minimal_client_version` выше нашей**. Семейство `gpt-5.6` требует `>= 0.144.0`, а в `scripts/lib/codex-oauth.mjs` было зашито `0.142.5` → бэкенд отдавал только 5.4/5.5.

Проверено вживую на подписке (токен codex CLI):

| client_version | модели |
|---|---|
| 0.142.5 | gpt-5.5, gpt-5.4, gpt-5.4-mini, gpt-5.3-codex-spark, codex-auto-review |
| **0.144.0** | + **gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna** |

## Фикс

- `CLIENT_VERSION` → `0.144.0` (текущий релиз codex CLI).

## Проверка

- `/models` на 0.144.0 отдаёт все три 5.6 (у них `minimal_client_version: 0.144.0`, `supported_in_api: true`).
- Реальный `/responses` к `gpt-5.6-sol` (stream, store:false) → HTTP 200, ответ «pong», usage корректный. То есть модель не только видна, но и отвечает.
- `compareModelDesc` ставит 5.6 наверх списка; offline self-check `codex-oauth.mjs` зелёный.

Независимо от #19 (store:false фикс) — разные файлы, конфликтов нет.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated model availability checks to request the latest supported model set.
  * Improved model-list filtering for the current Codex client version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->