### PR TITLE
Fix reasoning controls for Ollama Cloud and OpenCode Go

### DIFF
--- a/agent/agent.ts
+++ b/agent/agent.ts
@@ -2,7 +2,13 @@ import { defineAgent } from "eve";
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 // Провайдер и его модели — единый источник в provider.ts (тот же конфиг у agent/vision.ts).
 // codex = подписка ChatGPT (Responses API + OAuth); ollama/opencode = OpenAI-совместимый chat.
-import { providerConfig as cfg, providerName, withReasoningStripped, makeCodexModel } from "./provider.js";
+import {
+  compatibleThinkingEffort,
+  providerConfig as cfg,
+  providerName,
+  withReasoningStripped,
+  makeCodexModel,
+} from "./provider.js";
 
 // Codex-подписка говорит на Responses API — отдельная модель-фабрика (@ai-sdk/openai).
 // Остальные провайдеры — OpenAI-совместимый chat/completions через openai-compatible.
@@ -21,6 +27,9 @@ const textModel =
 
 export default defineAgent({
   model: withReasoningStripped(textModel),
+  // eve maps this provider-agnostic setting to reasoning_effort for the
+  // OpenAI-compatible Ollama Cloud and OpenCode Go endpoints.
+  reasoning: compatibleThinkingEffort,
   // Кастомный провайдер не отдаёт метаданные окна через AI Gateway — задаём вручную.
   // ВАЖНО: значение ОБЯЗАНО быть ≤ реального окна модели, иначе запрос переполнит окно до компактации.
   modelContextWindowTokens: cfg.contextWindow,

--- a/agent/provider.ts
+++ b/agent/provider.ts
@@ -54,12 +54,19 @@ export const providerName = PROVIDER;
 export const providerConfig = PROVIDERS[PROVIDER as keyof typeof PROVIDERS] ?? PROVIDERS.ollama;
 
 // THINKING_EFFORT (.env, пишут /model и /think в Telegram): reasoning-усилие модели.
-// Нативно применяется только на codex (providerOptions.openai.reasoningEffort → reasoning.effort
-// в теле /responses, см. codexProviderOptions). Для остальных провайдеров — сохранённый профиль
-// без рантайм-эффекта. Уровни — из общего каталога мастера (model-catalog.mjs), чтобы список
-// кнопок и валидация не разъезжались. Невалидное/пустое значение молча игнорируем («не задан»).
+// Codex получает его через providerOptions.openai.reasoningEffort ниже. Ollama Cloud
+// и OpenCode Go говорят на OpenAI-compatible chat/completions; eve передаёт им
+// provider-agnostic reasoning как reasoning_effort (см. compatibleThinkingEffort).
+// Уровни — из общего каталога мастера, чтобы кнопки и рантайм не разъезжались.
 const effortRaw = (process.env.THINKING_EFFORT ?? "").toLowerCase();
 export const thinkingEffort = EFFORTS.includes(effortRaw) ? effortRaw : undefined;
+const COMPATIBLE_EFFORTS = ["low", "medium", "high"] as const;
+type CompatibleEffort = (typeof COMPATIBLE_EFFORTS)[number];
+export const compatibleThinkingEffort: CompatibleEffort | undefined =
+  (PROVIDER === "ollama" || PROVIDER === "opencode")
+  && (COMPATIBLE_EFFORTS as readonly string[]).includes(effortRaw)
+    ? effortRaw as CompatibleEffort
+    : undefined;
 
 // --- Codex (подписка ChatGPT): Responses API через @ai-sdk/openai ----------------------------
 // Кастомный fetch: перед КАЖДЫМ запросом подставляет свежий Bearer + ChatGPT-Account-ID

--- a/docs/menu.md
+++ b/docs/menu.md
@@ -89,7 +89,7 @@ Three read-only screens.
 
 - **⏰ Timers** — the `iva-*` (and `xfeed-daily`) systemd timers with their next run, plus the open-task count from `data/tasks.json`.
 - **🧩 Skills** — every installed skill with a one-line description, paged.
-- **📊 Status** — one card: version, provider · model · thinking, search provider and key badge, language, userbot state, Google, and today's token usage (the same figure as `/usage`). **🔄 Refresh** re-reads everything.
+- **📊 Status** — one card: version, provider · model · thinking, search provider and key badge, language, userbot state, Google, and today's token usage (the same figure as `/usage`). **🔄 Refresh** re-reads everything. Thinking levels are selectable for OpenAI subscriptions and for the OpenAI-compatible Ollama Cloud and OpenCode Go APIs; the latter expose the common `low` / `medium` / `high` contract.
 
 ## Maintenance
 

--- a/scripts/lib/model-catalog.d.mts
+++ b/scripts/lib/model-catalog.d.mts
@@ -26,6 +26,8 @@ export const EFFORTS: readonly string[];
 export const FALLBACK_EFFORTS: readonly string[];
 export const CATALOG: Record<string, ProviderCatalogEntry>;
 
+export function providerSupportsReasoning(provider: string): boolean;
+export function providerFallbackReasoningLevels(provider: string): string[];
 export function fetchModels(provider: string, key?: string, opts?: FetchModelOptions): Promise<string[]>;
 export function fetchModelOptions(provider: string, key?: string, opts?: FetchModelOptions): Promise<ModelOption[]>;
 export function checkKey(provider: string, key: string): Promise<string | null>;

--- a/scripts/lib/model-catalog.mjs
+++ b/scripts/lib/model-catalog.mjs
@@ -65,16 +65,26 @@ export const CATALOG = {
   },
 };
 
+// Ollama Cloud and OpenCode Go both expose OpenAI-compatible reasoning_effort.
+// Their /models payloads contain IDs only, so the API's common low/medium/high
+// contract is the best available capability signal. Codex is richer: its live
+// catalog carries a model-specific subset.
+const REASONING_PROVIDERS = new Set(["ollama", "opencode", "codex"]);
+
+export const providerSupportsReasoning = (provider) => REASONING_PROVIDERS.has(provider);
+export const providerFallbackReasoningLevels = (provider) =>
+  providerSupportsReasoning(provider) ? [...FALLBACK_EFFORTS] : [];
+
 const optionsFor = (provider, models) =>
   models.map((id) => ({
     id,
-    reasoningLevels: provider === "codex" ? [...FALLBACK_EFFORTS] : [],
+    reasoningLevels: providerFallbackReasoningLevels(provider),
   }));
 
 // Live model options with static fallback. Codex performs exactly one /models request
 // and keeps its model-specific reasoning levels on the in-memory wizard state.
 // 401/403 from key providers remains an actionable auth error; network/format failures
-// use static model buttons and low/medium/high for Codex.
+// use static model buttons and the provider's conservative reasoning fallback.
 export async function fetchModelOptions(provider, key, {
   dataDir,
   listCodexCatalog = listCodexModelCatalog,

--- a/scripts/lib/model-catalog.test.mjs
+++ b/scripts/lib/model-catalog.test.mjs
@@ -16,7 +16,21 @@ test("Codex network/malformed failure falls back to models with low/medium/high"
   assert.ok(options.every((option) => JSON.stringify(option.reasoningLevels) === JSON.stringify(FALLBACK_EFFORTS)));
 });
 
-test("non-Codex models have no fake reasoning choices", async () => {
+test("Ollama Cloud and OpenCode Go expose their OpenAI-compatible reasoning contract", async () => {
+  for (const provider of ["ollama", "opencode"]) {
+    const options = await fetchModelOptions(provider, "test", {
+      fetchFn: async () => new Response(JSON.stringify({
+        data: [{ id: "reasoning-model" }],
+      }), { status: 200 }),
+    });
+    assert.deepEqual(options, [{
+      id: "reasoning-model",
+      reasoningLevels: [...FALLBACK_EFFORTS],
+    }]);
+  }
+});
+
+test("heterogeneous OpenRouter catalog does not invent reasoning choices", async () => {
   const options = await fetchModelOptions("openrouter", "unused");
   assert.ok(options.length > 0);
   assert.ok(options.every((option) => option.reasoningLevels.length === 0));

--- a/scripts/telegram-poll.mjs
+++ b/scripts/telegram-poll.mjs
@@ -16,7 +16,14 @@ import { fileURLToPath } from "node:url";
 import { randomBytes } from "node:crypto";
 import { readEntries, summarize, formatUsageReport, parseWindow } from "./lib/usage.mjs";
 import { readEnvFresh, readEnvValues, upsertEnv } from "./lib/env-file.mjs";
-import { CATALOG, EFFORTS, FALLBACK_EFFORTS, fetchModelOptions, checkKey } from "./lib/model-catalog.mjs";
+import {
+  CATALOG,
+  EFFORTS,
+  fetchModelOptions,
+  checkKey,
+  providerFallbackReasoningLevels,
+  providerSupportsReasoning,
+} from "./lib/model-catalog.mjs";
 import { getAccessToken, runDeviceCodeLogin } from "./lib/codex-oauth.mjs";
 import { compactNumber, modelSummary } from "./lib/model-summary.mjs";
 import { acquireUpdateLock, releaseUpdateLock } from "./lib/update-safety.mjs";
@@ -592,7 +599,7 @@ async function currentConfig() {
   return {
     provider,
     model: env[cat.modelVar] || cat.def,
-    effort: provider === "codex" ? (env.THINKING_EFFORT ?? "").toLowerCase() : "",
+    effort: providerSupportsReasoning(provider) ? (env.THINKING_EFFORT ?? "").toLowerCase() : "",
   };
 }
 
@@ -641,13 +648,15 @@ async function handleThinkCmd(chatId, from, { msgId } = {}) {
   const { provider, model, effort } = await currentConfig();
   const st = newWizard(chatId, from, "think");
   st.msgId = msgId ?? null;
-  if (provider !== "codex") {
+  if (!providerSupportsReasoning(provider)) {
     await endWizard(st, tr(
-      `Thinking level is unavailable for ${CATALOG[provider].label}. Choose OpenAI subscription via /model first.`,
-      `Уровень размышлений недоступен для ${CATALOG[provider].label}. Сначала выбери подписку OpenAI через /model.`,
+      `Adjustable thinking is unavailable for ${CATALOG[provider].label}. Choose a reasoning-capable provider via /model.`,
+      `Настраиваемые размышления недоступны для ${CATALOG[provider].label}. Выбери провайдера с reasoning через /model.`,
     ), menuRow());
     return;
   }
+  const cat = CATALOG[provider];
+  const env = await readEnvValues(ENV_PATH);
   st.step = "loading";
   await wizScreen(st, tr(
     `Loading thinking levels for ${model}…`,
@@ -656,7 +665,7 @@ async function handleThinkCmd(chatId, from, { msgId } = {}) {
   if (!wizardIsCurrent(st)) return;
   const loaded = await runWizardRequest(
     st,
-    () => fetchModelOptions("codex", undefined, { dataDir: DATA_DIR_ABS }),
+    () => fetchModelOptions(provider, cat.keyVar ? env[cat.keyVar] : undefined, { dataDir: DATA_DIR_ABS }),
   );
   if (loaded.stale) return;
   if (!loaded.ok) return endWizard(st, tr(
@@ -665,7 +674,7 @@ async function handleThinkCmd(chatId, from, { msgId } = {}) {
   ), menuRow());
   const options = loaded.value;
   const option = options.find((candidate) => candidate.id === model)
-    || { id: model, reasoningLevels: [...FALLBACK_EFFORTS] };
+    || { id: model, reasoningLevels: providerFallbackReasoningLevels(provider) };
   st.modelOptions = [option];
   st.model = model;
   st.efforts = [...option.reasoningLevels];
@@ -757,7 +766,7 @@ async function showModelScreen(st) {
   const current = env[cat.modelVar];
   const currentOption = current
     ? options.find((option) => option.id === current)
-      || { id: current, reasoningLevels: st.provider === "codex" ? [...FALLBACK_EFFORTS] : [] }
+      || { id: current, reasoningLevels: providerFallbackReasoningLevels(st.provider) }
     : null;
   st.modelOptions = [
     ...(currentOption ? [currentOption] : []),
@@ -896,7 +905,7 @@ async function handleWizardCallback(cq) {
   if (action.startsWith("m:")) {
     const option = selectWizardModel(st, action.slice("m:".length));
     if (!option) return true;
-    if (st.provider !== "codex") {
+    if (option.reasoningLevels.length === 0) {
       st.effort = null;
       try {
         await saveWizard(st);


### PR DESCRIPTION
## What changed

- expose `low`, `medium`, and `high` thinking controls for Ollama Cloud and OpenCode Go in the existing Telegram button flow
- apply the selected value through Eve's provider-agnostic `reasoning` setting, which the OpenAI-compatible SDK sends as `reasoning_effort`
- keep OpenRouter unchanged because its curated catalog is heterogeneous
- document the provider behavior

## Root cause

The menu and runtime both hard-coded reasoning support to the `codex` provider. This made `THINKING_EFFORT` decorative for Ollama Cloud and OpenCode Go even though both APIs accept and execute `reasoning_effort`.

## Evidence

Live authenticated probes accepted `none`, `low`, `medium`, and `high` on Ollama Cloud `deepseek-v4-pro` and OpenCode Go `kimi-k3`; the latter three returned reasoning content. Ollama's official OpenAI-compatibility docs also list `reasoning_effort` for chat completions.

## Validation

- 225/225 Node tests
- `npm run typecheck`
- `npx eve build`
- `MODEL_PROVIDER=ollama THINKING_EFFORT=high npx eve info --json` reports `reasoning: "high"`
- `git diff --check`