### PR TITLE
fix(cli): iva reset чистит .eve/.workflow-data — реальное место стора eve

### DIFF
--- a/bin/iva.mjs
+++ b/bin/iva.mjs
@@ -7,7 +7,7 @@
 import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync, mkdirSync, rmSync, readdirSync, chmodSync } from "node:fs";
 import { randomBytes } from "node:crypto";
-import { join, dirname } from "node:path";
+import { join, dirname, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import { homedir } from "node:os";
 import { createInterface } from "node:readline/promises";
@@ -589,23 +589,28 @@ function cmdRestart() {
   restartServices(); // regenerate the unit before restart → PORT stays in sync with IVA_PORT in .env
   ok("Restarted: iva + telegram-poll");
 }
-// Full reset: stop services, wipe .workflow-data, bring it back up. A plain restart
+// Full reset: stop services, wipe the workflow store, bring it back up. A plain restart
 // does NOT cure a stuck/bloated run — on startup eve re-enqueues all pending/running
-// runs from .workflow-data ("Re-enqueued N active run(s) on startup"). We clean while the server
-// is stopped (otherwise we'd delete files out from under a live process). Wipes ALL parked dialogs.
+// runs ("Re-enqueued N active run(s) on startup"). We clean while the server is stopped
+// (otherwise we'd delete files out from under a live process). Wipes ALL parked dialogs.
+// Current eve keeps the store in .eve/.workflow-data; the bare .workflow-data is where
+// older versions kept it — clear both so reset works across eve upgrades.
 function cmdReset() {
   requireSystemd();
   step("Full reset: stopping services…");
   sc("stop", ...SERVICES);
-  const wf = join(ROOT, ".workflow-data");
-  if (existsSync(wf)) {
+  let found = false;
+  for (const wf of [join(ROOT, ".eve", ".workflow-data"), join(ROOT, ".workflow-data")]) {
+    if (!existsSync(wf)) continue;
+    found = true;
     try {
       rmSync(wf, { recursive: true, force: true });
-      ok(".workflow-data cleared — stuck/accumulated workflow runs reset");
+      ok(`${relative(ROOT, wf)} cleared — stuck/accumulated workflow runs reset`);
     } catch (e) {
-      warn(`failed to delete .workflow-data: ${e.message}`);
+      warn(`failed to delete ${relative(ROOT, wf)}: ${e.message}`);
     }
-  } else ok(".workflow-data already empty");
+  }
+  if (!found) ok("workflow store already empty");
   restartServices();
   ok("Restarted: iva + telegram-poll");
 }


### PR DESCRIPTION
## Проблема

`iva reset` («clear stuck workflows and restart») чистит `ROOT/.workflow-data`, но текущий eve хранит стор в `ROOT/.eve/.workflow-data`. В итоге единственная команда против зависших ходов пишет «.workflow-data already empty» и ничего не сбрасывает.

Наткнулся вживую: рестарт iva посреди активного хода оставил в сторе «running»-зомби, который заблокировал диалог (сообщения доходят, LLM-вызовов нет, в логе старта — «Re-enqueued 15 active run(s)»), а `iva reset` не помог бы. Про сам клин заведу отдельное issue — здесь только починка reset.

## Решение

`cmdReset` проходит по обоим местоположениям — `.eve/.workflow-data` (актуальное) и `.workflow-data` (старое) — и удаляет те, что существуют. Так reset переживает и будущие переезды стора между версиями eve в обе стороны.

## Проверено

- `node --check bin/iva.mjs`;
- на живой установке 0.3.2 (VPS): ручной эквивалент (stop → удалить `.eve/.workflow-data` → start) убрал 15 зависших ранов, лог старта чистый, агент снова отвечает.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the `reset` command to reliably clean up workflow data from both the current and legacy storage locations.
  * Added more precise handling and messaging when workflow data isn’t present (including an “already empty” outcome).
  * Continued the existing behavior of stopping services before cleanup and restarting them afterward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->