### PR TITLE
fix(telegram): show the current model in /restart and /update replies

### DIFF
--- a/scripts/lib/env-file.mjs
+++ b/scripts/lib/env-file.mjs
@@ -25,6 +25,13 @@ export async function readEnvValues(path) {
   }
 }
 
+// Base env refreshed with the current .env file: file values win, base-only keys survive.
+// For long-running processes (the Telegram bridge) whose process.env snapshot goes stale
+// after the /model wizard edits .env — display code must read through this, not process.env.
+export async function readEnvFresh(path, base = process.env) {
+  return { ...base, ...(await readEnvValues(path)) };
+}
+
 // Upsert keys in .env: updates = {KEY: string | null} (null ⇒ drop the line).
 // First matching line is replaced in place, duplicates are dropped, missing keys are
 // appended at the end. Values must be single-line — a multiline paste (e.g. a mangled

--- a/scripts/lib/env-file.test.mjs
+++ b/scripts/lib/env-file.test.mjs
@@ -3,7 +3,7 @@ import { strict as assert } from "node:assert";
 import { chmod, mkdtemp, readFile, writeFile, stat, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { parseEnvText, readEnvValues, upsertEnv } from "./env-file.mjs";
+import { parseEnvText, readEnvFresh, readEnvValues, upsertEnv } from "./env-file.mjs";
 
 const dir = await mkdtemp(join(tmpdir(), "env-file-test-"));
 const p = join(dir, ".env");
@@ -36,6 +36,14 @@ assert.equal(await readFile(p, "utf8"), "A=x\nB=2\n");
 // multiline value must throw, not corrupt the file.
 await assert.rejects(() => upsertEnv(p, { KEY: "line1\nline2" }), /newline/);
 assert.equal(await readFile(p, "utf8"), "A=x\nB=2\n", "file untouched after reject");
+
+// fresh read: file values win over the (stale) base snapshot; base-only keys survive.
+await writeFile(p, "MODEL_PROVIDER=codex\nCODEX_MODEL=gpt-5.6\n");
+assert.deepEqual(
+  await readEnvFresh(p, { MODEL_PROVIDER: "opencode", OPENCODE_MODEL: "kimi-k3", PATH: "/usr/bin" }),
+  { MODEL_PROVIDER: "codex", CODEX_MODEL: "gpt-5.6", OPENCODE_MODEL: "kimi-k3", PATH: "/usr/bin" },
+);
+assert.deepEqual(await readEnvFresh(join(dir, "missing"), { A: "1" }), { A: "1" }, "missing file → base as-is");
 
 await rm(dir, { recursive: true, force: true });
 console.log("env-file: all assertions passed");

--- a/scripts/lib/update-ui.test.mjs
+++ b/scripts/lib/update-ui.test.mjs
@@ -225,6 +225,38 @@ test("update callback is acknowledged before any message edit", async () => {
   }
 });
 
+test("up-to-date check shows the model from fresh .env, not this process's snapshot", async () => {
+  const previousFetch = globalThis.fetch;
+  const previousEnv = Object.fromEntries(
+    ["TELEGRAM_BOT_TOKEN", "TELEGRAM_ALLOWED_USER_IDS", "MODEL_PROVIDER", "OPENCODE_MODEL"].map((k) => [k, process.env[k]]),
+  );
+  process.env.TELEGRAM_BOT_TOKEN = "token";
+  process.env.TELEGRAM_ALLOWED_USER_IDS = "42";
+  // The bridge's snapshot is stale: the /model wizard rewrote .env after this process started.
+  process.env.MODEL_PROVIDER = "opencode";
+  process.env.OPENCODE_MODEL = "stale-model";
+  const calls = [];
+  globalThis.fetch = async (url, init) => {
+    calls.push({ method: url.split("/").at(-1), body: JSON.parse(init.body) });
+    return { ok: true, json: async () => ({ ok: true, result: { message_id: 10 } }) };
+  };
+  try {
+    const bridge = await import(`../telegram-poll.mjs?fresh=${Date.now()}`);
+    await bridge.handleUpdateCheck(1, {
+      inspectImpl: async () => ({ hasCommitUpdate: false, localVersion: "1.2.3" }),
+      envImpl: async () => ({ MODEL_PROVIDER: "codex", CODEX_MODEL: "fresh-model" }),
+    });
+    const edit = calls.find((call) => call.method === "editMessageText");
+    assert.match(edit.body.text, /OpenAI · fresh-model/);
+  } finally {
+    globalThis.fetch = previousFetch;
+    for (const [key, value] of Object.entries(previousEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+});
+
 test("manual update offer keeps commit-based behavior and marks a stable release as shown", async () => {
   const previousFetch = globalThis.fetch;
   const previousToken = process.env.TELEGRAM_BOT_TOKEN;

--- a/scripts/telegram-poll.mjs
+++ b/scripts/telegram-poll.mjs
@@ -15,7 +15,7 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { randomBytes } from "node:crypto";
 import { readEntries, summarize, formatUsageReport, parseWindow } from "./lib/usage.mjs";
-import { readEnvValues, upsertEnv } from "./lib/env-file.mjs";
+import { readEnvFresh, readEnvValues, upsertEnv } from "./lib/env-file.mjs";
 import { CATALOG, EFFORTS, fetchModels, checkKey } from "./lib/model-catalog.mjs";
 import { getAccessToken, runDeviceCodeLogin } from "./lib/codex-oauth.mjs";
 import { compactNumber, modelSummary } from "./lib/model-summary.mjs";
@@ -215,7 +215,7 @@ function launchSelfUpdate(jobId) {
 
 export async function handleUpdateCheck(
   chatId,
-  { inspectImpl = inspectUpstream, markNotifiedImpl = markVersionNotified } = {},
+  { inspectImpl = inspectUpstream, markNotifiedImpl = markVersionNotified, envImpl = () => readEnvFresh(ENV_PATH) } = {},
 ) {
   const status = await reply(chatId, t("◇ Checking for updates", "◇ Проверяю обновления"));
   if (!status) return;
@@ -227,7 +227,9 @@ export async function handleUpdateCheck(
     return;
   }
   if (!info.hasCommitUpdate) {
-    const model = modelSummary(process.env);
+    // Not modelSummary(process.env): the /model wizard edits .env at runtime and restarts
+    // only the agent — this bridge keeps running, so its env snapshot may hold the old model.
+    const model = modelSummary(await envImpl());
     await edit(chatId, status.message_id, t(
       `✅ You're up to date\n\nIva v${info.localVersion ?? "?"}\nModel: ${model.line}`,
       `✅ У вас актуальная версия\n\nIva v${info.localVersion ?? "?"}\nМодель: ${model.line}`,
@@ -655,7 +657,8 @@ async function handleControl(update) {
     return true;
   }
   // /restart, /new, /clear, /compact → process restart (reliable reset/recovery).
-  const resetCopy = resetMessageCopy(cmd);
+  // Fresh .env, not this process's snapshot — see the same note in handleUpdateCheck.
+  const resetCopy = resetMessageCopy(cmd, await readEnvFresh(ENV_PATH));
   const status = await reply(chatId, resetCopy.pending);
   const ok = await restartAgent();
   if (!status) return true;


### PR DESCRIPTION
## Problem

After switching the model with the `/model` wizard, `/restart`, `/new` and the "You're up to date" reply of `/update` keep announcing the **previous** model, even though the agent is already running the new one.

Reproduction:

1. `/model` → pick a new provider/model → "Restart now" — the confirmation correctly shows the new model, and the agent really uses it.
2. Later send `/restart` (or `/update` when no update is available) — the reply says `Model: <old provider · old model>`.

## Root cause

The wizard writes the new configuration to `.env` and restarts **only `iva.service`** — by design the bridge keeps running so the chat stays responsive. But the bridge process loaded its environment once at startup (`node --env-file=.env`), so its `process.env` snapshot still holds the old values, and both `resetMessageCopy(cmd)` (default `env = process.env`) and `handleUpdateCheck` (`modelSummary(process.env)`) render the model from that stale snapshot.

The wizard's own screens already avoid this by reading `.env` fresh (`currentConfig()` / `readEnvValues`); these two display paths just never got the same treatment. Display-only — the agent itself always restarts with the correct model — but it reads as if the model switch had silently rolled back.

## Fix

- New `readEnvFresh(path, base = process.env)` in `scripts/lib/env-file.mjs`: current `.env` values layered over the process snapshot (file wins, env-only keys survive, missing file degrades to the snapshot — pure-env setups keep working).
- `/restart`/`/new`/`/clear`/`/compact` copy and the up-to-date `/update` reply now read the model summary through it. `handleUpdateCheck` takes an injectable `envImpl`, consistent with its existing `inspectImpl`/`markNotifiedImpl` seams.

## Tests

- `env-file.test.mjs`: `readEnvFresh` merge semantics (file wins over base; missing file → base as-is).
- `update-ui.test.mjs`: regression test reproducing the report — stale `process.env` model vs fresh `.env` model; before the fix the reply rendered `OpenCode · stale-model`, now it renders the fresh model.

`node --test scripts/lib/*.test.mjs`: 30 pass, 0 fail.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Telegram status messages now reflect the latest model configuration after `.env` changes.
  * Restart, new, clear, and compact commands now use current configuration values.
  * Environment settings remain available when the `.env` file is missing, preventing stale or empty status information.
* **Tests**
  * Added coverage for refreshed configuration reads and up-to-date model display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->