### PR TITLE
feat: Telegram rich messages в ответах (таблицы/таск-листы/details/формулы, Bot API 10.1)

### DIFF
--- a/agent/channels/telegram.ts
+++ b/agent/channels/telegram.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 // Разметка Telegram — ЕДИНЫЙ источник правды (тот же модуль, что у cron-скриптов).
 // toTelegramHtmlChunks: markdown → массив готовых, сбалансированных HTML-чанков ≤limit
 // (гарантирует длину ПОСЛЕ конвертации). htmlToPlain: декодирующий plain-фолбэк.
-import { toTelegramHtmlChunks, htmlToPlain } from "../../scripts/lib/telegram-format.mjs";
+import { toTelegramHtmlChunks, htmlToPlain, needsRichMessage } from "../../scripts/lib/telegram-format.mjs";
 import { describeImage } from "../vision.js";
 import { sanitizeInbound, scanOutbound } from "../lib/security-gate.js";
 
@@ -254,6 +254,32 @@ export default telegramChannel({
       // toTelegramHtmlChunks режет на чанки И конвертирует, гарантируя длину каждого
       // чанка ≤4096 ПОСЛЕ конвертации (ручной chunkMarkdown+mdToTelegramHtml мог раздуть
       // чанк тегами за лимит → 400). Пустые чанки не шлём (Telegram отвергает пустой текст).
+
+      // Rich message (sendRichMessage, Bot API 10.1): таблицы/таск-листы/<details>/формулы
+      // рендерятся нативно — HTML-путь так не умеет. Пробуем rich ТОЛЬКО для них; любая
+      // ошибка (старый Bot API, парс, лимит 32768, RICH_MESSAGE_*) проваливается в HTML-путь
+      // ниже — worst case = сегодняшнее поведение. request() = raw Bot API call, транспорт
+      // JSON, поэтому rich_message шлём объектом. chat_id/thread берём из channel.telegram.
+      if (needsRichMessage(guard.text)) {
+        try {
+          const res = await channel.telegram.request("sendRichMessage", {
+            chat_id: channel.telegram.chatId,
+            rich_message: { markdown: guard.text },
+            ...(channel.telegram.messageThreadId !== undefined
+              ? { message_thread_id: channel.telegram.messageThreadId }
+              : {}),
+          });
+          if (res.ok) return;
+          console.error(
+            "[telegram] sendRichMessage отвергнут, фолбэк HTML:",
+            res.status,
+            JSON.stringify(res.body).slice(0, 300),
+          );
+        } catch (err) {
+          console.error("[telegram] sendRichMessage упал, фолбэк HTML:", err);
+        }
+      }
+
       for (const html of toTelegramHtmlChunks(guard.text, 4096)) {
         if (!html) continue;
         try {

--- a/scripts/lib/telegram-format.d.mts
+++ b/scripts/lib/telegram-format.d.mts
@@ -5,3 +5,4 @@ export function sanitizeTelegramHtml(html: unknown): string;
 export function mdToTelegramHtml(md: unknown): string;
 export function chunkMarkdown(md: unknown, limit?: number): string[];
 export function toTelegramHtmlChunks(md: unknown, limit?: number): string[];
+export function needsRichMessage(md: unknown): boolean;

--- a/scripts/lib/telegram-format.mjs
+++ b/scripts/lib/telegram-format.mjs
@@ -327,3 +327,24 @@ export function toTelegramHtmlChunks(md, limit = 4096) {
     try { return [escHtml(md)]; } catch { return [""]; }
   }
 }
+
+// ── rich-message routing ────────────────────────────────────────────────────────
+// True when the text has a construct that Telegram's rich messages
+// (sendRichMessage, Bot API 10.1) render natively but parse_mode=HTML CANNOT:
+// GFM tables, task lists, <details>, block math. Headings/quotes/bold/etc.
+// render fine in HTML, so — like hermes-agent — we do NOT route on those: normal
+// replies stay on the proven HTML path. Conservative by design: a false negative
+// is just today's behavior; a false positive falls back on API rejection anyway.
+export function needsRichMessage(md) {
+  const s = String(md);
+  // GFM table delimiter row: a line of only pipes/dashes/colons/space with a dash run.
+  // Plain prose effectively never produces such a line, so this alone is a safe signal.
+  for (const line of s.split("\n")) {
+    const t = line.trim();
+    if (t.includes("|") && /-{2,}/.test(t) && /^[|\-: \t]+$/.test(t)) return true;
+  }
+  if (/^[ \t]*[-*][ \t]+\[[ xX]\][ \t]+/m.test(s)) return true; // task list
+  if (/<details[\s>]/i.test(s)) return true;                    // collapsible
+  if (/\$\$[\s\S]+?\$\$/.test(s)) return true;                  // block math
+  return false;
+}

--- a/scripts/lib/telegram-rich.test.mjs
+++ b/scripts/lib/telegram-rich.test.mjs
@@ -1,0 +1,20 @@
+// Self-check for needsRichMessage — run: node scripts/lib/telegram-rich.test.mjs
+import { strict as assert } from "node:assert";
+import { needsRichMessage } from "./telegram-format.mjs";
+
+// Rich: constructs the HTML path can't render → route to sendRichMessage.
+assert.equal(needsRichMessage("| a | b |\n|---|---|\n| 1 | 2 |"), true, "table");
+assert.equal(needsRichMessage("col1 | col2\n:--- | ---:\nx | y"), true, "table no outer pipes");
+assert.equal(needsRichMessage("- [ ] todo\n- [x] done"), true, "task list");
+assert.equal(needsRichMessage("<details><summary>x</summary>y</details>"), true, "details");
+assert.equal(needsRichMessage("formula:\n$$E = mc^2$$"), true, "block math");
+
+// Plain: HTML path renders these fine → must stay off rich.
+assert.equal(needsRichMessage("**bold** and _italic_ and `code`"), false, "inline fmt");
+assert.equal(needsRichMessage("## Heading\n\ntext\n\n> quote"), false, "heading+quote");
+assert.equal(needsRichMessage("- bullet\n- list"), false, "plain list");
+assert.equal(needsRichMessage("price is $5 and $10"), false, "inline dollars (not $$)");
+assert.equal(needsRichMessage("a | b without a delimiter row"), false, "pipe but no table");
+assert.equal(needsRichMessage(""), false, "empty");
+
+console.log("telegram-rich: all assertions passed");


### PR DESCRIPTION
## Что

iva теперь шлёт обычные ответы через **`sendRichMessage`** (Bot API 10.1), когда в тексте есть конструкции, которые `parse_mode=HTML` не рендерит: **GFM-таблицы, таск-листы `- [ ]`, `<details>`, блочные формулы `$$…$$`**. Всё остальное (bold/italic/code/цитаты/заголовки/spoiler/links) остаётся на текущем HTML-пути.

## Как

- `needsRichMessage(md)` — детектор в общем `scripts/lib/telegram-format.mjs` (единый источник правды разметки). Гейт зеркалит hermes-agent (`_needs_rich_rendering`: table/task-list/details/math).
- В `message.completed`: при срабатывании → `channel.telegram.request("sendRichMessage", {chat_id, rich_message:{markdown}, message_thread_id?})`. **Любая** ошибка (pre-10.1 Bot API, парс, лимит 32768, `RICH_MESSAGE_*`) → провал в существующий HTML+plain путь. **Worst case = сегодняшнее поведение.**
- iva не стримит ответы → одноразовый выбор rich-vs-HTML, без streaming-finalize (боль hermes нас не касается).
- Транспорт eve — JSON, поэтому `rich_message` шлётся объектом. chat_id/thread берутся из `channel.telegram`.

## Скоуп / решения

- Медиа/локальные картинки НЕ трогаю (YAGNI): обычные ответы их не содержат; `![](file:)`-аплоад — отдельный скилл rich-post (Path A на будущее).
- Заголовки НЕ триггерят rich (как и у hermes) — модель часто пишет `##`, иначе почти каждый ответ шёл бы через новый API. Включается одной строкой.

## Проверки

- `node scripts/lib/telegram-rich.test.mjs` — 11 assert, зелёно
- `eve build` (Node 24) — ок
- `tsgo --noEmit` — 0 ошибок

## Осталось

Живой тест на боевом боте (api.telegram.org уже поддерживает 10.1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Telegram messages with tables, task lists, expandable sections, or block math now use enhanced rich-message formatting.
  * Messages automatically fall back to standard formatting if rich delivery is unavailable or unsuccessful.

* **Bug Fixes**
  * Improved preservation of complex Markdown formatting in Telegram messages.

* **Tests**
  * Added coverage for rich and standard Markdown formatting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->