### PR TITLE
fix: reap bash subprocess groups on timeout

### DIFF
--- a/agent/tools/bash.ts
+++ b/agent/tools/bash.ts
@@ -1,19 +1,223 @@
 import { defineTool } from "eve/tools";
 import { z } from "zod";
-import { exec } from "node:child_process";
-import { statSync } from "node:fs";
+import { execFileSync, spawn } from "node:child_process";
+import { readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { Worker } from "node:worker_threads";
 
 // Host-native bash. Переопределяет встроенный sandbox-bash eve: команда выполняется
 // напрямую на реальной файловой системе VPS через node:child_process (без sandbox).
 // Самодостаточно: импортирует только eve/tools, zod и node-builtins.
 
 const MAX_OUTPUT = 30_000; // оставляем последние ~30k символов каждого потока
+const TERM_GRACE_MS = 400;
+const KILL_GRACE_MS = 400;
+const REAP_POLL_MS = 20;
+const PIPE_DRAIN_GRACE_MS = 100;
+// A per-call Worker must have enough time to start and observe the root process.
+// Shorter deadlines are rejected instead of pretending they can be enforced reliably.
+export const MIN_TIMEOUT_MS = 100;
+export const MAX_TIMEOUT_MS = 2_147_483_647;
+const DEADLINE_ARMED = 0;
+const DEADLINE_CANCELLED = 1;
+const DEADLINE_EXPIRED = 2;
+const DEADLINE_PROBE_FAILED = 3;
+
+// setTimeout shares the agent's event loop. A synchronous tool or native call can
+// block that loop past the deadline, so a small worker owns the deadline signal.
+// The worker only observes the root PID and signals the process group created by
+// this invocation; manager-owned jobs in another group remain outside its scope.
+const DEADLINE_WATCHDOG_SOURCE = String.raw`
+  const { execFileSync } = require("node:child_process");
+  const { readFileSync } = require("node:fs");
+  const { workerData } = require("node:worker_threads");
+  const state = new Int32Array(workerData.state);
+  const pid = workerData.pid;
+  const deadlineNs = workerData.deadlineNs;
+  const termGraceNs = BigInt(workerData.termGraceMs) * 1000000n;
+  const killGraceNs = BigInt(workerData.killGraceMs) * 1000000n;
+  const pollMs = workerData.pollMs;
+
+  function signalGroup(signal) {
+    try {
+      process.kill(-pid, signal);
+      return true;
+    } catch (error) {
+      return error && error.code !== "ESRCH";
+    }
+  }
+
+  function signalRoot(signal) {
+    try {
+      process.kill(pid, signal);
+      return true;
+    } catch (error) {
+      return !error || error.code !== "ESRCH";
+    }
+  }
+
+  function portableRootState() {
+    try {
+      const stat = execFileSync(
+        "/bin/ps",
+        ["-o", "stat=", "-p", String(pid)],
+        {
+          encoding: "utf8",
+          maxBuffer: 1024,
+          stdio: ["ignore", "pipe", "ignore"],
+          timeout: 100,
+        },
+      ).trim();
+      if (!stat || stat.startsWith("Z")) return 0;
+      return 1;
+    } catch {
+      return signalRoot(0) ? -1 : 0;
+    }
+  }
+
+  function rootState() {
+    if (process.platform === "linux" && !workerData.forcePortableProbe) {
+      try {
+        const stat = readFileSync("/proc/" + pid + "/stat", "utf8");
+        const stateOffset = stat.lastIndexOf(") ") + 2;
+        if (stateOffset >= 2) {
+          const processState = stat[stateOffset];
+          return processState === "Z" || processState === "X" || processState === "x"
+            ? 0
+            : 1;
+        }
+      } catch (error) {
+        if (error && error.code === "ENOENT") return 0;
+      }
+    }
+    return portableRootState();
+  }
+
+  function waitUntilDeadline(deadline) {
+    while (Atomics.load(state, 0) === 0) {
+      const remainingNs = deadline - process.hrtime.bigint();
+      if (remainingNs <= 0n) return true;
+      const remainingMs = Number((remainingNs + 999999n) / 1000000n);
+      Atomics.wait(state, 0, 0, Math.min(pollMs, remainingMs));
+    }
+    return false;
+  }
+
+  function waitForGroupExit(deadline) {
+    while (process.hrtime.bigint() < deadline) {
+      if (!signalGroup(0)) return true;
+      Atomics.wait(state, 1, 0, pollMs);
+    }
+    return !signalGroup(0);
+  }
+
+  const reachedDeadline = waitUntilDeadline(deadlineNs);
+  if (reachedDeadline && Atomics.load(state, 0) === 0) {
+    const observedRootState = rootState();
+    const deadlineResult =
+      observedRootState === 1 ? 2 : observedRootState === 0 ? 1 : 3;
+    Atomics.compareExchange(state, 0, 0, deadlineResult);
+  }
+  const deadlineResult = Atomics.load(state, 0);
+  if (deadlineResult === 2 || deadlineResult === 3) {
+    if (signalGroup("SIGTERM")) {
+      const termDeadline = process.hrtime.bigint() + termGraceNs;
+      if (!waitForGroupExit(termDeadline)) {
+        signalGroup("SIGKILL");
+        waitForGroupExit(process.hrtime.bigint() + killGraceNs);
+      }
+    }
+  } else {
+    Atomics.compareExchange(state, 0, 0, 1);
+  }
+`;
+
+export const deadlineWorkerRuntime = {
+  create(options: ConstructorParameters<typeof Worker>[1]): Worker {
+    return new Worker(DEADLINE_WATCHDOG_SOURCE, options);
+  },
+};
 
 function truncate(s: string): { text: string; truncated: boolean } {
   if (s.length <= MAX_OUTPUT) return { text: s, truncated: false };
   return { text: s.slice(s.length - MAX_OUTPUT), truncated: true };
+}
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function signalProcessGroup(pid: number, signal: NodeJS.Signals | 0): boolean {
+  try {
+    // detached:true makes the shell the leader of a fresh POSIX process group.
+    // A negative pid addresses that whole group, including grandchildren.
+    process.kill(-pid, signal);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === "ESRCH") return false;
+    return false;
+  }
+}
+
+function processGroupExists(pid: number): boolean {
+  return signalProcessGroup(pid, 0);
+}
+
+type RootProcessState = "live" | "exited" | "unknown";
+
+function signalRootExists(pid: number): RootProcessState {
+  try {
+    process.kill(pid, 0);
+    return "live";
+  } catch (error) {
+    return (error as NodeJS.ErrnoException)?.code === "ESRCH" ? "exited" : "unknown";
+  }
+}
+
+function portableRootProcessState(pid: number): RootProcessState {
+  try {
+    const stat = execFileSync("/bin/ps", ["-o", "stat=", "-p", String(pid)], {
+      encoding: "utf8",
+      maxBuffer: 1024,
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 100,
+    }).trim();
+    if (!stat || stat.startsWith("Z")) return "exited";
+    return "live";
+  } catch {
+    return signalRootExists(pid) === "exited" ? "exited" : "unknown";
+  }
+}
+
+function rootProcessState(pid: number): RootProcessState {
+  if (process.platform === "linux") {
+    try {
+      const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+      const stateOffset = stat.lastIndexOf(") ") + 2;
+      if (stateOffset >= 2) {
+        const state = stat[stateOffset];
+        return state === "Z" || state === "X" || state === "x" ? "exited" : "live";
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException)?.code === "ENOENT") return "exited";
+    }
+  }
+  return portableRootProcessState(pid);
+}
+
+async function waitForGroupExit(groupPid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!processGroupExists(groupPid)) return true;
+    await delay(REAP_POLL_MS);
+  }
+  return !processGroupExists(groupPid);
+}
+
+async function reapProcessGroup(groupPid: number): Promise<void> {
+  if (!signalProcessGroup(groupPid, "SIGTERM")) return;
+  if (await waitForGroupExit(groupPid, TERM_GRACE_MS)) return;
+  signalProcessGroup(groupPid, "SIGKILL");
+  await waitForGroupExit(groupPid, KILL_GRACE_MS);
 }
 
 // Модель иногда угадывает cwd (например /root/... вместо реального HOME или несуществующий
@@ -58,12 +262,29 @@ export default defineTool({
     timeoutMs: z
       .number()
       .int()
-      .positive()
+      .min(MIN_TIMEOUT_MS, `timeoutMs должен быть не меньше ${MIN_TIMEOUT_MS} ms`)
+      .max(MAX_TIMEOUT_MS, `timeoutMs должен быть не больше ${MAX_TIMEOUT_MS} ms`)
       .optional()
-      .describe("Таймаут в миллисекундах (по умолчанию 120000)"),
+      .describe(
+        `Таймаут в миллисекундах, от ${MIN_TIMEOUT_MS} до ${MAX_TIMEOUT_MS} ms ` +
+          "(по умолчанию 120000)",
+      ),
   }),
   async execute({ command, cwd, timeoutMs }) {
     const timeout = timeoutMs ?? 120_000;
+    if (
+      !Number.isSafeInteger(timeout) ||
+      timeout < MIN_TIMEOUT_MS ||
+      timeout > MAX_TIMEOUT_MS
+    ) {
+      return {
+        stdout: "",
+        stderr:
+          `timeoutMs должен быть целым числом от ${MIN_TIMEOUT_MS} до ` +
+          `${MAX_TIMEOUT_MS} ms.`,
+        exitCode: 1,
+      };
+    }
     const norm = normalizeCwd(cwd);
     if (norm.error) return { stdout: "", stderr: norm.error, exitCode: 1 };
     const runCwd = norm.cwd ?? process.cwd();
@@ -75,25 +296,224 @@ export default defineTool({
       truncated?: boolean;
       timedOut?: boolean;
     }>((resolve) => {
-      exec(
-        command,
-        { cwd: runCwd, timeout, maxBuffer: 64 * 1024 * 1024, encoding: "utf8" },
-        (error, stdout, stderr) => {
-          const out = truncate(stdout ?? "");
-          const err = truncate(stderr ?? "");
-          // error.code — числовой код выхода; для таймаута node ставит error.killed=true.
-          const e = error as (Error & { code?: number; killed?: boolean }) | null;
-          const exitCode = e?.code ?? (error ? 1 : 0);
-          resolve({
-            stdout: out.text,
-            stderr: err.text,
-            exitCode,
-            cwd: runCwd, // фактическая директория запуска — модель видит, где реально выполнилось
-            truncated: out.truncated || err.truncated || undefined,
-            timedOut: e?.killed || undefined,
-          });
-        },
-      );
+      const resolveSpawnFailure = (error: unknown) => {
+        const detail = error instanceof Error ? error.message : String(error);
+        const failure = truncate(`Не удалось запустить shell: ${detail}`);
+        resolve({
+          stdout: "",
+          stderr: failure.text,
+          exitCode: 1,
+          cwd: runCwd,
+          truncated: failure.truncated || undefined,
+        });
+      };
+      let child: ReturnType<typeof spawn>;
+      try {
+        child = spawn(command, {
+          cwd: runCwd,
+          shell: true,
+          detached: true,
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+      } catch (error) {
+        resolveSpawnFailure(error);
+        return;
+      }
+      let stdout = "";
+      let stderr = "";
+      let outputTruncated = false;
+      let exitCode = 1;
+      let timedOut = false;
+      let commandExited = false;
+      let pipesDone = false;
+      let cleanupDone = false;
+      let settled = false;
+      let cleanup: Promise<void> | null = null;
+      let pipeDrainTimer: ReturnType<typeof setTimeout> | undefined;
+      let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+      let initialized = false;
+
+      child.once("error", (error) => {
+        if (!initialized) {
+          resolveSpawnFailure(error);
+          return;
+        }
+        stderr = append(stderr, error.message);
+        commandExited = true;
+        cleanupDone = true;
+        pipesDone = true;
+        cancelDeadline();
+        finish();
+      });
+
+      const childPid = child.pid;
+      const childStdout = child.stdout;
+      const childStderr = child.stderr;
+      if (childPid === undefined || !childStdout || !childStderr) return;
+
+      const deadlineNs = process.hrtime.bigint() + BigInt(timeout) * 1_000_000n;
+      const deadlineState = new Int32Array(new SharedArrayBuffer(2 * Int32Array.BYTES_PER_ELEMENT));
+
+      const append = (current: string, chunk: string): string => {
+        const next = truncate(current + chunk);
+        if (next.truncated) outputTruncated = true;
+        return next.text;
+      };
+      childStdout.setEncoding("utf8");
+      childStderr.setEncoding("utf8");
+      childStdout.on("data", (chunk: string) => {
+        stdout = append(stdout, chunk);
+      });
+      childStderr.on("data", (chunk: string) => {
+        stderr = append(stderr, chunk);
+      });
+
+      const finish = () => {
+        if (settled || !commandExited || !pipesDone || !cleanupDone) return;
+        settled = true;
+        if (timeoutTimer) clearTimeout(timeoutTimer);
+        if (pipeDrainTimer) clearTimeout(pipeDrainTimer);
+        const deadlineResult = Atomics.load(deadlineState, 0);
+        timedOut ||= deadlineResult === DEADLINE_EXPIRED;
+        if (deadlineResult === DEADLINE_PROBE_FAILED) {
+          stderr = append(
+            stderr,
+            `${stderr ? "\n" : ""}Не удалось проверить состояние shell на дедлайне; ` +
+              "группа процессов остановлена.",
+          );
+          exitCode = 1;
+        }
+        resolve({
+          stdout,
+          stderr,
+          exitCode,
+          cwd: runCwd,
+          truncated: outputTruncated || undefined,
+          timedOut: timedOut || undefined,
+        });
+      };
+      const startCleanup = () => {
+        if (cleanup) return cleanup;
+        cleanup = reapProcessGroup(childPid)
+          .catch(() => {})
+          .finally(() => {
+            cleanupDone = true;
+            if (!pipesDone) {
+              pipeDrainTimer = setTimeout(() => {
+                childStdout.destroy();
+                childStderr.destroy();
+                pipesDone = true;
+                finish();
+              }, PIPE_DRAIN_GRACE_MS);
+            }
+            finish();
+        });
+        return cleanup;
+      };
+      const cancelDeadline = () => {
+        if (
+          Atomics.compareExchange(
+            deadlineState,
+            0,
+            DEADLINE_ARMED,
+            DEADLINE_CANCELLED,
+          ) === DEADLINE_ARMED
+        ) {
+          Atomics.notify(deadlineState, 0);
+        }
+      };
+
+      child.once("exit", (code) => {
+        commandExited = true;
+        exitCode = typeof code === "number" ? code : 1;
+        cancelDeadline();
+        timedOut ||= Atomics.load(deadlineState, 0) === DEADLINE_EXPIRED;
+        void startCleanup().then(finish);
+      });
+      child.once("close", () => {
+        pipesDone = true;
+        if (pipeDrainTimer) clearTimeout(pipeDrainTimer);
+        cancelDeadline();
+        timedOut ||= Atomics.load(deadlineState, 0) === DEADLINE_EXPIRED;
+        startCleanup();
+        finish();
+      });
+
+      const enforceDeadline = () => {
+        const remainingNs = deadlineNs - process.hrtime.bigint();
+        if (remainingNs > 0n) {
+          timeoutTimer = setTimeout(
+            enforceDeadline,
+            Number((remainingNs + 999_999n) / 1_000_000n),
+          );
+          return;
+        }
+        if (commandExited) return;
+        const deadlineResult = Atomics.load(deadlineState, 0);
+        if (deadlineResult === DEADLINE_EXPIRED) {
+          timedOut = true;
+          startCleanup();
+          return;
+        }
+        if (deadlineResult === DEADLINE_PROBE_FAILED) {
+          startCleanup();
+          return;
+        }
+        const observedRootState = rootProcessState(childPid);
+        if (observedRootState === "exited") {
+          cancelDeadline();
+          startCleanup();
+          return;
+        }
+        if (observedRootState === "unknown") {
+          if (
+            Atomics.compareExchange(
+              deadlineState,
+              0,
+              DEADLINE_ARMED,
+              DEADLINE_PROBE_FAILED,
+            ) === DEADLINE_ARMED
+          ) {
+            Atomics.notify(deadlineState, 0);
+          }
+          startCleanup();
+          return;
+        }
+        if (
+          Atomics.compareExchange(
+            deadlineState,
+            0,
+            DEADLINE_ARMED,
+            DEADLINE_EXPIRED,
+          ) === DEADLINE_ARMED
+        ) {
+          Atomics.notify(deadlineState, 0);
+          timedOut = true;
+          startCleanup();
+        }
+      };
+      initialized = true;
+      timeoutTimer = setTimeout(enforceDeadline, timeout);
+      try {
+        const deadlineWorker = deadlineWorkerRuntime.create({
+          eval: true,
+          workerData: {
+            state: deadlineState.buffer,
+            pid: childPid,
+            deadlineNs,
+            termGraceMs: TERM_GRACE_MS,
+            killGraceMs: KILL_GRACE_MS,
+            pollMs: REAP_POLL_MS,
+          },
+        });
+        // An asynchronous Worker failure leaves the already-armed main-thread
+        // deadline and process lifecycle handlers in charge.
+        deadlineWorker.on("error", () => {});
+        deadlineWorker.unref();
+      } catch {
+        // Resource exhaustion can make Worker construction throw synchronously.
+        // The main-thread timer remains a bounded fallback while its loop is responsive.
+      }
     });
   },
 });

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -47,6 +47,31 @@
   synchronous `Type=simple` start semantics, and timer start jobs return in their active
   waiting state, so a synthetic `activating` transition would not model these units.
 
+## IVA-001 bash process lifecycle
+
+- Host bash runs in its own POSIX process group with stdin closed. Timeout sends `SIGTERM`,
+  waits 400 ms, then sends `SIGKILL` and waits another bounded 400 ms. Timeout classification
+  checks the root process state, so a delayed Node exit event does not produce a false timeout.
+  A per-call worker observes the monotonic deadline and enforces it even while the main Node
+  event loop is blocked. Linux uses `/proc` for root state; macOS uses the POSIX `ps` state
+  so an exited zombie is not reported as timed out. If neither probe can establish state,
+  cleanup fails closed with an explicit error.
+- The schema and runtime accept deadlines from 100 through 2,147,483,647 ms. The lower bound
+  gives a newly started worker time to observe the process; the upper bound matches Node's
+  maximum timer delay and prevents overflow warnings and a hot rescheduling loop.
+- Spawn resource failures are handled before PID, stream, worker or timer setup and return a
+  bounded structured error; an `EMFILE` condition cannot crash the host process.
+- Lifecycle handlers and the main-thread deadline are armed before the optional deadline
+  worker. If worker initialization fails under resource pressure, execution continues with
+  the main-thread deadline fallback and cannot orphan the spawned process group.
+- The same group cleanup runs after a normal shell exit, so background descendants cannot
+  outlive the tool call while they remain in that group. A process which deliberately creates
+  a new session with `setsid`, or a manager-owned job such as `systemd-run`, has its own
+  lifecycle outside this process-group contract.
+- Stdout and stderr are consumed as streams while retaining the existing last-30,000-character
+  result contract, cwd reporting and truncation marker. After bounded group cleanup, inherited
+  output pipes are closed so a process outside the owned group cannot hold the tool call open.
+
 ## Aimasters.Me user-feedback backlog (2026-07-28)
 
 - Source evidence, issue triage, source-message links and links to attached screenshots/video are in

--- a/scripts/bash-tool.test.mjs
+++ b/scripts/bash-tool.test.mjs
@@ -1,0 +1,621 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { spawn } from "node:child_process";
+
+const {
+  default: bash,
+  deadlineWorkerRuntime,
+  MAX_TIMEOUT_MS,
+  MIN_TIMEOUT_MS,
+} = await import("../agent/tools/bash.ts");
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function shellQuote(value) {
+  return `'${String(value).replaceAll("'", "'\\''")}'`;
+}
+
+function readPid(file) {
+  if (!existsSync(file)) return null;
+  const pid = Number.parseInt(readFileSync(file, "utf8").trim(), 10);
+  return Number.isSafeInteger(pid) && pid > 1 ? pid : null;
+}
+
+function isAlive(pid) {
+  if (pid === null) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (error?.code === "ESRCH") return false;
+    throw error;
+  }
+}
+
+async function waitForPid(file, timeoutMs = 500) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const pid = readPid(file);
+    if (pid !== null) return pid;
+    await delay(10);
+  }
+  assert.fail(`child did not write its PID to ${file}`);
+}
+
+async function waitUntilGone(pid, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isAlive(pid)) return true;
+    await delay(20);
+  }
+  return !isAlive(pid);
+}
+
+async function within(promise, timeoutMs, message) {
+  let timer;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((_, reject) => {
+        timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function runWithExhaustedFileDescriptors() {
+  const script = String.raw`
+    import { closeSync, openSync } from "node:fs";
+    const { default: bash } = await import("./agent/tools/bash.ts");
+    const descriptors = [];
+    try {
+      while (true) descriptors.push(openSync("/dev/null", "r"));
+    } catch (error) {
+      if (error?.code !== "EMFILE") throw error;
+    }
+    let result;
+    try {
+      result = await bash.execute({ command: ":", timeoutMs: 1_000 });
+    } finally {
+      for (const descriptor of descriptors) closeSync(descriptor);
+    }
+    process.stdout.write(JSON.stringify(result));
+  `;
+  const child = spawn(
+    "bash",
+    [
+      "-c",
+      'ulimit -n 64; exec "$1" --input-type=module -e "$2"',
+      "bash",
+      process.execPath,
+      script,
+    ],
+    {
+      cwd: process.cwd(),
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk) => {
+    stdout += chunk;
+  });
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+  const exitCode = await new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", resolve);
+  });
+  return { stdout, stderr, exitCode };
+}
+
+function termResistantCommand(pidFile, { asChild = false, detachIo = false } = {}) {
+  const redirect = detachIo ? " </dev/null >/dev/null 2>&1" : "";
+  const processCommand =
+    `trap '' TERM HUP; printf '%s\\n' "$$" > ${shellQuote(pidFile)}; ` +
+    `exec sleep 3600${redirect}`;
+  if (!asChild) return processCommand;
+  // Keep exec's /bin/sh as the timed process and make the TERM-resistant process
+  // its child. A timeout must reap the whole tree, not only this outer shell.
+  return `bash -c ${shellQuote(processCommand)} & wait`;
+}
+
+function escapedProcessGroupCommand(
+  pidFile,
+  { detachIo = false, wait = false } = {},
+) {
+  const redirect = detachIo ? " </dev/null >/dev/null 2>&1" : "";
+  const escaped =
+    `trap '' TERM HUP; printf '%s\\n' "$$" > ${shellQuote(pidFile)}; ` +
+    "exec sleep 3600";
+  return (
+    `setsid sh -c ${shellQuote(escaped)}${redirect} & ` +
+    `while [ ! -s ${shellQuote(pidFile)} ]; do sleep 0.01; done` +
+    (wait ? "; wait" : "")
+  );
+}
+
+function startFakeManager(requestFile, pidFile) {
+  let managed = null;
+  const poll = setInterval(() => {
+    if (managed || !existsSync(requestFile)) return;
+    managed = spawn("sleep", ["3600"], {
+      detached: true,
+      stdio: "ignore",
+      // A manager starts the unit in its own process group.
+      env: { PATH: process.env.PATH },
+    });
+    managed.unref();
+    writeFileSync(pidFile, `${managed.pid}\n`);
+  }, 5);
+  return () => {
+    clearInterval(poll);
+    if (managed && isAlive(managed.pid)) process.kill(managed.pid, "SIGKILL");
+  };
+}
+
+test("bash preserves stdout, stderr and the effective cwd", async () => {
+  const cwd = mkdtempSync(join(tmpdir(), "iva-bash-normal-"));
+  try {
+    const result = await bash.execute({
+      command: "printf stdout; printf stderr >&2",
+      cwd,
+      timeoutMs: 1_000,
+    });
+    assert.deepEqual(result, {
+      stdout: "stdout",
+      stderr: "stderr",
+      exitCode: 0,
+      cwd,
+      truncated: undefined,
+      timedOut: undefined,
+    });
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("bash preserves an ordinary non-zero shell exit code", async () => {
+  const result = await bash.execute({
+    command: "printf failed >&2; exit 7",
+    timeoutMs: 1_000,
+  });
+  assert.equal(result.stdout, "");
+  assert.equal(result.stderr, "failed");
+  assert.equal(result.exitCode, 7);
+  assert.equal(result.timedOut, undefined);
+});
+
+test("bash input schema rejects deadlines below the documented floor", () => {
+  assert.equal(MIN_TIMEOUT_MS, 100);
+  const rejected = bash.inputSchema.safeParse({
+    command: ":",
+    timeoutMs: MIN_TIMEOUT_MS - 1,
+  });
+  assert.equal(rejected.success, false);
+  assert.match(rejected.error.issues[0].message, /100 ms/);
+  assert.equal(
+    bash.inputSchema.safeParse({ command: ":", timeoutMs: MIN_TIMEOUT_MS }).success,
+    true,
+  );
+});
+
+test("bash input schema enforces Node's maximum timer delay", () => {
+  assert.equal(MAX_TIMEOUT_MS, 2_147_483_647);
+  const rejected = bash.inputSchema.safeParse({
+    command: ":",
+    timeoutMs: MAX_TIMEOUT_MS + 1,
+  });
+  assert.equal(rejected.success, false);
+  assert.match(rejected.error.issues[0].message, /2147483647 ms/);
+  assert.equal(
+    bash.inputSchema.safeParse({ command: ":", timeoutMs: MAX_TIMEOUT_MS }).success,
+    true,
+  );
+});
+
+test("direct execute rejects a deadline below the floor before spawning", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "iva-bash-timeout-floor-"));
+  const marker = join(dir, "spawned");
+  try {
+    const result = await bash.execute({
+      command: `: > ${shellQuote(marker)}`,
+      timeoutMs: MIN_TIMEOUT_MS - 1,
+    });
+    assert.equal(result.exitCode, 1);
+    assert.match(result.stderr, /timeoutMs.*100.*2147483647 ms/);
+    assert.equal(existsSync(marker), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("direct execute rejects a deadline above Node's timer limit before spawning", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "iva-bash-timeout-ceiling-"));
+  const marker = join(dir, "spawned");
+  try {
+    const result = await bash.execute({
+      command: `: > ${shellQuote(marker)}`,
+      timeoutMs: MAX_TIMEOUT_MS + 1,
+    });
+    assert.equal(result.exitCode, 1);
+    assert.match(result.stderr, /timeoutMs.*100.*2147483647 ms/);
+    assert.equal(existsSync(marker), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("spawn resource failure returns a bounded result without an unhandled error", async () => {
+  const child = await within(
+    runWithExhaustedFileDescriptors(),
+    3_000,
+    "EMFILE regression process did not settle",
+  );
+  assert.equal(child.exitCode, 0, child.stderr);
+  const result = JSON.parse(child.stdout);
+  assert.equal(result.exitCode, 1);
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, /EMFILE|too many open files/i);
+  assert.equal(result.stderr.length <= 30_000, true);
+});
+
+test("worker initialization failure falls back without orphaning the child group", async (t) => {
+  const dir = mkdtempSync(join(tmpdir(), "iva-bash-worker-init-"));
+  const pidFile = join(dir, "shell.pid");
+  t.mock.method(deadlineWorkerRuntime, "create", () => {
+    throw new Error("injected Worker initialization failure");
+  });
+  const execution = bash.execute({
+    command: `printf '%s\\n' "$$" > ${shellQuote(pidFile)}; sleep 3600`,
+    timeoutMs: MIN_TIMEOUT_MS,
+  });
+  let pid = null;
+  try {
+    pid = await waitForPid(pidFile);
+    const result = await within(
+      execution,
+      1_800,
+      "main-thread deadline fallback did not settle after Worker init failure",
+    );
+    assert.equal(result.timedOut, true);
+    assert.equal(await waitUntilGone(pid, 1_500), true);
+  } finally {
+    pid ??= readPid(pidFile);
+    if (isAlive(pid)) process.kill(-pid, "SIGKILL");
+    await execution.catch(() => {});
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("a delayed exit event does not turn an already-exited command into a timeout", async () => {
+  const execution = bash.execute({ command: "exit 7", timeoutMs: 100 });
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 250);
+  const result = await within(execution, 1_800, "delayed exit event did not settle");
+  assert.equal(result.exitCode, 7);
+  assert.equal(result.timedOut, undefined);
+});
+
+test("portable deadline probe recognizes an exited root while the main loop is blocked", async (t) => {
+  const createWorker = deadlineWorkerRuntime.create;
+  t.mock.method(deadlineWorkerRuntime, "create", (options) =>
+    createWorker({
+      ...options,
+      workerData: {
+        ...options.workerData,
+        forcePortableProbe: true,
+      },
+    }),
+  );
+  const execution = bash.execute({ command: "exit 7", timeoutMs: MIN_TIMEOUT_MS });
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 250);
+  const result = await within(execution, 1_800, "portable deadline probe did not settle");
+  assert.equal(result.exitCode, 7);
+  assert.equal(result.timedOut, undefined);
+});
+
+test("minimum deadline is enforced while the Node event loop is blocked", async () => {
+  const execution = bash.execute({
+    command: "sleep 0.2; printf completed",
+    timeoutMs: MIN_TIMEOUT_MS,
+  });
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 300);
+  const result = await within(execution, 1_800, "blocked event loop disabled the deadline");
+  assert.equal(result.timedOut, true);
+  assert.equal(result.stdout.includes("completed"), false);
+});
+
+test("deadline checks the root PID rather than a surviving process group", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "iva-bash-root-pid-"));
+  const pidFile = join(dir, "child.pid");
+  const command =
+    `${termResistantCommand(pidFile)} & ` +
+    `while [ ! -s ${shellQuote(pidFile)} ]; do sleep 0.01; done; exit 7`;
+  const execution = bash.execute({ command, timeoutMs: 100 });
+  let pid = null;
+  try {
+    const pidDeadline = Date.now() + 500;
+    while (!existsSync(pidFile) && Date.now() < pidDeadline) {
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5);
+    }
+    pid = readPid(pidFile);
+    assert.notEqual(pid, null, "background child did not write its PID");
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 250);
+    const result = await within(execution, 1_800, "root PID deadline check did not settle");
+    assert.equal(result.exitCode, 7);
+    assert.equal(result.timedOut, undefined);
+    assert.equal(await waitUntilGone(pid, 1_500), true);
+  } finally {
+    pid ??= readPid(pidFile);
+    if (isAlive(pid)) process.kill(pid, "SIGKILL");
+    await within(execution.catch(() => {}), 1_000, "root PID execution did not settle");
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("closing fd 4 cannot crash bash execution or change its exit code", async () => {
+  const result = await within(
+    bash.execute({ command: "exec 4<&-; exit 9", timeoutMs: 1_000 }),
+    1_800,
+    "closing fd 4 prevented bash execution from settling",
+  );
+  assert.equal(result.exitCode, 9);
+  assert.equal(result.timedOut, undefined);
+});
+
+test("closing fd 3 cannot turn a normal exit into a timeout", async () => {
+  const result = await within(
+    bash.execute({ command: "exec 3>&-; exit 0", timeoutMs: 1_000 }),
+    1_800,
+    "closing fd 3 prevented bash execution from settling",
+  );
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.timedOut, undefined);
+});
+
+test("writing to fd 3 cannot disable the command deadline", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "iva-bash-fd-spoof-"));
+  const pidFile = join(dir, "shell.pid");
+  const execution = bash.execute({
+    command:
+      `printf '%s\\n' "$$" > ${shellQuote(pidFile)}; ` +
+      "(printf x >&3) 2>/dev/null || :; while :; do :; done",
+    timeoutMs: 100,
+  });
+  let pid = null;
+  try {
+    pid = await waitForPid(pidFile);
+    const result = await within(
+      execution,
+      1_800,
+      "writing to fd 3 disabled the command deadline",
+    );
+    assert.equal(result.timedOut, true);
+  } finally {
+    pid ??= readPid(pidFile);
+    if (isAlive(pid)) process.kill(-pid, "SIGKILL");
+    await within(execution.catch(() => {}), 1_000, "fd spoof execution did not settle");
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("bash closes stdin so a command waiting for input receives EOF", async () => {
+  const result = await bash.execute({
+    command: "if IFS= read -r line; then printf unexpected; else printf stdin-closed; fi",
+    timeoutMs: 1_000,
+  });
+  assert.equal(result.stdout, "stdin-closed");
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.timedOut, undefined);
+});
+
+test("bash preserves the last 30000 characters of each output stream", async () => {
+  const script =
+    `process.stdout.write("prefix-" + "o".repeat(30000));` +
+    `process.stderr.write("prefix-" + "e".repeat(30000));`;
+  const result = await bash.execute({
+    command: `${shellQuote(process.execPath)} -e ${shellQuote(script)}`,
+    timeoutMs: 1_000,
+  });
+  assert.equal(result.stdout, "o".repeat(30_000));
+  assert.equal(result.stderr, "e".repeat(30_000));
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.truncated, true);
+  assert.equal(result.timedOut, undefined);
+});
+
+test("normal calls do not accumulate cleanup timers", async () => {
+  const timeoutHandles = () =>
+    process.getActiveResourcesInfo().filter((resource) => resource === "Timeout").length;
+  const before = timeoutHandles();
+  const started = Date.now();
+  for (let index = 0; index < 3; index++) {
+    const result = await bash.execute({ command: ":", timeoutMs: 1_000 });
+    assert.equal(result.exitCode, 0);
+  }
+  await delay(50);
+  assert.equal(timeoutHandles() <= before, true, "completed bash calls leaked cleanup timers");
+  assert.equal(Date.now() - started < 1_800, true, "normal calls performed unbounded cleanup work");
+});
+
+test("timeout resolves within two seconds when a child ignores SIGTERM", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "iva-bash-term-"));
+  const pidFile = join(dir, "child.pid");
+  const execution = bash.execute({
+    command: termResistantCommand(pidFile),
+    timeoutMs: 100,
+  });
+  let pid = null;
+  try {
+    pid = await waitForPid(pidFile);
+    const result = await within(
+      execution,
+      1_800,
+      "bash timeout did not resolve within 1800ms for a TERM-resistant child",
+    );
+    assert.equal(result.timedOut, true);
+  } finally {
+    pid ??= readPid(pidFile);
+    if (isAlive(pid)) process.kill(pid, "SIGKILL");
+    await within(execution.catch(() => {}), 1_000, "bash execution did not settle after test cleanup");
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("normal shell exit reaps a background TERM-resistant descendant in its group", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "iva-bash-normal-reap-"));
+  const pidFile = join(dir, "child.pid");
+  const command = `${termResistantCommand(pidFile)} &`;
+  let pid = null;
+  try {
+    const result = await within(
+      bash.execute({ command, timeoutMs: 1_000 }),
+      1_800,
+      "bash did not settle after a normal shell exit with a background child",
+    );
+    pid = await waitForPid(pidFile);
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.timedOut, undefined);
+    assert.equal(
+      await waitUntilGone(pid, 1_500),
+      true,
+      `background child PID ${pid} survived its parent shell`,
+    );
+  } finally {
+    pid ??= readPid(pidFile);
+    if (isAlive(pid)) process.kill(pid, "SIGKILL");
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("descendant cleanup after a normal shell exit does not report a timeout", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "iva-bash-normal-deadline-"));
+  const pidFile = join(dir, "child.pid");
+  const command = `${termResistantCommand(pidFile, { detachIo: true })} &`;
+  let pid = null;
+  try {
+    const result = await within(
+      bash.execute({ command, timeoutMs: 100 }),
+      1_800,
+      "bash did not settle after cleanup crossed the command deadline",
+    );
+    pid = await waitForPid(pidFile);
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.timedOut, undefined);
+    assert.equal(
+      await waitUntilGone(pid, 1_500),
+      true,
+      `background child PID ${pid} survived cleanup after its parent exited`,
+    );
+  } finally {
+    pid ??= readPid(pidFile);
+    if (isAlive(pid)) process.kill(pid, "SIGKILL");
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("a setsid process outside the owned group cannot hold result pipes open", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "iva-bash-setsid-bounded-"));
+  const pidFile = join(dir, "child.pid");
+  let pid = null;
+  try {
+    const result = await within(
+      bash.execute({
+        command: escapedProcessGroupCommand(pidFile),
+        timeoutMs: 1_000,
+      }),
+      1_800,
+      "a process outside the owned group held inherited output pipes open",
+    );
+    pid = await waitForPid(pidFile);
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.timedOut, undefined);
+    assert.equal(isAlive(pid), true, "setsid must place the process outside the owned group");
+  } finally {
+    pid ??= readPid(pidFile);
+    if (isAlive(pid)) process.kill(pid, "SIGKILL");
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("timeout settles when a setsid process outside the owned group inherits output pipes", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "iva-bash-setsid-timeout-"));
+  const pidFile = join(dir, "child.pid");
+  const execution = bash.execute({
+    command: escapedProcessGroupCommand(pidFile, { wait: true }),
+    timeoutMs: 100,
+  });
+  let pid = null;
+  try {
+    pid = await waitForPid(pidFile);
+    const result = await within(
+      execution,
+      1_800,
+      "bash timeout did not settle after a setsid descendant inherited its pipes",
+    );
+    assert.equal(result.timedOut, true);
+    assert.equal(isAlive(pid), true, "setsid must place the process outside the owned group");
+  } finally {
+    pid ??= readPid(pidFile);
+    if (isAlive(pid)) process.kill(pid, "SIGKILL");
+    await within(execution.catch(() => {}), 1_000, "bash execution did not settle after test cleanup");
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("timeout leaves no TERM-resistant child PID behind", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "iva-bash-reap-"));
+  const pidFile = join(dir, "child.pid");
+  const execution = bash.execute({
+    command: termResistantCommand(pidFile, { asChild: true, detachIo: true }),
+    timeoutMs: 100,
+  });
+  let pid = null;
+  try {
+    pid = await waitForPid(pidFile);
+    const result = await within(execution, 1_800, "bash timeout did not settle");
+    assert.equal(result.timedOut, true);
+    assert.equal(
+      await waitUntilGone(pid, 1_500),
+      true,
+      `TERM-resistant child PID ${pid} survived the timeout`,
+    );
+  } finally {
+    pid ??= readPid(pidFile);
+    if (isAlive(pid)) process.kill(pid, "SIGKILL");
+    await execution.catch(() => {});
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("a fake-manager process outside the PGID remains outside bash cleanup", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "iva-bash-fake-manager-"));
+  const requestFile = join(dir, "start.request");
+  const pidFile = join(dir, "managed.pid");
+  const stopManager = startFakeManager(requestFile, pidFile);
+  let pid = null;
+  try {
+    const result = await bash.execute({
+      command:
+        `: > ${shellQuote(requestFile)}; ` +
+        `while [ ! -s ${shellQuote(pidFile)} ]; do sleep 0.01; done`,
+      timeoutMs: 2_000,
+    });
+    assert.equal(result.exitCode, 0);
+    pid = await waitForPid(pidFile);
+    assert.equal(isAlive(pid), true, "manager-owned work must outlive the requesting bash client");
+  } finally {
+    stopManager();
+    pid ??= readPid(pidFile);
+    if (isAlive(pid)) process.kill(pid, "SIGKILL");
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #52

## What changed
- Runs host bash in its own detached POSIX process group with closed stdin.
- Enforces timeout through a monotonic watchdog even when the main Node event loop is blocked; sends TERM then KILL with bounded cleanup.
- Reaps same-group background descendants after normal shell exit while leaving deliberate `setsid`/manager-owned jobs outside the tool group.
- Handles spawn/worker startup failures without crashes or orphaned processes.
- Uses portable zombie detection on supported Linux/macOS hosts and validates timeout range `100..2147483647` before spawn.
- Preserves stdout/stderr tails, cwd, truncation and exit-code behavior.

## TDD evidence
RED repros covered TERM-resistant descendants, normal-exit background survivors, inherited-pipe hangs, delayed event-loop deadlines, 1ms worker-start races, EMFILE spawn failure, Worker constructor failure, portable zombie detection and timer overflow.

GREEN on rebased head `1be671f`:
- `node --test scripts/bash-tool.test.mjs` - 25/25
- `npm run typecheck` - pass
- `npx eve build` - pass
- `git diff --check origin/main...HEAD` - pass

## UX before/after
A timed-out or failed command now returns a bounded structured result and cannot leave IVA waiting on its owned process group. Existing output and cwd behavior remain unchanged.

## Review boundary
Multiple independent blind passes reproduced the failures above; all accepted blockers were fixed and regression-tested. Scope is frozen at the issue contract; no further exploratory polishing is part of this PR.

CodeRabbit CLI: skipped because the authenticated account has no assigned seat; GitHub CI is the final merge gate.