### PR TITLE
Telegram: model-specific reasoning buttons

### DIFF
--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -1,0 +1,8 @@
+# Implementation notes
+
+- Reimplemented the useful part of PR #34 on current `main`, while keeping its author credited in the new draft PR.
+- The Telegram wizard remains the only configuration UI. A selected Codex model carries its own live reasoning levels in the in-memory flow state.
+- `/models` is fetched once per screen load. No cross-process cache or generated reasoning-level file is introduced.
+- Network, empty and malformed Codex catalogs fall back to `low`, `medium`, `high`. Runtime validation accepts the stable protocol set through `max`; `ultra` stays unsupported.
+- Non-Codex providers skip the reasoning screen and clear the inactive global effort value when their model is saved.
+- Old callbacks are rejected by both Telegram message ID and wizard step, so an earlier screen cannot mutate a later screen in the same edited message.

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -6,3 +6,4 @@
 - Network, empty and malformed Codex catalogs fall back to `low`, `medium`, `high`. Runtime validation accepts the stable protocol set through `max`; `ultra` stays unsupported.
 - Non-Codex providers skip the reasoning screen and clear the inactive global effort value when their model is saved.
 - Old callbacks are rejected by both Telegram message ID and wizard step, so an earlier screen cannot mutate a later screen in the same edited message.
+- Every wizard-owned network result checks object identity on both success and error; a cancelled/replaced flow cannot resurrect itself with a late response.

--- a/scripts/lib/codex-model-catalog.test.mjs
+++ b/scripts/lib/codex-model-catalog.test.mjs
@@ -1,0 +1,59 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  listCodexModelCatalog,
+  parseCodexModelCatalog,
+} from "./codex-oauth.mjs";
+
+test("catalog parser supports model/slug/id/name and preserves quoted Unicode IDs", () => {
+  const parsed = parseCodexModelCatalog({
+    result: {
+      items: [
+        {
+          model: "gpt-5.5",
+          supported_reasoning_levels: ["minimal", { effort: "low" }, { level: "MAX" }, "ultra"],
+        },
+        { slug: 'gpt-"кавычка"', supported_reasoning_levels: [{ id: "medium" }] },
+        { id: "preset-id", supported_reasoning_levels: [{ name: "high" }] },
+        { name: "модель-имя", supported_reasoning_levels: [] },
+      ],
+    },
+    tiers: [{ id: "not-a-model" }],
+  });
+
+  const byId = Object.fromEntries(parsed.map((entry) => [entry.id, entry.reasoningLevels]));
+  assert.deepEqual(byId["gpt-5.5"], ["minimal", "low", "max"]);
+  assert.deepEqual(byId['gpt-"кавычка"'], ["medium"]);
+  assert.deepEqual(byId["preset-id"], ["high"]);
+  assert.deepEqual(byId["модель-имя"], ["low", "medium", "high"]);
+  assert.equal(byId["not-a-model"], undefined);
+});
+
+test("catalog parser handles strings, nested wrappers, empty and malformed input", () => {
+  assert.deepEqual(parseCodexModelCatalog(null), []);
+  assert.deepEqual(parseCodexModelCatalog({ models: [null, {}, "", "   ", { model: 42 }] }), []);
+  assert.deepEqual(parseCodexModelCatalog(["gpt-5", "модель"]), [
+    { id: "gpt-5", reasoningLevels: ["low", "medium", "high"] },
+    { id: "модель", reasoningLevels: ["low", "medium", "high"] },
+  ]);
+  assert.deepEqual(
+    parseCodexModelCatalog({ envelope: { data: [{ model: "gpt-6", supported_reasoning_levels: "bad" }] } }),
+    [{ id: "gpt-6", reasoningLevels: ["low", "medium", "high"] }],
+  );
+});
+
+test("model catalog and reasoning levels come from one HTTP request", async () => {
+  let requests = 0;
+  const result = await listCodexModelCatalog({
+    dataDir: "/unused",
+    authHeadersFn: async () => ({ Authorization: "Bearer test" }),
+    fetchFn: async () => {
+      requests += 1;
+      return new Response(JSON.stringify({
+        models: [{ model: "gpt-5.5", supported_reasoning_levels: ["low", "high"] }],
+      }), { status: 200 });
+    },
+  });
+  assert.equal(requests, 1);
+  assert.deepEqual(result, [{ id: "gpt-5.5", reasoningLevels: ["low", "high"] }]);
+});

--- a/scripts/lib/codex-oauth.d.mts
+++ b/scripts/lib/codex-oauth.d.mts
@@ -15,6 +15,11 @@ export interface LoginOptions {
   lang?: string;
 }
 
+export interface CodexModelCatalogEntry {
+  id: string;
+  reasoningLevels: string[];
+}
+
 export const ISSUER: string;
 export const CLIENT_ID: string;
 export const CODEX_BASE_URL: string;
@@ -31,3 +36,5 @@ export function runDeviceCodeLogin(opts?: LoginOptions): Promise<CodexAuth>;
 export function runBrowserLogin(opts?: LoginOptions): Promise<CodexAuth>;
 export function login(mode?: "device" | "browser", opts?: LoginOptions): Promise<CodexAuth>;
 export function listCodexModels(opts?: { dataDir?: string }): Promise<string[]>;
+export function parseCodexModelCatalog(json: unknown): CodexModelCatalogEntry[];
+export function listCodexModelCatalog(opts?: { dataDir?: string }): Promise<CodexModelCatalogEntry[]>;

--- a/scripts/lib/codex-oauth.d.mts
+++ b/scripts/lib/codex-oauth.d.mts
@@ -20,6 +20,12 @@ export interface CodexModelCatalogEntry {
   reasoningLevels: string[];
 }
 
+export interface CodexModelCatalogOptions {
+  dataDir?: string;
+  fetchFn?: typeof fetch;
+  authHeadersFn?: (dataDir?: string) => Promise<Record<string, string>>;
+}
+
 export const ISSUER: string;
 export const CLIENT_ID: string;
 export const CODEX_BASE_URL: string;
@@ -35,6 +41,6 @@ export function codexAuthHeaders(dataDir?: string): Promise<Record<string, strin
 export function runDeviceCodeLogin(opts?: LoginOptions): Promise<CodexAuth>;
 export function runBrowserLogin(opts?: LoginOptions): Promise<CodexAuth>;
 export function login(mode?: "device" | "browser", opts?: LoginOptions): Promise<CodexAuth>;
-export function listCodexModels(opts?: { dataDir?: string }): Promise<string[]>;
+export function listCodexModels(opts?: CodexModelCatalogOptions): Promise<string[]>;
 export function parseCodexModelCatalog(json: unknown): CodexModelCatalogEntry[];
-export function listCodexModelCatalog(opts?: { dataDir?: string }): Promise<CodexModelCatalogEntry[]>;
+export function listCodexModelCatalog(opts?: CodexModelCatalogOptions): Promise<CodexModelCatalogEntry[]>;

--- a/scripts/lib/codex-oauth.mjs
+++ b/scripts/lib/codex-oauth.mjs
@@ -13,6 +13,10 @@ import { chmodSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "n
 import { createServer } from "node:http";
 import { spawn } from "node:child_process";
 import { dirname, join } from "node:path";
+import {
+  CANONICAL_REASONING_EFFORTS,
+  FALLBACK_REASONING_EFFORTS,
+} from "./reasoning-levels.mjs";
 
 export const ISSUER = "https://auth.openai.com";
 export const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"; // публичный client_id Codex CLI
@@ -31,6 +35,7 @@ const FALLBACK_PORT = 1457;
 
 const b64url = (buf) => Buffer.from(buf).toString("base64url");
 const defaultDir = () => process.env.ASSISTANT_DATA_DIR || "data";
+const MODELS_FETCH_TIMEOUT_MS = 10_000;
 // Язык подсказок входа (en по умолчанию — как у codex CLI). Мастер/CLI прокидывают lang.
 const tr = (lang, en, ru) => (lang === "ru" ? ru : en);
 
@@ -305,37 +310,105 @@ export async function login(mode = "device", opts = {}) {
   return mode === "browser" ? runBrowserLogin(opts) : runDeviceCodeLogin(opts);
 }
 
-// ── список моделей подписки (для мастера) ──────────────────────────────────
-// Форма ответа (codex protocol): { models: [ { model: "gpt-5.1", id, display_name, ... } ] }.
-// Идентификатор для запроса — поле `model` (slug), НЕ `id` (id пресета). Берём его, с фолбэками.
-// Сортируем «новые сверху» (gpt-5.5 > gpt-5.1 > gpt-5). При 0 распознанных — бросаем ошибку
-// с сырым телом, чтобы мастер показал реальную форму ответа (а не молча свалился в ручной ввод).
-export async function listCodexModels({ dataDir = defaultDir() } = {}) {
-  const headers = await codexAuthHeaders(dataDir);
-  const res = await fetch(`${CODEX_BASE_URL}/models?client_version=${CLIENT_VERSION}`, { headers });
-  if (!res.ok) throw new Error(`list models failed: ${res.status} ${(await res.text()).slice(0, 300)}`);
-  const json = await res.json();
-  const arr = Array.isArray(json) ? json : json.models || json.data || json.model_presets || [];
-  let slugs = arr.map((m) => (typeof m === "string" ? m : m?.model || m?.slug || m?.id || m?.name)).filter(Boolean);
-  // Форма ответа могла измениться — рекурсивно ищем любой вложенный массив моделей.
-  if (!slugs.length) slugs = deepFindModels(json);
-  const uniq = [...new Set(slugs)];
-  if (!uniq.length) throw new Error(`models endpoint returned no usable models — raw: ${JSON.stringify(json).slice(0, 500)}`);
-  return uniq.sort(compareModelDesc);
+// ── модели подписки и их reasoning levels (один запрос /models) ────────────
+// Telegram строит оба экрана из одного ответа. setup.mjs использует тонкий
+// listCodexModels() ниже и не платит вторым запросом за тот же каталог.
+const MODEL_LIST_KEYS = /^(models?|model_presets|presets|items|data)$/i;
+const CANONICAL_REASONING_LEVELS = new Set(CANONICAL_REASONING_EFFORTS);
+
+function cleanString(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
-// Рекурсивно собирает slug'и из любого вложенного массива объектов с полем model/slug
-// (устойчиво к смене ключа-обёртки в ответе бэкенда).
-function deepFindModels(node, out = []) {
-  if (Array.isArray(node)) {
-    for (const it of node) {
-      if (it && typeof it === "object" && (it.model || it.slug)) out.push(it.model || it.slug);
-      else deepFindModels(it, out);
-    }
-  } else if (node && typeof node === "object") {
-    for (const k of Object.keys(node)) deepFindModels(node[k], out);
+function modelId(node, parentKey) {
+  if (!node || typeof node !== "object" || Array.isArray(node)) return null;
+  const primary = cleanString(node.model) || cleanString(node.slug);
+  if (primary) return primary;
+  // `id`/`name` are documented fallbacks, but only inside a model-list wrapper:
+  // arbitrary metadata such as tiers:[{id:"flex"}] must not become a model button.
+  if (MODEL_LIST_KEYS.test(parentKey || "")) return cleanString(node.id) || cleanString(node.name);
+  return null;
+}
+
+function reasoningLevels(node) {
+  if (!Array.isArray(node?.supported_reasoning_levels)) {
+    return { levels: [...FALLBACK_REASONING_EFFORTS], live: false };
   }
-  return out;
+  const levels = node.supported_reasoning_levels
+    .map((level) => {
+      if (typeof level === "string") return cleanString(level)?.toLowerCase() || null;
+      return cleanString(level?.effort)?.toLowerCase()
+        || cleanString(level?.level)?.toLowerCase()
+        || cleanString(level?.id)?.toLowerCase()
+        || cleanString(level?.name)?.toLowerCase()
+        || null;
+    })
+    .filter((level) => level && CANONICAL_REASONING_LEVELS.has(level));
+  const unique = [...new Set(levels)];
+  return unique.length
+    ? { levels: unique, live: true }
+    : { levels: [...FALLBACK_REASONING_EFFORTS], live: false };
+}
+
+// Pure parser kept separate from auth/network so malformed and future wrapper
+// shapes can be covered without credentials. Quotes and Unicode in IDs remain
+// untouched; buttons carry only their numeric index.
+export function parseCodexModelCatalog(json) {
+  const found = new Map();
+  function walk(node, parentKey = "") {
+    if (Array.isArray(node)) {
+      for (const item of node) {
+        const stringId = MODEL_LIST_KEYS.test(parentKey) ? cleanString(item) : null;
+        if (stringId && !found.has(stringId)) {
+          found.set(stringId, {
+            id: stringId,
+            reasoningLevels: [...FALLBACK_REASONING_EFFORTS],
+            live: false,
+          });
+        } else {
+          walk(item, parentKey);
+        }
+      }
+      return;
+    }
+    if (!node || typeof node !== "object") return;
+    const id = modelId(node, parentKey);
+    if (id) {
+      const { levels, live } = reasoningLevels(node);
+      const previous = found.get(id);
+      if (!previous || (!previous.live && live)) {
+        found.set(id, { id, reasoningLevels: levels, live });
+      }
+    }
+    for (const [key, value] of Object.entries(node)) {
+      if (key !== "supported_reasoning_levels") walk(value, key);
+    }
+  }
+  walk(json, Array.isArray(json) ? "models" : "");
+  return [...found.values()]
+    .map(({ id, reasoningLevels }) => ({ id, reasoningLevels }))
+    .sort((a, b) => compareModelDesc(a.id, b.id));
+}
+
+export async function listCodexModelCatalog({
+  dataDir = defaultDir(),
+  fetchFn = fetch,
+  authHeadersFn = codexAuthHeaders,
+} = {}) {
+  const headers = await authHeadersFn(dataDir);
+  const res = await fetchFn(`${CODEX_BASE_URL}/models?client_version=${CLIENT_VERSION}`, {
+    headers,
+    signal: AbortSignal.timeout(MODELS_FETCH_TIMEOUT_MS),
+  });
+  if (!res.ok) throw new Error(`list models failed: ${res.status} ${(await res.text()).slice(0, 300)}`);
+  const json = await res.json();
+  const catalog = parseCodexModelCatalog(json);
+  if (!catalog.length) throw new Error(`models endpoint returned no usable models — raw: ${JSON.stringify(json).slice(0, 500)}`);
+  return catalog;
+}
+
+export async function listCodexModels(opts = {}) {
+  return (await listCodexModelCatalog(opts)).map((entry) => entry.id);
 }
 
 // «Новые сверху»: сравниваем числовую версию в slug (gpt-5.1 → 5.1), при равенстве — по имени.
@@ -361,14 +434,14 @@ if (import.meta.url === `file://${process.argv[1]}`) {
   assert(accountFromIdToken(jwt).accountId === "acc_1", "accountId");
   assert(accountFromIdToken(jwt).planType === "pro", "planType");
   assert(accountFromIdToken("garbage").accountId === null, "bad id_token → null");
-  // Разбор списка моделей: slug из поля `model`, сортировка «новые сверху».
-  const models = [{ model: "gpt-5" }, { model: "gpt-5.1" }, { id: "preset-x", model: "gpt-5.1-codex" }];
-  const parsed = [...new Set(models.map((m) => m.model || m.slug || m.id || m.name).filter(Boolean))].sort(compareModelDesc);
-  assert(parsed[0].startsWith("gpt-5.1"), `newest first, got ${parsed[0]}`);
-  assert(parsed.includes("gpt-5"), "keeps gpt-5");
-  // deepFindModels: устойчивость к смене ключа-обёртки.
-  assert(deepFindModels({ result: { items: [{ model: "gpt-5.1" }, { slug: "gpt-6" }] } }).length === 2, "deepFindModels nested");
-  assert(deepFindModels({ tiers: [{ id: "flex" }] }).length === 0, "deepFind ignores non-model arrays");
+  // Разбор списка моделей: model/slug/id/name, сортировка и защита от metadata id.
+  const parsed = parseCodexModelCatalog({
+    result: { items: [{ model: "gpt-5" }, { slug: "gpt-5.1" }, { id: "preset-x" }, { name: "gpt-6" }] },
+    tiers: [{ id: "flex" }],
+  });
+  assert(parsed[0].id === "gpt-6", `newest first, got ${parsed[0]?.id}`);
+  assert(parsed.some((entry) => entry.id === "gpt-5"), "keeps gpt-5");
+  assert(!parsed.some((entry) => entry.id === "flex"), "ignores non-model metadata arrays");
   assert(tr("ru", "en", "ру") === "ру" && tr("en", "en", "ру") === "en", "tr lang");
   console.log("codex-oauth self-check ok");
 }

--- a/scripts/lib/model-catalog.d.mts
+++ b/scripts/lib/model-catalog.d.mts
@@ -16,8 +16,8 @@ export interface ModelOption {
   reasoningLevels: string[];
 }
 
-export const EFFORTS: string[];
-export const FALLBACK_EFFORTS: string[];
+export const EFFORTS: readonly string[];
+export const FALLBACK_EFFORTS: readonly string[];
 export const CATALOG: Record<string, ProviderCatalogEntry>;
 
 export function fetchModels(provider: string, key?: string, opts?: { dataDir?: string }): Promise<string[]>;

--- a/scripts/lib/model-catalog.d.mts
+++ b/scripts/lib/model-catalog.d.mts
@@ -11,8 +11,15 @@ export interface ProviderCatalogEntry {
   models: string[];
 }
 
+export interface ModelOption {
+  id: string;
+  reasoningLevels: string[];
+}
+
 export const EFFORTS: string[];
+export const FALLBACK_EFFORTS: string[];
 export const CATALOG: Record<string, ProviderCatalogEntry>;
 
 export function fetchModels(provider: string, key?: string, opts?: { dataDir?: string }): Promise<string[]>;
+export function fetchModelOptions(provider: string, key?: string, opts?: { dataDir?: string }): Promise<ModelOption[]>;
 export function checkKey(provider: string, key: string): Promise<string | null>;

--- a/scripts/lib/model-catalog.d.mts
+++ b/scripts/lib/model-catalog.d.mts
@@ -16,10 +16,16 @@ export interface ModelOption {
   reasoningLevels: string[];
 }
 
+export interface FetchModelOptions {
+  dataDir?: string;
+  listCodexCatalog?: (opts?: { dataDir?: string }) => Promise<ModelOption[]>;
+  fetchFn?: typeof fetch;
+}
+
 export const EFFORTS: readonly string[];
 export const FALLBACK_EFFORTS: readonly string[];
 export const CATALOG: Record<string, ProviderCatalogEntry>;
 
-export function fetchModels(provider: string, key?: string, opts?: { dataDir?: string }): Promise<string[]>;
-export function fetchModelOptions(provider: string, key?: string, opts?: { dataDir?: string }): Promise<ModelOption[]>;
+export function fetchModels(provider: string, key?: string, opts?: FetchModelOptions): Promise<string[]>;
+export function fetchModelOptions(provider: string, key?: string, opts?: FetchModelOptions): Promise<ModelOption[]>;
 export function checkKey(provider: string, key: string): Promise<string | null>;

--- a/scripts/lib/model-catalog.mjs
+++ b/scripts/lib/model-catalog.mjs
@@ -1,12 +1,17 @@
 // Provider/model/effort catalog for the /model and /think Telegram wizards.
-// Static lists are the offline fallback; fetchModels() prefers the provider's live
-// list (same endpoints as scripts/setup.mjs, which cannot be imported — it runs an
-// interactive readline at import). Edit the arrays below to curate what the wizard offers.
-import { listCodexModels } from "./codex-oauth.mjs";
+// Static model lists are the offline fallback. Codex returns model IDs and each
+// model's supported reasoning levels in the same /models response.
+import { listCodexModelCatalog } from "./codex-oauth.mjs";
+import {
+  CANONICAL_REASONING_EFFORTS,
+  FALLBACK_REASONING_EFFORTS,
+} from "./reasoning-levels.mjs";
 
-// Reasoning-effort levels. Shared with agent/provider.ts (THINKING_EFFORT validation),
-// applied natively on codex only.
-export const EFFORTS = ["minimal", "low", "medium", "high"];
+// Runtime accepts the stable protocol vocabulary. Telegram only offers the live
+// model-specific subset; when the response is missing/broken it uses the conservative
+// three-button fallback. `ultra` is intentionally absent from both lists.
+export const EFFORTS = CANONICAL_REASONING_EFFORTS;
+export const FALLBACK_EFFORTS = FALLBACK_REASONING_EFFORTS;
 
 // A hung provider endpoint must not stall the bridge's single getUpdates loop.
 const FETCH_TIMEOUT_MS = 10_000;
@@ -60,31 +65,51 @@ export const CATALOG = {
   },
 };
 
-// Live model list with static fallback. 401/403 → {auth:true} error (stored key is
-// dead — the wizard re-enters the key flow); any other failure (network, format
-// drift) → the static list above.
-export async function fetchModels(provider, key, { dataDir } = {}) {
+const optionsFor = (provider, models) =>
+  models.map((id) => ({
+    id,
+    reasoningLevels: provider === "codex" ? [...FALLBACK_EFFORTS] : [],
+  }));
+
+// Live model options with static fallback. Codex performs exactly one /models request
+// and keeps its model-specific reasoning levels on the in-memory wizard state.
+// 401/403 from key providers remains an actionable auth error; network/format failures
+// use static model buttons and low/medium/high for Codex.
+export async function fetchModelOptions(provider, key, {
+  dataDir,
+  listCodexCatalog = listCodexModelCatalog,
+  fetchFn = fetch,
+} = {}) {
   const cat = CATALOG[provider];
+  if (!cat) return [];
   try {
     if (provider === "codex") {
-      const live = await listCodexModels(dataDir ? { dataDir } : {});
-      return live.length ? live : cat.models;
+      const live = await listCodexCatalog(dataDir ? { dataDir } : {});
+      return live.length ? live : optionsFor(provider, cat.models);
     }
     if (cat.base && provider !== "openrouter") {
-      const res = await fetch(`${cat.base}/models`, {
+      const res = await fetchFn(`${cat.base}/models`, {
         headers: { Authorization: `Bearer ${key}` },
         signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
       });
       if (res.status === 401 || res.status === 403) throw Object.assign(new Error("key rejected"), { auth: true });
-      if (!res.ok) return cat.models;
-      const ids = ((await res.json()).data || []).map((m) => m.id).sort();
-      return ids.length ? ids : cat.models;
+      if (!res.ok) return optionsFor(provider, cat.models);
+      const ids = ((await res.json()).data || [])
+        .map((model) => typeof model?.id === "string" ? model.id.trim() : "")
+        .filter(Boolean)
+        .sort();
+      return ids.length ? optionsFor(provider, ids) : optionsFor(provider, cat.models);
     }
   } catch (e) {
     if (e.auth) throw e;
-    return cat.models;
+    return optionsFor(provider, cat.models);
   }
-  return cat.models; // openrouter and anything else: static curated list
+  return optionsFor(provider, cat.models); // openrouter and anything else: static curated list
+}
+
+// Compatibility for setup or future CLI consumers that only need IDs.
+export async function fetchModels(provider, key, opts = {}) {
+  return (await fetchModelOptions(provider, key, opts)).map((option) => option.id);
 }
 
 // Cheap key validity probe (same lenient policy as setup.mjs: network flake ⇒ accept).

--- a/scripts/lib/model-catalog.test.mjs
+++ b/scripts/lib/model-catalog.test.mjs
@@ -1,0 +1,23 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  CATALOG,
+  FALLBACK_EFFORTS,
+  fetchModelOptions,
+} from "./model-catalog.mjs";
+
+test("Codex network/malformed failure falls back to models with low/medium/high", async () => {
+  const options = await fetchModelOptions("codex", undefined, {
+    listCodexCatalog: async () => {
+      throw new Error("offline");
+    },
+  });
+  assert.deepEqual(options.map((option) => option.id), CATALOG.codex.models);
+  assert.ok(options.every((option) => JSON.stringify(option.reasoningLevels) === JSON.stringify(FALLBACK_EFFORTS)));
+});
+
+test("non-Codex models have no fake reasoning choices", async () => {
+  const options = await fetchModelOptions("openrouter", "unused");
+  assert.ok(options.length > 0);
+  assert.ok(options.every((option) => option.reasoningLevels.length === 0));
+});

--- a/scripts/lib/reasoning-levels.mjs
+++ b/scripts/lib/reasoning-levels.mjs
@@ -1,0 +1,17 @@
+// Stable reasoning vocabulary understood by the runtime protocol.
+// Telegram shows a model's live subset, with a conservative fallback when the
+// catalog is unavailable. `ultra` is intentionally unsupported.
+export const CANONICAL_REASONING_EFFORTS = Object.freeze([
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+]);
+
+export const FALLBACK_REASONING_EFFORTS = Object.freeze([
+  "low",
+  "medium",
+  "high",
+]);

--- a/scripts/lib/tg-flow.mjs
+++ b/scripts/lib/tg-flow.mjs
@@ -36,7 +36,8 @@ export function createFlows({ tg, log = () => {} }) {
   function start(chatId, userId, flow, extra = {}) {
     const st = {
       flow, chatId, userId, createdAt: Date.now(),
-      msgId: null, provider: null, models: null, model: null, effort: null,
+      msgId: null, provider: null, modelOptions: null, model: null, efforts: null, effort: null,
+      step: null,
       awaitText: null, // обобщение awaitKey (:388): { kind, secret, data }
       screen: null, page: 0, data: {},
       ...extra,

--- a/scripts/telegram-poll.mjs
+++ b/scripts/telegram-poll.mjs
@@ -16,7 +16,7 @@ import { fileURLToPath } from "node:url";
 import { randomBytes } from "node:crypto";
 import { readEntries, summarize, formatUsageReport, parseWindow } from "./lib/usage.mjs";
 import { readEnvFresh, readEnvValues, upsertEnv } from "./lib/env-file.mjs";
-import { CATALOG, EFFORTS, fetchModels, checkKey } from "./lib/model-catalog.mjs";
+import { CATALOG, EFFORTS, FALLBACK_EFFORTS, fetchModelOptions, checkKey } from "./lib/model-catalog.mjs";
 import { getAccessToken, runDeviceCodeLogin } from "./lib/codex-oauth.mjs";
 import { compactNumber, modelSummary } from "./lib/model-summary.mjs";
 import { acquireUpdateLock, releaseUpdateLock } from "./lib/update-safety.mjs";
@@ -495,6 +495,41 @@ const EFFORT_SET = new Set(EFFORTS);
 // effortLabel — функция (tr на месте вызова): язык не замораживается в module-level const.
 const effortLabel = (v) => (v && EFFORT_SET.has(v) ? v : tr("not set", "не задан"));
 
+export function isStaleWizard(st, messageId) {
+  return !st || (st.msgId != null && messageId != null && st.msgId !== messageId);
+}
+
+export function wizardActionAllowed(st, action) {
+  if (!st || action === "cancel") return Boolean(st);
+  if (action === "keep") return st.step === "intro" || st.step === "effort";
+  if (action === "chg") return st.step === "intro";
+  if (action.startsWith("prov:")) return st.step === "provider";
+  if (action.startsWith("m:")) return st.step === "models";
+  if (action.startsWith("eff:")) return st.step === "effort";
+  if (action.startsWith("rs:")) return st.step === "saved";
+  return false;
+}
+
+export function selectWizardModel(st, rawIndex) {
+  const index = Number(rawIndex);
+  if (!Number.isInteger(index) || index < 0) return null;
+  const option = st.modelOptions?.[index];
+  if (!option) return null;
+  st.model = option.id;
+  st.efforts = [...option.reasoningLevels];
+  return option;
+}
+
+export function selectWizardEffort(st, value) {
+  if (value === "unset") {
+    st.effort = null;
+    return true;
+  }
+  if (!EFFORT_SET.has(value) || !st.efforts?.includes(value)) return false;
+  st.effort = value;
+  return true;
+}
+
 async function currentConfig() {
   const env = await readEnvValues(ENV_PATH);
   const provider = CATALOG[env.MODEL_PROVIDER] ? env.MODEL_PROVIDER : "ollama";
@@ -502,7 +537,7 @@ async function currentConfig() {
   return {
     provider,
     model: env[cat.modelVar] || cat.def,
-    effort: (env.THINKING_EFFORT ?? "").toLowerCase(),
+    effort: provider === "codex" ? (env.THINKING_EFFORT ?? "").toLowerCase() : "",
   };
 }
 
@@ -524,11 +559,13 @@ const refuseSecretInGroup = (st) =>
     "Ключи — это секрет. Открой личный чат со мной и введи ключ там.",
   ), menuRow());
 
-function effortRows(ns, withKeep) {
-  return [
-    EFFORTS.map((e) => btn(e, `${ns}:eff:${e}`)),
-    [btn(tr("Don't set", "Не задавать"), `${ns}:eff:unset`), withKeep ? btn(tr("Keep", "Оставить"), `${ns}:keep`) : cancelRow()[0]],
-  ];
+function effortRows(ns, withKeep, efforts) {
+  const rows = [];
+  for (let i = 0; i < efforts.length; i += 3) {
+    rows.push(efforts.slice(i, i + 3).map((effort) => btn(effort, `${ns}:eff:${effort}`)));
+  }
+  rows.push([btn(tr("Don't set", "Не задавать"), `${ns}:eff:unset`), withKeep ? btn(tr("Keep", "Оставить"), `${ns}:keep`) : cancelRow()[0]]);
+  return rows;
 }
 
 // {msgId} (опц.) — хендофф из /menu: визард заменяет flow-слот и рисует в ТО ЖЕ сообщение меню.
@@ -536,6 +573,7 @@ async function handleModelCmd(chatId, from, { msgId } = {}) {
   const { provider, model, effort } = await currentConfig();
   const st = newWizard(chatId, from, "model");
   st.msgId = msgId ?? null;
+  st.step = "intro";
   await wizScreen(st, tr(
     `Now: provider ${provider} · model ${model} · thinking: ${effortLabel(effort)}.`,
     `Сейчас: провайдер ${provider} · модель ${model} · размышления: ${effortLabel(effort)}.`,
@@ -545,13 +583,36 @@ async function handleModelCmd(chatId, from, { msgId } = {}) {
 }
 
 async function handleThinkCmd(chatId, from, { msgId } = {}) {
-  const { effort } = await currentConfig();
+  const { provider, model, effort } = await currentConfig();
   const st = newWizard(chatId, from, "think");
   st.msgId = msgId ?? null;
-  await wizScreen(st, tr(`Thinking level: ${effortLabel(effort)}.`, `Уровень размышлений: ${effortLabel(effort)}.`), effortRows("iva_think", true));
+  if (provider !== "codex") {
+    await endWizard(st, tr(
+      `Thinking level is unavailable for ${CATALOG[provider].label}. Choose OpenAI subscription via /model first.`,
+      `Уровень размышлений недоступен для ${CATALOG[provider].label}. Сначала выбери подписку OpenAI через /model.`,
+    ), menuRow());
+    return;
+  }
+  st.step = "loading";
+  await wizScreen(st, tr(
+    `Loading thinking levels for ${model}…`,
+    `Загружаю уровни размышлений для ${model}…`,
+  ), [cancelRow()]);
+  const options = await fetchModelOptions("codex", undefined, { dataDir: DATA_DIR_ABS });
+  if (flows.get(st.chatId, st.userId) !== st) return;
+  const option = options.find((candidate) => candidate.id === model)
+    || { id: model, reasoningLevels: [...FALLBACK_EFFORTS] };
+  st.modelOptions = [option];
+  st.model = model;
+  st.efforts = [...option.reasoningLevels];
+  st.step = "effort";
+  await wizScreen(st,
+    tr(`Thinking level for ${model}: ${effortLabel(effort)}.`, `Уровень размышлений для ${model}: ${effortLabel(effort)}.`),
+    effortRows("iva_think", true, st.efforts));
 }
 
 async function showProviderScreen(st) {
+  st.step = "provider";
   const rows = Object.entries(CATALOG).map(([id, c]) => [btn(c.label, `iva_model:prov:${id}`)]);
   rows.push(cancelRow());
   await wizScreen(st, tr("Pick a provider:", "Выбери провайдера:"), rows);
@@ -561,6 +622,11 @@ async function pickProvider(st, provider) {
   st.provider = provider;
   const cat = CATALOG[provider];
   if (cat.auth === "oauth") {
+    st.step = "loading";
+    await wizScreen(st, tr(
+      "Checking the OpenAI subscription…",
+      "Проверяю подписку OpenAI…",
+    ), [cancelRow()]);
     // File presence is not enough — a revoked/expired refresh token would let the wizard
     // finish into a config that 401s every turn. getAccessToken refreshes a stale token
     // and throws when there is no usable auth → device-link login.
@@ -578,6 +644,7 @@ async function pickProvider(st, provider) {
     // awaitText обобщает старый awaitKey (см. handleControl): диспатчер по pending.awaitText
     // отдаёт следующий текст этому визарду (handleKeyMessage), а не eve.
     st.awaitText = { kind: "apikey", secret: true, data: {} };
+    st.step = "awaiting_key";
     await wizScreen(st,
       tr(
         `Need a ${cat.label} API key. Send it in the next message — I'll delete it from the chat right away.\n` +
@@ -594,15 +661,21 @@ async function pickProvider(st, provider) {
 async function showModelScreen(st) {
   const cat = CATALOG[st.provider];
   const env = await readEnvValues(ENV_PATH);
-  let models;
+  st.step = "loading";
+  await wizScreen(st, tr(
+    `Loading models for ${cat.label}…`,
+    `Загружаю модели ${cat.label}…`,
+  ), [cancelRow()]);
+  let options;
   try {
-    models = await fetchModels(st.provider, cat.keyVar ? env[cat.keyVar] : undefined, { dataDir: DATA_DIR_ABS });
+    options = await fetchModelOptions(st.provider, cat.keyVar ? env[cat.keyVar] : undefined, { dataDir: DATA_DIR_ABS });
   } catch {
-    // fetchModels only throws when the live /models probe rejected the stored key (401/403) —
+    // fetchModelOptions only throws when the live /models probe rejected the stored key (401/403) —
     // re-enter the key flow instead of offering a list the dead key can't use.
     // В группе новый ключ вводить нельзя (его не удалить) — отказ до установки awaitText.
     if (!isPrivateChat(st)) return refuseSecretInGroup(st);
     st.awaitText = { kind: "apikey", secret: true, data: {} };
+    st.step = "awaiting_key";
     await wizScreen(st,
       tr(
         `The saved ${cat.label} key was rejected. Send a new key in the next message — I'll delete it from the chat right away.`,
@@ -611,10 +684,19 @@ async function showModelScreen(st) {
       [cancelRow()]);
     return;
   }
+  if (flows.get(st.chatId, st.userId) !== st) return;
   // Keep the currently configured model selectable even when the live list is long.
   const current = env[cat.modelVar];
-  st.models = [...new Set([...(current ? [current] : []), ...models])].slice(0, 30);
-  const rows = st.models.map((m, i) => [btn(m, `iva_model:m:${i}`)]);
+  const currentOption = current
+    ? options.find((option) => option.id === current)
+      || { id: current, reasoningLevels: st.provider === "codex" ? [...FALLBACK_EFFORTS] : [] }
+    : null;
+  st.modelOptions = [
+    ...(currentOption ? [currentOption] : []),
+    ...options.filter((option) => option.id !== current),
+  ].slice(0, 30);
+  st.step = "models";
+  const rows = st.modelOptions.map((option, i) => [btn(option.id, `iva_model:m:${i}`)]);
   rows.push(cancelRow());
   await wizScreen(st, tr(`Model (${cat.label}):`, `Модель (${cat.label}):`), rows);
 }
@@ -623,6 +705,7 @@ async function showModelScreen(st) {
 // awaited, so the getUpdates loop keeps running; the continuation discards itself
 // when this state object is no longer the current wizard (cancelled/replaced).
 function startCodexLogin(st) {
+  st.step = "login";
   // Serialize device-code log lines (link, one-time code) into ordered chat messages.
   let q = Promise.resolve();
   const tlog = (m) => { q = q.then(() => reply(st.chatId, String(m).trim())); };
@@ -689,13 +772,8 @@ async function saveWizard(st) {
 async function showSaved(st) {
   const { provider, model, effort } = await currentConfig();
   let text = tr(`Saved: ${provider} · ${model} · thinking: ${effortLabel(effort)}.`, `Сохранил: ${provider} · ${model} · размышления: ${effortLabel(effort)}.`);
-  if (EFFORT_SET.has(effort) && provider !== "codex") {
-    text += tr(
-      "\nThe thinking level is saved in the profile, but natively applies only on codex.",
-      "\nУровень размышлений сохранён в профиле, но нативно применяется только на codex.",
-    );
-  }
   text += tr("\nRestart the agent to apply?", "\nПерезапустить агента, чтобы применить?");
+  st.step = "saved";
   await wizScreen(st, text, [[btn(tr("Restart now", "Перезапустить сейчас"), "iva_model:rs:now"), btn(tr("Later", "Позже"), "iva_model:rs:later")]]);
 }
 
@@ -710,10 +788,11 @@ async function handleWizardCallback(cq) {
   const action = cq.data.replace(/^iva_(model|think):/, "");
   const st = getWizard(chatId, from);
   // No state (bridge restarted / TTL) or a tap on an older wizard message → stale.
-  if (!st || (st.msgId && messageId && st.msgId !== messageId)) {
+  if (isStaleWizard(st, messageId)) {
     await tg("editMessageText", { chat_id: chatId, message_id: messageId, text: tr("This dialog has expired — send /model again.", "Диалог устарел — отправь /model заново.") });
     return true;
   }
+  if (!wizardActionAllowed(st, action)) return true;
   if (action === "keep") {
     await endWizard(st, st.flow === "think" ? tr("Kept the current thinking level.", "Оставил текущий уровень размышлений.") : tr("Kept the current configuration.", "Оставил текущую конфигурацию."), menuRow());
     return true;
@@ -732,15 +811,28 @@ async function handleWizardCallback(cq) {
     return true;
   }
   if (action.startsWith("m:")) {
-    const m = st.models?.[Number(action.slice("m:".length))];
-    if (!m) return true;
-    st.model = m;
-    await wizScreen(st, tr("Thinking level:", "Уровень размышлений:"), effortRows("iva_model", false));
+    const option = selectWizardModel(st, action.slice("m:".length));
+    if (!option) return true;
+    if (st.provider !== "codex") {
+      st.effort = null;
+      try {
+        await saveWizard(st);
+      } catch (e) {
+        await endWizard(st, tr("Couldn't save .env: " + e.message, "Не удалось сохранить .env: " + e.message), menuRow());
+        return true;
+      }
+      await showSaved(st);
+      return true;
+    }
+    st.step = "effort";
+    await wizScreen(st,
+      tr(`Thinking level for ${option.id}:`, `Уровень размышлений для ${option.id}:`),
+      effortRows("iva_model", false, st.efforts));
     return true;
   }
   if (action.startsWith("eff:")) {
     const v = action.slice("eff:".length);
-    st.effort = EFFORT_SET.has(v) ? v : null; // "unset" and anything unknown ⇒ drop
+    if (!selectWizardEffort(st, v)) return true;
     try {
       await saveWizard(st);
     } catch (e) {

--- a/scripts/telegram-poll.mjs
+++ b/scripts/telegram-poll.mjs
@@ -490,6 +490,19 @@ const getWizard = (chatId, userId) => flows.get(chatId, userId);
 const newWizard = (chatId, userId, flow, extra) => flows.start(chatId, userId, flow, extra);
 const wizScreen = (st, text, rows) => flows.screen(st, text, rows);
 const endWizard = (st, text, rows) => flows.end(st, text, rows);
+const wizardIsCurrent = (st) => flows.get(st.chatId, st.userId) === st;
+
+// A network result belongs to the wizard object that started it. The slot can be
+// replaced while the request is pending (Cancel, /menu, another /model), so both
+// success and error must be discarded before either path mutates or renders state.
+export async function runWizardRequest(st, request, isCurrent = wizardIsCurrent) {
+  try {
+    const value = await request();
+    return isCurrent(st) ? { ok: true, value } : { stale: true };
+  } catch (error) {
+    return isCurrent(st) ? { ok: false, error } : { stale: true };
+  }
+}
 
 const EFFORT_SET = new Set(EFFORTS);
 // effortLabel — функция (tr на месте вызова): язык не замораживается в module-level const.
@@ -598,8 +611,17 @@ async function handleThinkCmd(chatId, from, { msgId } = {}) {
     `Loading thinking levels for ${model}…`,
     `Загружаю уровни размышлений для ${model}…`,
   ), [cancelRow()]);
-  const options = await fetchModelOptions("codex", undefined, { dataDir: DATA_DIR_ABS });
-  if (flows.get(st.chatId, st.userId) !== st) return;
+  if (!wizardIsCurrent(st)) return;
+  const loaded = await runWizardRequest(
+    st,
+    () => fetchModelOptions("codex", undefined, { dataDir: DATA_DIR_ABS }),
+  );
+  if (loaded.stale) return;
+  if (!loaded.ok) return endWizard(st, tr(
+    "Couldn't load thinking levels. Send /think to try again.",
+    "Не удалось загрузить уровни размышлений. Отправь /think, чтобы попробовать снова.",
+  ), menuRow());
+  const options = loaded.value;
   const option = options.find((candidate) => candidate.id === model)
     || { id: model, reasoningLevels: [...FALLBACK_EFFORTS] };
   st.modelOptions = [option];
@@ -627,17 +649,17 @@ async function pickProvider(st, provider) {
       "Checking the OpenAI subscription…",
       "Проверяю подписку OpenAI…",
     ), [cancelRow()]);
+    if (!wizardIsCurrent(st)) return;
     // File presence is not enough — a revoked/expired refresh token would let the wizard
     // finish into a config that 401s every turn. getAccessToken refreshes a stale token
     // and throws when there is no usable auth → device-link login.
-    try {
-      await getAccessToken(DATA_DIR_ABS);
-    } catch {
-      return startCodexLogin(st);
-    }
+    const auth = await runWizardRequest(st, () => getAccessToken(DATA_DIR_ABS));
+    if (auth.stale) return;
+    if (!auth.ok) return startCodexLogin(st);
     return showModelScreen(st);
   }
   const env = await readEnvValues(ENV_PATH);
+  if (!wizardIsCurrent(st)) return;
   if (!env[cat.keyVar]) {
     // В группе ключ вводить нельзя (его не удалить) — отказ до установки awaitText.
     if (!isPrivateChat(st)) return refuseSecretInGroup(st);
@@ -661,15 +683,19 @@ async function pickProvider(st, provider) {
 async function showModelScreen(st) {
   const cat = CATALOG[st.provider];
   const env = await readEnvValues(ENV_PATH);
+  if (!wizardIsCurrent(st)) return;
   st.step = "loading";
   await wizScreen(st, tr(
     `Loading models for ${cat.label}…`,
     `Загружаю модели ${cat.label}…`,
   ), [cancelRow()]);
-  let options;
-  try {
-    options = await fetchModelOptions(st.provider, cat.keyVar ? env[cat.keyVar] : undefined, { dataDir: DATA_DIR_ABS });
-  } catch {
+  if (!wizardIsCurrent(st)) return;
+  const loaded = await runWizardRequest(
+    st,
+    () => fetchModelOptions(st.provider, cat.keyVar ? env[cat.keyVar] : undefined, { dataDir: DATA_DIR_ABS }),
+  );
+  if (loaded.stale) return;
+  if (!loaded.ok) {
     // fetchModelOptions only throws when the live /models probe rejected the stored key (401/403) —
     // re-enter the key flow instead of offering a list the dead key can't use.
     // В группе новый ключ вводить нельзя (его не удалить) — отказ до установки awaitText.
@@ -684,7 +710,7 @@ async function showModelScreen(st) {
       [cancelRow()]);
     return;
   }
-  if (flows.get(st.chatId, st.userId) !== st) return;
+  const options = loaded.value;
   // Keep the currently configured model selectable even when the live list is long.
   const current = env[cat.modelVar];
   const currentOption = current
@@ -734,7 +760,11 @@ function startCodexLogin(st) {
 async function handleKeyMessage(msg, st) {
   const chatId = msg.chat.id;
   const del = await tg("deleteMessage", { chat_id: chatId, message_id: msg.message_id });
-  if (!del.ok) await reply(chatId, tr("Couldn't delete the message with the key — delete it manually.", "Не смог удалить сообщение с ключом — удали его вручную."));
+  if (!wizardIsCurrent(st)) return true;
+  if (!del.ok) {
+    await reply(chatId, tr("Couldn't delete the message with the key — delete it manually.", "Не смог удалить сообщение с ключом — удали его вручную."));
+    if (!wizardIsCurrent(st)) return true;
+  }
   const key = msg.text.trim();
   // Not key-shaped (whitespace / too short) — most likely an ordinary message typed
   // while the prompt was pending. Don't store it; end the wait so the chat works again.
@@ -749,13 +779,23 @@ async function handleKeyMessage(msg, st) {
     return true;
   }
   const cat = CATALOG[st.provider];
-  const err = await checkKey(st.provider, key);
+  const checked = await runWizardRequest(st, () => checkKey(st.provider, key));
+  if (checked.stale) return true;
+  if (!checked.ok) {
+    await endWizard(st, tr(
+      "Couldn't validate the key. Start again with /model.",
+      "Не удалось проверить ключ. Начни заново через /model.",
+    ), menuRow());
+    return true;
+  }
+  const err = checked.value;
   if (err) {
     await wizScreen(st, tr(`Key rejected (${err}). Send another key or tap «Cancel».`, `Ключ не принят (${err}). Пришли другой ключ или нажми «Отмена».`), [cancelRow()]);
     return true;
   }
   st.awaitText = null;
   await upsertEnv(ENV_PATH, { [cat.keyVar]: key }); // persist immediately — the chat copy is gone
+  if (!wizardIsCurrent(st)) return true;
   await showModelScreen(st);
   return true;
 }
@@ -771,6 +811,7 @@ async function saveWizard(st) {
 
 async function showSaved(st) {
   const { provider, model, effort } = await currentConfig();
+  if (!wizardIsCurrent(st)) return;
   let text = tr(`Saved: ${provider} · ${model} · thinking: ${effortLabel(effort)}.`, `Сохранил: ${provider} · ${model} · размышления: ${effortLabel(effort)}.`);
   text += tr("\nRestart the agent to apply?", "\nПерезапустить агента, чтобы применить?");
   st.step = "saved";
@@ -818,9 +859,11 @@ async function handleWizardCallback(cq) {
       try {
         await saveWizard(st);
       } catch (e) {
+        if (!wizardIsCurrent(st)) return true;
         await endWizard(st, tr("Couldn't save .env: " + e.message, "Не удалось сохранить .env: " + e.message), menuRow());
         return true;
       }
+      if (!wizardIsCurrent(st)) return true;
       await showSaved(st);
       return true;
     }
@@ -836,9 +879,11 @@ async function handleWizardCallback(cq) {
     try {
       await saveWizard(st);
     } catch (e) {
+      if (!wizardIsCurrent(st)) return true;
       await endWizard(st, tr("Couldn't save .env: " + e.message, "Не удалось сохранить .env: " + e.message), menuRow());
       return true;
     }
+    if (!wizardIsCurrent(st)) return true;
     await showSaved(st);
     return true;
   }

--- a/scripts/telegram-poll.test.mjs
+++ b/scripts/telegram-poll.test.mjs
@@ -11,6 +11,7 @@ const {
   wizardActionAllowed,
   selectWizardModel,
   selectWizardEffort,
+  runWizardRequest,
 } = await import("./telegram-poll.mjs");
 
 const enc = new TextEncoder();
@@ -116,4 +117,19 @@ test("model switch carries that model's levels; unknown effort never clears stat
   assert.equal(st.effort, "max");
   assert.equal(selectWizardEffort(st, "unset"), true);
   assert.equal(st.effort, null);
+});
+
+test("Cancel during a rejected model fetch discards the stale error path", async () => {
+  const st = { chatId: 1, userId: "2" };
+  let active = st;
+  let rejectFetch;
+  const pending = runWizardRequest(
+    st,
+    () => new Promise((_resolve, reject) => { rejectFetch = reject; }),
+    (candidate) => active === candidate,
+  );
+
+  active = null; // Cancel removed this object from the flow slot while fetch was pending.
+  rejectFetch(Object.assign(new Error("key rejected"), { auth: true }));
+  assert.deepEqual(await pending, { stale: true });
 });

--- a/scripts/telegram-poll.test.mjs
+++ b/scripts/telegram-poll.test.mjs
@@ -4,7 +4,14 @@ import assert from "node:assert/strict";
 // telegram-poll.mjs reads env at import and guards its poll loop behind a direct-execution check,
 // so importing it here is side-effect-free. A dummy token keeps the API base a harmless string.
 process.env.TELEGRAM_BOT_TOKEN ??= "test:token";
-const { readCappedStream, handleAwaitNonText } = await import("./telegram-poll.mjs");
+const {
+  readCappedStream,
+  handleAwaitNonText,
+  isStaleWizard,
+  wizardActionAllowed,
+  selectWizardModel,
+  selectWizardEffort,
+} = await import("./telegram-poll.mjs");
 
 const enc = new TextEncoder();
 function streamOf(...parts) {
@@ -78,4 +85,35 @@ test("secret prompt + non-file attachment (photo) → deleted with an ack, not d
   const consumed = await handleAwaitNonText(msg, pending, r.io);
   assert.equal(consumed, true);
   assert.deepEqual(r.names(), ["delete", "reply"]); // deleted + told how to send; never reaches eve
+});
+
+test("stale wizard callbacks are rejected by message and screen step", () => {
+  const st = { msgId: 42, step: "models" };
+  assert.equal(isStaleWizard(st, 41), true);
+  assert.equal(isStaleWizard(st, 42), false);
+  assert.equal(isStaleWizard(null, 42), true);
+  assert.equal(wizardActionAllowed(st, "m:0"), true);
+  assert.equal(wizardActionAllowed(st, "eff:high"), false);
+  assert.equal(wizardActionAllowed(st, "unknown"), false);
+});
+
+test("model switch carries that model's levels; unknown effort never clears state", () => {
+  const st = {
+    model: "old",
+    effort: "low",
+    efforts: ["low"],
+    modelOptions: [
+      { id: "gpt-a", reasoningLevels: ["low", "medium"] },
+      { id: "gpt-b", reasoningLevels: ["high", "max"] },
+    ],
+  };
+  assert.deepEqual(selectWizardModel(st, "1"), st.modelOptions[1]);
+  assert.equal(st.model, "gpt-b");
+  assert.deepEqual(st.efforts, ["high", "max"]);
+  assert.equal(selectWizardEffort(st, "bogus"), false);
+  assert.equal(st.effort, "low");
+  assert.equal(selectWizardEffort(st, "max"), true);
+  assert.equal(st.effort, "max");
+  assert.equal(selectWizardEffort(st, "unset"), true);
+  assert.equal(st.effort, null);
 });


### PR DESCRIPTION
## What changed

- keep model and reasoning configuration in the existing Telegram button wizard
- fetch Codex models and each model's `supported_reasoning_levels` in one `/models` request
- show a loading screen before network work, then offer only the selected model's levels
- keep catalog data only in the current in-memory wizard state
- fall back to `low`, `medium`, `high` for offline, empty, or malformed catalog responses
- skip the reasoning screen for non-Codex providers and reject stale/unknown callbacks
- validate runtime values against the stable `minimal`/`low`/`medium`/`high`/`xhigh`/`max` protocol set; `ultra` remains unsupported

## Why

PR #34 correctly identified that the Telegram UI should follow the live Codex model catalog. This version incorporates that UX direction while removing the cross-process cache and keeping model selection and reasoning selection in one simple flow.

Incorporates the idea from #34. Credit and thanks to @AndyShaman for finding the gap and supplying the upstream response shape.

## User impact

`/model` now goes from provider to model to that model's reasoning buttons. `/think` reloads the live levels for the currently selected Codex model. Users see an immediate loading status during the request, while bad network or response data still leaves a small usable fallback.

## Validation

- `node --test scripts/lib/*.test.mjs scripts/lib/menu/*.test.mjs scripts/*.test.mjs` - 190 passed
- `npm run typecheck`
- `npx eve build`

Tests cover `model`/`slug`/`id`/`name`, quotes and Unicode, empty/malformed responses, one-request catalog loading, offline fallback, stale callbacks, unknown efforts, and model switching.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model selection now loads provider-specific options, including dynamically supported Codex reasoning levels.
  * Added Codex model catalog discovery with fallback options for unavailable or malformed responses.
  * The configuration wizard now skips reasoning selection for non-Codex providers and clears inactive reasoning settings.
  * Improved wizard handling prevents outdated requests or interactions from changing newer configuration steps.

* **Bug Fixes**
  * Rejected API keys now return users to key entry.
  * Unsupported or invalid reasoning choices are safely ignored.

* **Tests**
  * Added coverage for model catalogs, fallback behavior, reasoning selection, and wizard state validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->