### PR TITLE
fix(menu): never leak a secret file to the agent; accept client_secre…

### DIFF
--- a/docs/menu.md
+++ b/docs/menu.md
@@ -63,7 +63,7 @@ Search keys, the userbot's `api_id`/`api_hash`, and the Google OAuth client JSON
 - **Never leaves the bridge.** The value never reaches the model, the logs, or any error text.
 - **Soft validation.** Keys are probed against the provider with a one-result request. A hard rejection (401/403) is refused; a network hiccup is accepted — a real flake shouldn't block you, and a wrong-but-shaped key surfaces later in the tool's own error.
 
-A photo of a key is *not* intercepted — only text. Send secrets as text, in your DM with the bot.
+While a prompt is waiting for a **secret**, nothing you send slips past to the model: a pasted key is captured, and a document or photo is intercepted too (deleted, with a short note on how to send it) — so a secret file like `client_secret.json` can't leak into the vault or the conversation. The Google client secret specifically may be sent as pasted text **or** as the `.json` file (downloaded in the bridge, size-capped, deleted before the download begins). Non-secret prompts (e.g. the memory interview) are unaffected — an attachment there reaches Iva as usual.
 
 ## Search
 
@@ -81,7 +81,7 @@ The userbot is opt-in beta; the full picture, including the anti-ban guardrail: 
 
 ## Google Workspace
 
-The **🔗 Google** screen checks for `~/.config/gws/client_secret.json`. Missing, it walks you through console.cloud.google.com — create an OAuth client of type *Desktop app*, download the JSON, paste it into the chat (it's shape-checked and written `0600`). Present, it probes authorization; if you're not signed in yet it shows a **Connect** button that runs the whole sign-in for you — no SSH. `gws auth login` only supports the loopback flow (it waits for the browser to hit `http://localhost:<port>` on the server), which can't complete from a browser on another machine. So Iva starts `gws` itself, sends you the Google consent link, and when you approve and paste the redirect URL back — the one that lands on a `http://localhost:…` page your browser can't load — it replays that callback against the loopback listener locally, finishing the exchange and storing the token. The pasted URL carries a one-time code, so Iva deletes that message and never logs it, then edits the screen to a final status (connected, or retry). What `gws` reaches: Gmail, Calendar, Drive, Sheets, Docs.
+The **🔗 Google** screen checks for `~/.config/gws/client_secret.json`. Missing, it walks you through console.cloud.google.com — create an OAuth client of type *Desktop app*, download the JSON, and send it into the chat — paste the contents or attach the `.json` file (it's shape-checked and written `0600`). Present, it probes authorization; if you're not signed in yet it shows a **Connect** button that runs the whole sign-in for you — no SSH. `gws auth login` only supports the loopback flow (it waits for the browser to hit `http://localhost:<port>` on the server), which can't complete from a browser on another machine. So Iva starts `gws` itself, sends you the Google consent link, and when you approve and paste the redirect URL back — the one that lands on a `http://localhost:…` page your browser can't load — it replays that callback against the loopback listener locally, finishing the exchange and storing the token. The pasted URL carries a one-time code, so Iva deletes that message and never logs it, then edits the screen to a final status (connected, or retry). What `gws` reaches: Gmail, Calendar, Drive, Sheets, Docs.
 
 ## Timers, Skills, Status
 

--- a/scripts/lib/menu/gws.mjs
+++ b/scripts/lib/menu/gws.mjs
@@ -135,12 +135,12 @@ export default {
           [ctx.backRow(PARENT)],
         );
       }
-      st.awaitText = { kind: "gwsjson", secret: true, data: {} };
+      st.awaitText = { kind: "gwsjson", secret: true, data: {}, file: true };
       return ctx.flows.screen(
         st,
         ctx.tr(
-          "Paste the contents of client_secret.json as text. I'll delete the message right away and store the file securely.",
-          "Пришли содержимое client_secret.json текстом. Сообщение сразу удалю, файл сохраню безопасно.",
+          "Send client_secret.json — either paste its contents as text, or attach the .json file. I'll delete the message right away and store it securely.",
+          "Пришли client_secret.json — вставь содержимое текстом ИЛИ прикрепи сам .json-файл. Сообщение сразу удалю, файл сохраню безопасно.",
         ),
         [[ctx.btn(ctx.tr("Cancel", "Отмена"), `iva_menu:${SID}:o`)]],
       );

--- a/scripts/lib/menu/index.mjs
+++ b/scripts/lib/menu/index.mjs
@@ -183,7 +183,11 @@ export function createMenu({ flows, tg, deps, screens = SCREENS }) {
   // (apikey/ubcred/gwsjson) удаляется ДО всего остального — значение не уходит в eve/лог/reply.
   // Отказ secret вне лички — на этапе установки awaitText (обязанность экрана); сюда доходит
   // только уже разрешённый ввод.
-  async function onText(msg, st) {
+  // opts.skipDelete — the caller has ALREADY removed the message and CONFIRMED the deletion succeeded
+  // (the bridge deletes a secret file, checks the result, and only then downloads + delivers the
+  // content here). Callers must never set it without a confirmed deletion — otherwise a still-visible
+  // secret would be processed. When set, we don't try to delete a second time.
+  async function onText(msg, st, opts = {}) {
     ctx.lang = getLang();
     if (!st || !st.awaitText) return true;
     const chatId = msg.chat?.id;
@@ -196,7 +200,7 @@ export function createMenu({ flows, tg, deps, screens = SCREENS }) {
       return true;
     }
     const a = st.awaitText;
-    if (a.secret) {
+    if (a.secret && !opts.skipDelete) {
       // delete-message-FIRST (:512-515). При провале удаления — предупреждение как в мосте;
       // текст ошибки НИКОГДА не содержит значение ключа.
       const del = await tg("deleteMessage", { chat_id: chatId, message_id: msg.message_id });

--- a/scripts/telegram-poll.mjs
+++ b/scripts/telegram-poll.mjs
@@ -111,13 +111,64 @@ async function saveOffset(offset, delivered = null) {
   }
 }
 
-async function tg(method, body) {
+// Every Bot API call carries a deadline — a hung response must never stall the single polling loop.
+// The default suits normal calls; getUpdates overrides it to sit above its own long-poll window.
+async function tg(method, body, { timeoutMs = 30_000 } = {}) {
   const res = await fetch(`${API}/${method}`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body ?? {}),
+    signal: AbortSignal.timeout(timeoutMs),
   });
   return res.json();
+}
+
+// Read a web ReadableStream as UTF-8 text with a HARD cap: it stops and cancels the stream the moment
+// the running total exceeds maxBytes, so an oversized (or size-unknown) body is never fully buffered.
+// The caller passes an already time-bounded body (see downloadTelegramFile) so a hung socket mid-read
+// aborts the read too. Returns null on over-size or a read error. Pure — unit-tested off the network.
+export async function readCappedStream(body, maxBytes) {
+  if (!body || typeof body.getReader !== "function") return null;
+  const reader = body.getReader();
+  const chunks = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.length;
+      if (total > maxBytes) {
+        await reader.cancel().catch(() => {});
+        return null;
+      }
+      chunks.push(Buffer.from(value));
+    }
+  } catch {
+    return null;
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+// Download a Telegram file's bytes as UTF-8 text (getFile → file download), hard-capped at maxBytes and
+// deadline-bounded at every step (getFile call, the download connection, and the streamed read — a size
+// cap alone doesn't save the loop from a stalled socket). Returns null on any failure or over-size.
+async function downloadTelegramFile(fileId, maxBytes) {
+  try {
+    const info = await tg("getFile", { file_id: fileId }, { timeoutMs: 10_000 });
+    const filePath = info?.result?.file_path;
+    if (!filePath) return null;
+    const res = await fetch(`https://api.telegram.org/file/bot${TOKEN}/${filePath}`, {
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!res.ok) return null;
+    // Cheap early reject when the server declares an over-size body; the stream reader below is the
+    // hard cap regardless (a missing or lying Content-Length can't get past it).
+    const declared = Number(res.headers.get("content-length"));
+    if (Number.isFinite(declared) && declared > maxBytes) return null;
+    return await readCappedStream(res.body, maxBytes);
+  } catch {
+    return null;
+  }
 }
 
 // Deliver one update to the local eve (we mimic a webhook). Three failure classes (see
@@ -765,6 +816,65 @@ async function registerBotCommands() {
   }
 }
 
+// Delete a message carrying a secret, warning the user if Telegram won't let us — a rejected secret
+// must never silently linger in the chat (mirrors the delete-first path in menu.onText).
+async function deleteSecretMessage(chatId, messageId) {
+  const del = await tg("deleteMessage", { chat_id: chatId, message_id: messageId }).catch(() => ({ ok: false }));
+  if (!del?.ok) {
+    await reply(chatId, tr("Couldn't delete your message — please delete it manually.", "Не смог удалить сообщение — удали его вручную.")).catch(() => {});
+  }
+  return del?.ok === true;
+}
+
+// Default I/O for handleAwaitNonText — injectable so the delete→download ordering and the
+// "never reaches eve" contract can be unit-tested with mocks.
+const nonTextIo = {
+  deleteSecret: (chatId, id) => deleteSecretMessage(chatId, id),
+  reply: (chatId, text) => reply(chatId, text),
+  download: (fileId, max) => downloadTelegramFile(fileId, max),
+  // Run the screen's own text handler on downloaded content WITHOUT re-deleting (already deleted).
+  deliver: (text, msg, st) => menu.onText({ ...msg, text }, st, { skipDelete: true }),
+};
+
+// A non-text message arrived while a menu/wizard awaits a SECRET (the caller gates this to
+// secret/file-capable states — a non-secret interview attachment falls through to eve untouched).
+// It must never reach eve. For a file-capable prompt (gws client_secret) a document is captured;
+// crucially the message is DELETED FIRST, before the download, so the secret doesn't linger in the
+// chat for the download's duration. Anything else is deleted with a clear ack telling the user how
+// to send it. Always returns true (the update is consumed, not delivered).
+export async function handleAwaitNonText(msg, pending, io = nonTextIo) {
+  const chatId = msg.chat?.id;
+  const a = pending.awaitText;
+  const MAX_BYTES = 256 * 1024;
+  if (a?.file && msg.document && pending.flow === "menu") {
+    if ((msg.document.file_size ?? 0) > MAX_BYTES) {
+      await io.deleteSecret(chatId, msg.message_id);
+      await io.reply(chatId, tr("That file is too large — paste the contents as text instead.", "Файл слишком большой — вставь содержимое текстом."));
+      return true;
+    }
+    // Delete FIRST, and only proceed once the secret has actually left the chat. If Telegram
+    // refused the deletion, deleteSecret already told the user to remove it manually — we must NOT
+    // download or deliver a secret that is still visible in the conversation. Consume it either way
+    // so it never reaches eve.
+    const deleted = await io.deleteSecret(chatId, msg.message_id);
+    if (!deleted) return true;
+    const content = await io.download(msg.document.file_id, MAX_BYTES);
+    if (content == null) {
+      await io.reply(chatId, tr("Couldn't read that file — paste the contents as text instead.", "Не смог прочитать файл — вставь содержимое текстом."));
+      return true;
+    }
+    await io.deliver(content, msg, pending); // skipDelete is safe now — the message is confirmed gone
+    return true;
+  }
+  // Secret prompt, but not a capturable file (a photo, or a text-only secret) — delete it so it can't
+  // reach eve, and tell the user how to send it instead of dropping it silently.
+  await io.deleteSecret(chatId, msg.message_id);
+  await io.reply(chatId, a?.file
+    ? tr("Send client_secret.json as text or attach the .json file — not a photo.", "Пришли client_secret.json текстом или прикрепи .json-файл — не фото.")
+    : tr("Send it as text, please.", "Пришли это, пожалуйста, текстом."));
+  return true;
+}
+
 // Control commands are handled by the BRIDGE (out-of-band) — they work even if the agent is stuck.
 // Trusted IDs only. Returns true if the command was handled (we do NOT deliver it to eve).
 async function handleControl(update) {
@@ -790,29 +900,40 @@ async function handleControl(update) {
   }
   const msg = update.message;
   const text = (msg?.text || "").trim();
-  // A pending flow (menu screen or /model wizard) awaiting text claims this user's next
-  // plain-text message (a key must never reach eve); a command aborts the wait — a silently
-  // still-visible prompt would invite pasting the key later, when nothing intercepts it.
-  // This runs BEFORE the busy-buffer gate (below), so a capture works even mid-turn.
-  if (msg?.from && text) {
+  // A pending flow (menu screen or /model wizard) awaiting input claims this user's next message
+  // (a key must never reach eve); a command aborts the wait — a silently still-visible prompt would
+  // invite pasting the key later, when nothing intercepts it. This runs BEFORE the busy-buffer gate
+  // (below), so a capture works even mid-turn. Non-text is intercepted only while awaiting a SECRET
+  // (or a file-capable secret): a document/photo could be the secret itself and must not reach eve.
+  // A non-secret await (e.g. the memory interview) lets a non-text message fall through unchanged.
+  if (msg?.from) {
     const pending = getWizard(msg.chat?.id, String(msg.from.id));
-    if (pending?.awaitText) {
+    const a = pending?.awaitText;
+    if (a) {
       if (text.startsWith("/")) {
         await endWizard(pending, tr("Cancelled — no longer waiting for input.", "Отменено — ожидание ввода снято.")).catch(() => {});
-      } else if (pending.flow === "menu") {
-        // Menu screens own their capture (interview / key intake / gws JSON / ubcred).
-        return menu.onText(msg, pending).catch((e) => {
-          log("menu capture error:", e.message); // e.message never contains a secret value
-          return true;
-        });
-      } else {
+      } else if (text) {
+        if (pending.flow === "menu") {
+          // Menu screens own their capture (interview / key intake / gws JSON / ubcred).
+          return menu.onText(msg, pending).catch((e) => {
+            log("menu capture error:", e.message); // e.message never contains a secret value
+            return true;
+          });
+        }
         // /model wizard key intake — consume the update even on failure (the key must never
         // be re-polled into eve). handleKeyMessage stays the wizard's own handler.
         return handleKeyMessage(msg, pending).catch((e) => {
           log("wizard key error:", e.message); // e.message never contains the key value
           return true;
         });
+      } else if (a.secret || a.file) {
+        // Non-text while awaiting a secret — never let it reach eve (delete-first inside).
+        return handleAwaitNonText(msg, pending).catch((e) => {
+          log("menu attachment capture error:", e.message); // never contains the secret value
+          return true;
+        });
       }
+      // else: non-secret await + non-text → fall through so eve handles it normally.
     }
   }
   if (!text.startsWith("/")) return false;
@@ -929,7 +1050,7 @@ async function main() {
         offset,
         timeout: 30,
         allowed_updates: ["message", "callback_query"],
-      });
+      }, { timeoutMs: 40_000 }); // above the 30s long-poll window
     } catch (e) {
       log("getUpdates network:", e.message);
       await sleep(3000);

--- a/scripts/telegram-poll.test.mjs
+++ b/scripts/telegram-poll.test.mjs
@@ -1,0 +1,81 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+// telegram-poll.mjs reads env at import and guards its poll loop behind a direct-execution check,
+// so importing it here is side-effect-free. A dummy token keeps the API base a harmless string.
+process.env.TELEGRAM_BOT_TOKEN ??= "test:token";
+const { readCappedStream, handleAwaitNonText } = await import("./telegram-poll.mjs");
+
+const enc = new TextEncoder();
+function streamOf(...parts) {
+  return new ReadableStream({
+    start(controller) {
+      for (const p of parts) controller.enqueue(typeof p === "string" ? enc.encode(p) : p);
+      controller.close();
+    },
+  });
+}
+
+// A recording double for handleAwaitNonText's I/O: captures call order, returns fixed content.
+// deleteOk controls whether the (mocked) Telegram deletion is reported as successful.
+function recorder(content = '{"installed":{}}', { deleteOk = true } = {}) {
+  const calls = [];
+  const io = {
+    deleteSecret: async (_c, id) => { calls.push(["delete", id]); return deleteOk; },
+    reply: async (_c, text) => { calls.push(["reply", text]); },
+    download: async (fileId) => { calls.push(["download", fileId]); return content; },
+    deliver: async (text) => { calls.push(["deliver", text]); },
+  };
+  return { calls, io, names: () => calls.map((c) => c[0]) };
+}
+
+test("readCappedStream reads a small body under the cap", async () => {
+  assert.equal(await readCappedStream(streamOf('{"installed":{}}'), 1024), '{"installed":{}}');
+});
+
+test("readCappedStream: oversized body with NO metadata → null (hard cap mid-stream)", async () => {
+  const chunk = "x".repeat(1000);
+  assert.equal(await readCappedStream(streamOf(chunk, chunk, chunk), 2048), null);
+});
+
+test("readCappedStream: exactly at the cap allowed, one over rejected; null body → null", async () => {
+  assert.equal(await readCappedStream(streamOf("abcd"), 4), "abcd");
+  assert.equal(await readCappedStream(streamOf("abcde"), 4), null);
+  assert.equal(await readCappedStream(null, 1024), null);
+});
+
+test("file-capable secret: message is DELETED BEFORE the download, then content delivered", async () => {
+  const r = recorder();
+  const msg = { chat: { id: 1 }, message_id: 42, document: { file_id: "F", file_size: 100 } };
+  const pending = { flow: "menu", awaitText: { secret: true, file: true, kind: "gwsjson" } };
+  const consumed = await handleAwaitNonText(msg, pending, r.io);
+  assert.equal(consumed, true); // consumed → handleControl won't deliver it to eve
+  assert.deepEqual(r.names(), ["delete", "download", "deliver"]);
+  assert.ok(r.names().indexOf("delete") < r.names().indexOf("download"), "delete must precede download");
+});
+
+test("failed deletion → the secret is NOT downloaded or delivered (still consumed)", async () => {
+  const r = recorder('{"installed":{}}', { deleteOk: false });
+  const msg = { chat: { id: 1 }, message_id: 42, document: { file_id: "F", file_size: 100 } };
+  const pending = { flow: "menu", awaitText: { secret: true, file: true, kind: "gwsjson" } };
+  const consumed = await handleAwaitNonText(msg, pending, r.io);
+  assert.equal(consumed, true); // never reaches eve
+  assert.deepEqual(r.names(), ["delete"]); // deletion failed → no download, no deliver
+});
+
+test("over-size document is deleted and never downloaded", async () => {
+  const r = recorder();
+  const msg = { chat: { id: 1 }, message_id: 9, document: { file_id: "F", file_size: 999_999 } };
+  const pending = { flow: "menu", awaitText: { secret: true, file: true, kind: "gwsjson" } };
+  await handleAwaitNonText(msg, pending, r.io);
+  assert.deepEqual(r.names(), ["delete", "reply"]); // no download
+});
+
+test("secret prompt + non-file attachment (photo) → deleted with an ack, not delivered to eve", async () => {
+  const r = recorder();
+  const msg = { chat: { id: 1 }, message_id: 7 }; // no .document → a photo/sticker/etc
+  const pending = { flow: "menu", awaitText: { secret: true, kind: "apikey" } };
+  const consumed = await handleAwaitNonText(msg, pending, r.io);
+  assert.equal(consumed, true);
+  assert.deepEqual(r.names(), ["delete", "reply"]); // deleted + told how to send; never reaches eve
+});


### PR DESCRIPTION
**Проблема** (безопасность). Пока экран /menu ждёт секрет, перехватывался только вставленный текст. Если прислать `client_secret.json` файлом (естественное действие, если только что скачал из Google Console), документ проскакивал мимо перехвата в handleControl (msg?.from && text, у документа пустой .text) и уходил в vault: агент скачивал его в vault/attachments/… и пересказывал содержимое в чат. Итог: Google OAuth client secret утекал в контекст модели и в git-бэкап vault. Воспроизводится на чистой установке.

**Фикс.** Пока ждётся ввод, мост перехватывает и не-текст, в vault он больше не попадает:
- Если промпт помечен файловым (awaitText.file) и пришёл документ, мост скачивает его (getFile + download, лимит 256 КБ) и отдаёт содержимое тому же валидируемому текст-обработчику экрана (menu.onText), сообщение удаляется. Так `client_secret.json` можно прислать **текстом** ИЛИ **файлом**, и он никогда не идёт через модель.
- Любое другое вложение во время секрет-промпта просто **удаляется**, промпт остаётся.

**Изменения**: telegram-poll.mjs (downloadTelegramFile + handleAwaitNonText; гейт ожидания теперь срабатывает и на не-текст), gws.mjs (пометка file-capable + текст промпта «текстом ИЛИ .json-файлом»), docs/menu.md.

**Проверка**: на свежей установке (Node 24), приём client_secret.json файлом - сообщение удалено, секрет записан 0600, в vault/attachments пусто, в агента ничего не ушло; вставка текстом работает как раньше.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Google Workspace setup now accepts the Google client secret as either pasted JSON or an attached `.json` file.
- **Bug Fixes**
  - Hardened secret intake during active prompts: non-text secret attachments are deleted before processing when possible; oversize/unreadable files are removed with guidance to paste safe text.
  - Improved routing for awaited secret inputs, including non-text updates.
- **Documentation**
  - Updated `/menu` instructions to clarify stricter secret/file handling behavior and supported Google Workspace secret inputs.
- **Tests**
  - Added coverage for capped Telegram stream reading and the non-text secret handling flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->