### PR TITLE
fix(security): привязать сервер агента к loopback (--host 127.0.0.1)

### DIFF
--- a/bin/iva.mjs
+++ b/bin/iva.mjs
@@ -120,7 +120,14 @@ function ivaServiceBody() {
     // index.mjs prewarm не делает → первое же вложение падает SandboxTemplateNotProvisionedError
     // (шаблона нет в .eve/sandbox-cache). Ключ шаблона — контент-хеш, после iva update он меняется,
     // поэтому provision обязан идти на каждом старте, а не разово. eve start остаётся foreground.
-    `ExecStart=${NODE} ${ROOT}/node_modules/eve/bin/eve.js start`,
+    // --host: bind to loopback only. eve's auth strategy localDev() treats a request as local
+    // by the hostname of request.url — i.e. by the client's own Host header — so a server bound
+    // to 0.0.0.0 hands local-dev rights (and with them a sandbox-free `bash` on the host) to
+    // anyone who can reach the port and sends `Host: 127.0.0.1`. The port is only ever consumed
+    // locally: telegram-poll, the sweep and the memory scripts all talk to 127.0.0.1.
+    // Env is not enough here — `eve start` takes options.host ?? "0.0.0.0" and overwrites
+    // HOST/NITRO_HOST for the spawned .output/server/index.mjs, so the flag is what binds.
+    `ExecStart=${NODE} ${ROOT}/node_modules/eve/bin/eve.js start --host 127.0.0.1`,
     `Environment=PORT=${port}`,
     `Environment=PATH=${NODE_BIN_DIR}:%h/.local/bin:/usr/local/bin:/usr/bin:/bin`,
     "Environment=AGENT_BROWSER_MAX_OUTPUT=24000",

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -31,6 +31,8 @@ Note: `getUpdates` — which the setup wizard uses to discover your user ID — 
 
 `bin/iva.mjs` is the single source of truth for every unit. Any restart through the `iva` CLI regenerates them first, so `Environment=PORT` always matches `IVA_PORT` in `.env`. Don't hand-edit `~/.config/systemd/user/iva-*` — edits get overwritten. If you write your own unit instead, bake the port literally (`Environment=PORT=8723`): systemd will not expand `$IVA_PORT` from an `EnvironmentFile`.
 
+The unit starts eve with `--host 127.0.0.1`, and a hand-written one must do the same. eve's `localDev()` auth strategy decides a request is local from the hostname in `request.url` — that is, from the client's own `Host` header — so a server listening on `0.0.0.0` grants local-dev access, and with it a sandbox-free shell on your box, to anyone who reaches the port with `Host: 127.0.0.1`. Setting `HOST` in the environment does not help: `eve start` uses `options.host ?? "0.0.0.0"` and overwrites `HOST`/`NITRO_HOST` for the server process it spawns. Nothing outside the machine needs this port — the Telegram bridge, the sweep and the memory scripts all talk to `127.0.0.1`.
+
 | Unit | When | Job |
 |------|------|-----|
 | `iva.service` | always | the agent (`eve start`), `Restart=always` |


### PR DESCRIPTION
Фикс к #40.

`eve start` слушал 0.0.0.0, а стратегия `localDev()` считает запрос локальным по хосту из `request.url`, то есть по заголовку `Host`, который присылает клиент. Любой, кто дотягивается до порта, отправляет `Host: 127.0.0.1` и получает права local-dev, а с ними — `bash` на хосте без песочницы. Telegram-allowlist такой запрос вообще не видит: он проверяется внутри канала.

Привязываю юнит к loopback. Переменной окружения тут мало: `eve start` берёт `options.host ?? "0.0.0.0"` и сам перезаписывает `HOST`/`NITRO_HOST` дочернему `.output/server/index.mjs` — поэтому именно флаг `--host 127.0.0.1`. Плюс абзац в `docs/deploy.md` для тех, кто пишет юнит руками.

Проверено на боевой инсталляции (0.3.3, Ubuntu 24.04): `ss -tlnp` показывает `127.0.0.1:8723` вместо `0.0.0.0:8723`, снаружи с подделанным Host — таймаут вместо ответа, локально `curl 127.0.0.1:8723/` → 200. Мост `telegram-poll`, business-sweep и ночные memory-скрипты работают без изменений — они и так ходят на 127.0.0.1.

Воспроизведение и подробности — в #40.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Services now bind explicitly to the local machine, preventing unintended external access and sandbox-free local treatment through crafted host headers.

* **Documentation**
  * Added deployment guidance explaining the required loopback binding, local service access, and risks of binding to all network interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->