### PR TITLE
Fix: memory-doctor falsely reports embed-index failure

### DIFF
--- a/scripts/memory/doctor.ts
+++ b/scripts/memory/doctor.ts
@@ -107,7 +107,9 @@ maint("link_cleanup", [`${SCRIPTS}/link_cleanup.py`, "."]);
 // Плагин: пересобрать сайдкар эмбеддингов для hybrid-поиска (только если включён). Запускаем
 // из корня проекта (cwd), а не из VAULT — скрипт лежит в scripts/, ключ читается из .env.
 if (process.env.MEMORY_SEARCH_MODE === "hybrid") {
-  const r = run("node", ["--env-file=.env", "scripts/memory/embed-index.ts"], process.cwd());
+  // Use process.execPath, not bare "node": the systemd unit's PATH does not include the
+  // nvm node dir, so spawning "node" by name fails with ENOENT and falsely reports a failure.
+  const r = run(process.execPath, ["--env-file=.env", "scripts/memory/embed-index.ts"], process.cwd());
   if (r.status !== 0) failures.push("embed-index");
 }
 


### PR DESCRIPTION
### Fix: memory-doctor falsely reports embed-index failure

The generated systemd memory-doctor unit's PATH omits the nvm node dir, so spawning node by name fails with ENOENT - the doctor then falsely reports an embed-index maintenance failure (and alerts on Telegram) even though the vault, uv/Python, and embedding key are all healthy.

Fix: spawn the child via process.execPath (the absolute path of the running interpreter) instead of a bare node, so it runs regardless of the unit's PATH - no need to bake the nvm dir into every generated unit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when rebuilding the hybrid embedding index in environments where the Node.js command is not available through the system PATH.
  * Preserved existing environment configuration and failure reporting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->