### PR TITLE
Add Kimi K3, fix dead vision models on Ollama and OpenCode Go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- 🖼️ **Photo descriptions were dead on both cheap providers** — vision runs on a hardcoded model per provider, and both had been retired out from under it: Ollama Cloud answered `410 gemma3:12b was retired at 2026-07-15`, OpenCode Go answered `401 Model gemini-3-flash is not supported`. Every photo silently landed in the vault with no description. Vision now uses `gemma4:31b` (Ollama) and `qwen3.7-plus` (Go), both re-verified against the live endpoints.
+- 🤖 **Kimi K3 in the model lists** — the new 1M-context Moonshot model is offered by `/model` and `iva config` on all three key-based providers: `kimi-k3` on OpenCode Go and Ollama Cloud, `moonshotai/kimi-k3` on OpenRouter (replacing the older `kimi-k2`). The offline fallback lists were re-synced with the live catalogs while we were there — Go gained `minimax-m3` and `grok-4.5`, and the Ollama list dropped two ids that provider never actually served (`qwen3.7-max`, `gemma3:12b`). Note that on Ollama Cloud `kimi-k3` bills as extra usage on top of the plan: with an empty extra balance it returns `402`.
+
 ## [0.3.4] - 2026-07-28
 
 Fix: memory cards survive updates, recovery targets the right Telegram conversation, thinking controls work across cloud providers, and private routes and files are locked down. Big thanks to the contributors whose reports and patches drove this release: [@AndyShaman](https://github.com/AndyShaman) (#34, #35, #36, #38, #42, #43 - the recovery fixes #35/#42 are merged with his authorship) and [@yakovmakovets](https://github.com/yakovmakovets) (#37, #39).

--- a/agent/provider.ts
+++ b/agent/provider.ts
@@ -18,7 +18,10 @@ const PROVIDERS = {
     textModel: process.env.OLLAMA_MODEL ?? "deepseek-v4-pro",
     contextWindow: Number(process.env.OLLAMA_CONTEXT_WINDOW ?? 131072),
     // Дешёвая мультимодалка того же провайдера (проверено на проде: принимает image_url, http 200).
-    visionModel: "gemma3:12b",
+    // Ollama Cloud снимает теги с раздачи: gemma3:12b отвечает 410 "retired at 2026-07-15" —
+    // заменён на gemma4:31b (проверено 2026-07-28). Текстовые модели (deepseek, glm, gpt-oss)
+    // отдают 400 "does not support image input", так что подменять vision на них нельзя.
+    visionModel: "gemma4:31b",
   },
   opencode: {
     // Продукт переименован Zen → Go, но API живёт на легаси-пути /zen/ (у /go/v1 — 404).
@@ -27,7 +30,10 @@ const PROVIDERS = {
     // Эндпоинт ждёт bare-ID — срезаем внутренний UI-префикс "opencode-go/" из дефолта и старых .env.
     textModel: (process.env.OPENCODE_MODEL ?? "deepseek-v4-pro").replace(/^opencode-go\//, ""),
     contextWindow: Number(process.env.OPENCODE_CONTEXT_WINDOW ?? 131072),
-    visionModel: "gemini-3-flash",
+    // gemini-3-flash выпал из каталога Go (401 "Model gemini-3-flash is not supported") — теперь
+    // qwen3.7-plus: отвечает 200 и кладёт описание в message.content. У glm-5.2/minimax-m3 текст
+    // уходит в reasoning, у mimo-v2.5 content пустой — vision.ts читает только content.
+    visionModel: "qwen3.7-plus",
   },
   openrouter: {
     baseURL: "https://openrouter.ai/api/v1",
@@ -36,7 +42,7 @@ const PROVIDERS = {
     // Дефолт — лишь заглушка на случай ручного .env; мастер всегда перезапишет живой проверкой.
     textModel: process.env.OPENROUTER_MODEL ?? "openai/gpt-5.1",
     contextWindow: Number(process.env.OPENROUTER_CONTEXT_WINDOW ?? 131072),
-    // Дешёвая гарантированно-мультимодальная модель для картинок (как gemini-3-flash у opencode):
+    // Дешёвая гарантированно-мультимодальная модель для картинок (как qwen3.7-plus у opencode):
     // vision работает независимо от выбранной текстовой модели (та может быть text-only).
     visionModel: "google/gemini-2.5-flash",
   },

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -6,8 +6,8 @@ Iva runs on your server with your keys. Here is every external service it talks 
 
 | Provider | Price | Text models | Vision |
 |---|---|---|---|
-| **OpenCode Go** (ex-Zen) | ~$5/mo | ~20 models fetched live at setup — `deepseek-v4-pro` (default), `kimi-k3`, `kimi-k2.7-code`, `glm-5.2`, `qwen3.7-max`, `minimax-m3`… | `gemini-3-flash` |
-| **Ollama Cloud** | ~$20/mo | `deepseek-v4-pro` (default) | `gemma3:12b` |
+| **OpenCode Go** (ex-Zen) | ~$5/mo | ~23 models fetched live at setup — `deepseek-v4-pro` (default), `kimi-k3`, `kimi-k2.7-code`, `glm-5.2`, `minimax-m3`, `qwen3.7-max`, `grok-4.5`… | `qwen3.7-plus` |
+| **Ollama Cloud** | ~$20/mo | ~19 models fetched live — `deepseek-v4-pro` (default), `kimi-k3`, `glm-5.2`, `minimax-m3`, `gpt-oss:120b`… | `gemma4:31b` |
 | **OpenRouter** | pay-as-you-go | 300+ models across vendors — pick any slug (`vendor/model`) | `google/gemini-2.5-flash` |
 | **OpenAI (ChatGPT subscription)** | your existing Plus/Pro/Team | the models your plan exposes (`gpt-5.x`, `-codex`), fetched live | same subscription (multimodal) |
 
@@ -21,7 +21,9 @@ The first three are plain API keys; the last rides your personal OpenAI subscrip
 MODEL_PROVIDER=opencode   # or ollama / openrouter / codex, then `iva restart`
 ```
 
-Start with Go: a quarter of the price, ~20 models to switch between (the wizard pulls the live list, so new ones like `kimi-k3` appear on their own). Keys, model pick and context-window settings live in [configuration.md](configuration.md).
+Start with Go: a quarter of the price, ~23 models to switch between (the wizard pulls the live list, so new ones like `kimi-k3` appear on their own). Keys, model pick and context-window settings live in [configuration.md](configuration.md).
+
+Two things about the live lists. Both catalogs churn — Ollama Cloud retired `gemma3:12b` on 2026-07-15 and Go dropped `gemini-3-flash`, so a hand-written model id in `.env` can start failing without you touching anything; if the bot goes quiet after weeks of silence on your side, re-run `iva config` and re-pick from the live list. And on Ollama Cloud the frontier tags (`kimi-k3` among them) bill as **extra usage** on top of the plan: with an empty extra-usage balance the API answers `402`, so top it up at [ollama.com/settings](https://ollama.com/settings) or stay on `deepseek-v4-pro`.
 
 ### OpenAI by ChatGPT subscription (`codex`)
 

--- a/scripts/lib/model-catalog.mjs
+++ b/scripts/lib/model-catalog.mjs
@@ -24,7 +24,10 @@ export const CATALOG = {
     keyVar: "OLLAMA_API_KEY",
     modelVar: "OLLAMA_MODEL",
     def: "deepseek-v4-pro",
-    models: ["deepseek-v4-pro", "deepseek-v4-flash", "qwen3.7-max", "gpt-oss:120b", "gemma3:12b"],
+    // Mirrors the live GET /models list (checked 2026-07-28). Ollama Cloud retires tags without
+    // notice — gemma3:12b went 410 on 2026-07-15 — so keep only IDs seen in the live response.
+    // kimi-k3 is billed as "extra usage" on top of the plan (402 with an empty extra balance).
+    models: ["deepseek-v4-pro", "deepseek-v4-flash", "kimi-k3", "glm-5.2", "minimax-m3", "gemma4:31b", "gpt-oss:120b"],
   },
   opencode: {
     label: "OpenCode Go",
@@ -34,7 +37,16 @@ export const CATALOG = {
     modelVar: "OPENCODE_MODEL",
     def: "deepseek-v4-pro",
     // Mirrors OPENCODE_MODELS in setup.mjs (bare IDs, no "opencode-go/" prefix).
-    models: ["deepseek-v4-pro", "deepseek-v4-flash", "kimi-k3", "kimi-k2.7-code", "glm-5.2", "qwen3.7-max"],
+    models: [
+      "deepseek-v4-pro",
+      "deepseek-v4-flash",
+      "kimi-k3",
+      "kimi-k2.7-code",
+      "glm-5.2",
+      "minimax-m3",
+      "qwen3.7-max",
+      "grok-4.5",
+    ],
   },
   codex: {
     label: "OpenAI (подписка)",
@@ -60,7 +72,7 @@ export const CATALOG = {
       "google/gemini-2.5-pro",
       "google/gemini-2.5-flash",
       "deepseek/deepseek-chat",
-      "moonshotai/kimi-k2",
+      "moonshotai/kimi-k3",
     ],
   },
 };

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -34,7 +34,9 @@ const OPENCODE_MODELS = [
   "kimi-k3",
   "kimi-k2.7-code",
   "glm-5.2",
+  "minimax-m3",
   "qwen3.7-max",
+  "grok-4.5",
 ];
 
 const C = { g: "\x1b[32m", y: "\x1b[33m", c: "\x1b[36m", b: "\x1b[1m", r: "\x1b[31m", x: "\x1b[0m" };


### PR DESCRIPTION
Two changes, both driven by provider catalogs drifting under us.

## Vision was broken on both cheap providers

`agent/provider.ts` pins one vision model per provider, and both had been retired:

- Ollama Cloud: `410 gemma3:12b was retired at 2026-07-15 00:00:00 -0700 PDT`
- OpenCode Go: `401 Model gemini-3-flash is not supported`

Effect: every photo landed in the vault with an empty description, silently - `describeImage` throws and the caller continues without vision by design.

Replacements verified with a real image payload against the live endpoints:

| Provider | Was | Now | Check |
|---|---|---|---|
| Ollama Cloud | `gemma3:12b` (410) | `gemma4:31b` | HTTP 200, description in `message.content` |
| OpenCode Go | `gemini-3-flash` (401) | `qwen3.7-plus` | HTTP 200, description in `message.content` |

Candidates rejected on evidence: `glm-5.2` and `minimax-m3` put the answer in `reasoning`, `mimo-v2.5` returns empty `content`, and `vision.ts` reads only `content`. Text models (`deepseek-*`, `glm-*`, `gpt-oss:*`) answer `400 this model does not support image input`, so they cannot stand in.

## Kimi K3 in the model lists

`kimi-k3` (Go, Ollama) and `moonshotai/kimi-k3` (OpenRouter, replacing `kimi-k2`; 1M context, tool calling per the OpenRouter catalog).

The `/model` wizard renders the live `GET /models` list, so K3 already showed up there; the static lists in `model-catalog.mjs` / `setup.mjs` are the offline fallback, and they had drifted - the Ollama entry listed `qwen3.7-max` and `gemma3:12b`, neither of which that provider serves. Both fallbacks now mirror the live responses (Ollama 19 models, Go 23); Go also gains `minimax-m3` and `grok-4.5`.

One gotcha documented in `docs/providers.md`: on Ollama Cloud `kimi-k3` bills as extra usage on top of the plan. With an empty extra-usage balance the API answers `402 this model uses extra usage only (not included plan usage)` even on an active subscription, so the button works but the first request fails.

## Verification

- `npm run typecheck` clean
- `node --test "scripts/lib/*.test.mjs"` - 120/120 pass
- Every model id and HTTP code above came from live calls to both providers, not from docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Photo descriptions now work with updated vision models for Ollama and OpenCode Go.
  - Replaced retired model selections that could cause failed requests or photos without descriptions.

- **Improvements**
  - Refreshed available model lists across supported providers, including Kimi K3 and additional models.
  - Updated offline setup catalogs so model selection remains available when provider APIs are unavailable.

- **Documentation**
  - Clarified provider pricing, model availability, catalog changes, and Ollama Cloud billing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->