### PR TITLE
fix: make systemd activation failures explicit

### DIFF
--- a/bin/iva.mjs
+++ b/bin/iva.mjs
@@ -2,8 +2,8 @@
 // Iva CLI — manage the self-host installation: update / config / doctor / uninstall + wrappers.
 // Self-contained, no external dependencies. Node 24+ (global fetch, spawnSync).
 //
-// SINGLE source of truth for systemd units (writeUnits): install.sh delegates here
-// (`iva _install-units`), and update/doctor reuse the same write.
+// SINGLE source of truth for systemd units and activation: install.sh delegates here
+// (`iva _install-units` + `_activate-units`), and CLI/doctor reuse the same paths.
 import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync, mkdirSync, rmSync, readdirSync, chmodSync, statSync } from "node:fs";
 import { randomBytes } from "node:crypto";
@@ -18,9 +18,11 @@ import { createTelegramUpdateReporter, loadTelegramJob, removeTelegramJob } from
 import { generateAssistantBearer, isAssistantBearer } from "../scripts/lib/assistant-auth.mjs";
 import { writeEnvAtomicSync } from "../scripts/lib/env-file.mjs";
 import { classifyAgentListeners } from "../scripts/lib/listener-security.mjs";
+import { cleanupSystemdUnits, createSystemdControl } from "../scripts/lib/systemd-control.mjs";
 import { userbotSyncArgs } from "../scripts/lib/userbot-deps.mjs";
 import {
   acquireUpdateLock,
+  commitThenRunPostCommit,
   createUpdateLog,
   createUpdateTransaction,
   releaseUpdateLock,
@@ -72,8 +74,8 @@ function cap(cmd, args, opts = {}) {
   return { code: r.status ?? 1, out: (r.stdout || "").trim(), err: (r.stderr || "").trim() };
 }
 const hasSystemd = () => !!cap("sh", ["-c", "command -v systemctl"]).out;
-const sc = (...args) => run("systemctl", ["--user", ...args]);
 const scQ = (...args) => cap("systemctl", ["--user", ...args]);
+const systemd = createSystemdControl({ run: (args) => scQ(...args) });
 const gitHead = () => cap("git", ["rev-parse", "--short", "HEAD"]).out;
 
 function readEnv() {
@@ -220,27 +222,24 @@ function writeUnits() {
     writeFileSync(join(UNIT_DIR, f), tpl);
     written.push(f);
   }
-  if (hasSystemd()) scQ("daemon-reload");
+  if (hasSystemd()) systemd.daemonReload();
   return written;
 }
 
-function enableUnits() {
-  sc("enable", "--now", ...SERVICES);
-  for (const t of TIMERS) sc("enable", "--now", t);
+function activateUnits() {
+  systemd.activate([...SERVICES, ...TIMERS]);
 }
 
 function removeUnits() {
   if (!existsSync(UNIT_DIR)) return [];
   const units = readdirSync(UNIT_DIR).filter((f) => /^iva.*\.(service|timer)$/.test(f));
-  for (const u of units) scQ("disable", "--now", u);
-  for (const u of units) {
-    try {
-      rmSync(join(UNIT_DIR, u));
-    } catch {}
-  }
-  scQ("daemon-reload");
-  scQ("reset-failed");
-  return units;
+  return cleanupSystemdUnits({
+    units,
+    disable: (unit) => systemd.disableNow([unit]),
+    remove: (unit) => rmSync(join(UNIT_DIR, unit)),
+    reload: () => systemd.daemonReload(),
+    reset: () => systemd.resetFailed(),
+  });
 }
 
 // Migrate old installs to IVA_PORT. Idempotent: on the first `iva update`
@@ -268,7 +267,7 @@ function migrateEnv({ quiet = false } = {}) {
 // on the old port (the unit was already baked) while clients read the new one — the same desync.
 function restartServices() {
   writeUnits();
-  return sc("restart", ...SERVICES).status === 0;
+  systemd.restart(SERVICES);
 }
 
 // ANSI tree like during install. The only source of the art is install.sh (heredoc
@@ -384,12 +383,14 @@ async function cmdUpdate(args) {
         protect: ["Сохраняю ваши изменения", "Изменения сохранены", "Не удалось сохранить изменения"],
         fetch: ["Получаю обновление", "Обновление получено", "Не удалось получить обновление"],
         build: ["Собираю Iva", "Iva собрана", "Не удалось собрать Iva"],
+        timerFailure: "Iva готова, но таймер автоматических обновлений не удалось активировать",
         current: "Iva уже обновлена",
       }
     : {
         protect: ["Saving your changes", "Changes saved", "Couldn't save your changes"],
         fetch: ["Getting the update", "Update received", "Couldn't get the update"],
         build: ["Building Iva", "Iva built", "Couldn't build Iva"],
+        timerFailure: "Iva is ready, but the automatic update timer could not be activated",
         current: "Iva is already up to date",
       };
 
@@ -429,8 +430,21 @@ async function cmdUpdate(args) {
   const ensureUpdateTimer = async () => {
     if (!hasSystemd()) return;
     writeUnits();
-    const timer = await tx.run("systemctl", ["--user", "enable", "--now", UPDATE_TIMER]);
-    if (timer.code !== 0) terminal.info(`⚠️ ${UPDATE_TIMER} was not enabled; run: iva doctor`);
+    systemd.activate([UPDATE_TIMER]);
+  };
+  const finalizeUpdate = async () => {
+    const finalized = await commitThenRunPostCommit({
+      commit: () => tx.commit(),
+      postCommit: ensureUpdateTimer,
+    });
+    if (finalized.ok) return true;
+
+    const detail = finalized.error?.message || String(finalized.error);
+    terminal.fail(text.timerFailure);
+    terminal.info(detail);
+    await reporter?.postCommitFailure(detail);
+    process.exitCode = 1;
+    return false;
   };
 
   try {
@@ -445,8 +459,7 @@ async function cmdUpdate(args) {
     await phaseDone("fetch");
 
     if (!update.changed && !force) {
-      await tx.commit();
-      await ensureUpdateTimer();
+      if (!(await finalizeUpdate())) return;
       terminal.info(`✅ ${text.current} (${versions.afterVersion})`);
       await reporter?.complete({ ...versions, changedLocal: tx.hadLocalChanges });
       return;
@@ -483,12 +496,11 @@ async function cmdUpdate(args) {
 
     if (hasSystemd()) {
       writeUnits();
-      const restarted = await tx.run("systemctl", ["--user", "restart", ...SERVICES]);
-      if (restarted.code !== 0) throw new Error("service restart failed");
+      systemd.restart(SERVICES);
       let healthy = false;
       const port = (readEnv().IVA_PORT || DEFAULT_PORT).trim();
       for (let attempt = 0; attempt < 30; attempt++) {
-        const active = SERVICES.every((service) => scQ("is-active", service).out === "active");
+        const active = SERVICES.every((service) => systemd.isActive(service));
         try {
           const response = await fetch(`http://127.0.0.1:${port}/`, { signal: AbortSignal.timeout(2000) });
           if (active && response.ok) { healthy = true; break; }
@@ -496,7 +508,7 @@ async function cmdUpdate(args) {
         await new Promise((resolve) => setTimeout(resolve, 1000));
       }
       if (!healthy) throw new Error("health check failed");
-      if (scQ("is-active", SVC_USERBOT).out === "active") {
+      if (systemd.isActive(SVC_USERBOT)) {
         const frozen = cap("uv", ["pip", "freeze", "--python", VENV_PY], { cwd: USERBOT_DIR });
         if (frozen.code !== 0 || !frozen.out)
           throw new Error("userbot: не удалось сохранить dependency snapshot перед обновлением");
@@ -508,8 +520,7 @@ async function cmdUpdate(args) {
     }
 
     await phaseDone("build");
-    await tx.commit();
-    await ensureUpdateTimer();
+    if (!(await finalizeUpdate())) return;
     const model = modelSummary(readEnv());
     terminal.info(`✅ Iva ${locale === "ru" ? "обновлена" : "updated"}`);
     terminal.info(`${versions.beforeVersion} → ${versions.afterVersion} · ${model.provider}/${model.model}`);
@@ -525,9 +536,12 @@ async function cmdUpdate(args) {
       codeRollbackOk = false;
     }
     if (phase === "build" && hasSystemd()) {
-      writeUnits();
-      const restarted = await tx.run("systemctl", ["--user", "restart", ...SERVICES]);
-      if (restarted.code !== 0) rollbackOk = false;
+      try {
+        writeUnits();
+        systemd.restart(SERVICES);
+      } catch {
+        rollbackOk = false;
+      }
       if (userbotUpdateAttempted && codeRollbackOk) {
         try {
           restartUserbotIfActive({
@@ -631,32 +645,46 @@ async function cmdDoctor() {
   const present = existsSync(UNIT_DIR) && readdirSync(UNIT_DIR).some((f) => /^iva.*\.(service|timer)$/.test(f));
   if (!present) {
     warn("systemd units not installed — installing…");
-    writeUnits();
-    enableUnits();
-    (ok("Units installed and enabled"), fixN++);
+    try {
+      writeUnits();
+      activateUnits();
+      (ok("Units installed, enabled and active"), fixN++);
+    } catch (e) {
+      (bad(e.message), badN++);
+    }
   } else {
-    writeUnits(); // refresh: Environment=PORT syncs with the current IVA_PORT (eliminates drift)
-    (ok("systemd units installed (refreshed)"), okN++);
+    try {
+      writeUnits(); // refresh: Environment=PORT syncs with the current IVA_PORT (eliminates drift)
+      (ok("systemd units installed (refreshed)"), okN++);
+    } catch (e) {
+      (bad(e.message), badN++);
+    }
   }
 
   // 5. Services active
   for (const svc of SERVICES) {
-    if (scQ("is-active", svc).out === "active") (ok(`${svc} active`), okN++);
+    if (systemd.isEnabled(svc) && systemd.isActive(svc)) (ok(`${svc} enabled and active`), okN++);
     else {
-      warn(`${svc} inactive — restarting…`);
-      scQ("reset-failed", svc);
-      sc("restart", svc);
-      if (scQ("is-active", svc).out === "active") (ok(`${svc} brought up`), fixN++);
-      else (bad(`${svc} won't start — journalctl --user -u ${svc} -e`), badN++);
+      warn(`${svc} disabled or inactive — activating…`);
+      try {
+        systemd.resetFailed([svc]);
+        systemd.activate([svc]);
+        (ok(`${svc} enabled and active`), fixN++);
+      } catch (e) {
+        (bad(e.message), badN++);
+      }
     }
   }
   // A newly generated bearer is read only at process start. Without this restart,
   // doctor would fix the file while leaving the live Eve process unable to accept it.
   if (bearerChanged) {
     warn("iva.service needs one restart to load the new internal bearer");
-    sc("restart", "iva.service");
-    if (scQ("is-active", "iva.service").out === "active") (ok("iva.service loaded the internal bearer"), fixN++);
-    else (bad("iva.service did not restart with the internal bearer"), badN++);
+    try {
+      systemd.restart(["iva.service"]);
+      (ok("iva.service loaded the internal bearer"), fixN++);
+    } catch (e) {
+      (bad(e.message), badN++);
+    }
   }
   // A refreshed unit does not move an already-running old process off 0.0.0.0.
   // Detect the actual socket and restart once so doctor repairs that upgrade state too.
@@ -668,28 +696,39 @@ async function cmdDoctor() {
   let listener = inspectListener();
   if (listener === "exposed") {
     warn(`iva.service is exposed beyond loopback on port ${port} - restarting securely`);
-    sc("restart", "iva.service");
-    for (let attempt = 0; attempt < 30; attempt++) {
-      await new Promise((resolve) => setTimeout(resolve, 500));
-      listener = inspectListener();
-      if (listener === "loopback") break;
+    try {
+      systemd.restart(["iva.service"]);
+      for (let attempt = 0; attempt < 30; attempt++) {
+        await new Promise((resolve) => setTimeout(resolve, 500));
+        listener = inspectListener();
+        if (listener === "loopback") break;
+      }
+      if (listener === "loopback") (ok(`iva.service bound to loopback:${port}`), fixN++);
+      else (bad(`iva.service still exposed on port ${port}`), badN++);
+    } catch (e) {
+      (bad(e.message), badN++);
     }
-    if (listener === "loopback") (ok(`iva.service bound to loopback:${port}`), fixN++);
-    else (bad(`iva.service still exposed on port ${port}`), badN++);
   } else if (listener === "loopback") (ok(`iva.service bound to loopback:${port}`), okN++);
   else if (listener === "absent") (warn(`no listener found on port ${port}`), warnN++);
   else (warn("could not inspect listener addresses (ss unavailable)"), warnN++);
 
   // Background timers enabled
+  let timerFailed = false;
   for (const t of TIMERS) {
-    if (scQ("is-enabled", t).out === "enabled") okN++;
+    if (systemd.isEnabled(t) && systemd.isActive(t)) okN++;
     else {
-      warn(`${t} disabled — enabling…`);
-      sc("enable", "--now", t);
-      fixN++;
+      warn(`${t} disabled or inactive — enabling…`);
+      try {
+        systemd.activate([t]);
+        fixN++;
+      } catch (e) {
+        timerFailed = true;
+        (bad(e.message), badN++);
+      }
     }
   }
-  ok(`Background timers checked (${TIMERS.length}: ${MEMORY_TIMERS.length} memory + update check)`);
+  if (!timerFailed)
+    ok(`Background timers enabled and active (${TIMERS.length}: ${MEMORY_TIMERS.length} memory + update check)`);
 
   // 6. Vault + git origin (report only — we don't initiate git operations)
   const vaultRel = env.ASSISTANT_VAULT_DIR || "vault";
@@ -736,8 +775,10 @@ function cmdReset() {
   step("Full reset: stopping services…");
   // Fail closed: quarantining the store under a live eve corrupts state and resurrects
   // the very runs we're clearing — if stop failed, don't touch anything.
-  if (sc("stop", ...SERVICES).status !== 0) {
-    bad("systemctl stop failed — workflow and Telegram control state left untouched");
+  try {
+    systemd.stop(SERVICES);
+  } catch (e) {
+    bad(`${e.message} Workflow and Telegram control state left untouched`);
     process.exit(1);
   }
   let found = false;
@@ -756,25 +797,27 @@ function cmdReset() {
     }
   }
   if (!found && !failed) ok("workflow and Telegram control state already empty");
-  const restarted = restartServices();
-  if (failed) {
-    bad("Reset INCOMPLETE — old workflow or Telegram control state may still be active");
-    process.exit(1);
+  let restartError = null;
+  try {
+    restartServices();
+  } catch (e) {
+    restartError = e;
   }
-  if (!restarted) {
-    bad("systemctl restart failed — services may be down, check: iva logs");
-    process.exit(1);
+  if (restartError) {
+    bad(restartError.message);
   }
+  if (failed) bad("Reset INCOMPLETE — old workflow or Telegram control state may still be active");
+  if (failed || restartError) process.exit(1);
   ok("Restarted: iva + telegram-poll");
 }
 function cmdStart() {
   requireSystemd();
-  enableUnits();
+  activateUnits();
   ok("Started and enabled at boot");
 }
 function cmdStop() {
   requireSystemd();
-  sc("stop", ...SERVICES);
+  systemd.stop(SERVICES);
   ok("Stopped");
 }
 function cmdLogs(args) {
@@ -969,12 +1012,10 @@ function restartUserbotIfActive({
   requirementsPath = join(USERBOT_DIR, "requirements.lock"),
   requireHashes = true,
 } = {}) {
-  if (!knownActive && scQ("is-active", SVC_USERBOT).out !== "active") return;
+  if (!knownActive && !systemd.isActive(SVC_USERBOT)) return;
   if (!quiet) step("Обновляю userbot-прокси…");
   ensureUserbotVenv({ quiet, requirementsPath, requireHashes });
-  const restarted = quiet ? scQ("restart", SVC_USERBOT) : sc("restart", SVC_USERBOT);
-  const code = quiet ? restarted.code : (restarted.status ?? 1);
-  if (code !== 0) throw new Error(`${SVC_USERBOT}: restart failed; run: journalctl --user -u ${SVC_USERBOT} -n 100`);
+  systemd.restart([SVC_USERBOT]);
   if (!quiet) ok("userbot-прокси перезапущен на новом коде");
 }
 
@@ -1013,8 +1054,10 @@ function cmdUserbot(args) {
     ensureUserbotToken(); // 0600 token file both the proxy and iva's connection read at runtime
     ensureUserbotVenv(); // throws → dispatch catches → exit 1, service NOT enabled
     writeUnits();
-    sc("enable", SVC_USERBOT);
-    sc("restart", SVC_USERBOT); // restart (not just enable --now) so a rewritten unit / new creds load
+    systemd.activate([SVC_USERBOT]);
+    // enable --now is idempotent and does not reload an already-active proxy.
+    // Restart after syncing deps/writing the unit so fresh credentials and code are live.
+    systemd.restart([SVC_USERBOT]);
     // NOTE: do NOT restart iva here — the agent runs this mid-chat, and iva reads the token
     // from the file at call time, so no restart is needed (Eve retries the MCP connection).
     ok("Userbot-прокси включён. Подключи аккаунт по QR через бота: напиши боту «подключи мой телеграм».");
@@ -1022,7 +1065,7 @@ function cmdUserbot(args) {
     return;
   }
   if (sub === "off") {
-    scQ("disable", "--now", SVC_USERBOT);
+    systemd.disableNow([SVC_USERBOT]);
     ok("Userbot-прокси остановлен и выключен.");
     return;
   }
@@ -1053,8 +1096,13 @@ const cmds = {
   help: cmdHelp,
   "--help": cmdHelp,
   "-h": cmdHelp,
-  // internal subcommand — install.sh delegates unit writing here (DRY)
+  // Internal installer seams: one writer and the same checked activator used by
+  // `iva start` and doctor. Success is printed only after every unit is enabled and active.
   "_install-units": () => ok(`systemd units written: ${writeUnits().length}`),
+  "_activate-units": () => {
+    activateUnits();
+    ok(`systemd units enabled and active: ${SERVICES.length + TIMERS.length}`);
+  },
 };
 
 const fn = cmds[cmd];

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -1,5 +1,26 @@
 # Implementation notes
 
+## Checked systemd activation (IVA-003 / #54)
+
+- All CLI systemd mutations now go through `scripts/lib/systemd-control.mjs`. A non-zero
+  command raises a sanitized error with a fixed per-unit journal hint; captured command
+  output and process environment are never copied into diagnostics.
+- Activation is idempotent and succeeds only after every requested unit reports both
+  `enabled` and `active`. Restart also verifies the final active state.
+- `install.sh` keeps unit rendering in `_install-units` and delegates activation to the
+  same checked `_activate-units` seam used by `iva start` and doctor.
+- Doctor records individual activation failures and keeps checking neighboring units.
+  Destructive reset still stops fail-closed and attempts to restart services after a
+  partial quarantine failure.
+- Uninstall cleanup attempts every unit disable and file removal, then daemon reload and
+  failed-state reset. It reports a bounded aggregate error only after all steps run.
+- A verified update commits its transaction before activating the automatic update timer.
+  Timer activation failure keeps the verified build, exits non-zero, and uses a dedicated
+  diagnostic in terminal and Telegram instead of entering the build rollback path.
+- No activation polling was added. The activated long-running services use systemd's
+  synchronous `Type=simple` start semantics, and timer start jobs return in their active
+  waiting state, so a synthetic `activating` transition would not model these units.
+
 ## Aimasters.Me user-feedback backlog (2026-07-28)
 
 - Source evidence, issue triage, source-message links and links to attached screenshots/video are in

--- a/install.sh
+++ b/install.sh
@@ -593,25 +593,10 @@ elif prompt_yes_no "$(t "Set up autostart via systemd (service + memory timers)?
   # Delegate writing the units to the iva CLI — the single source of truth (see bin/iva.mjs writeUnits).
   step "$(t "Installing systemd units (via the iva CLI)…" "Ставлю systemd-юниты (через iva CLI)…")"
   node "$PROJECT_DIR/bin/iva.mjs" _install-units || die "$(t "couldn't write the systemd units" "не удалось записать systemd-юниты")"
-  poll_installed=1
-  timers_installed=1
-
-  systemctl --user enable --now iva.service
-  if [ "$poll_installed" -eq 1 ]; then
-    systemctl --user enable --now iva-telegram-poll.service \
-      && ok "$(t "Bot enabled and online" "Бот включён и на связи")" \
-      || warn "$(t "couldn't start iva-telegram-poll (manually: npm run poll)" "не удалось запустить iva-telegram-poll (вручную: npm run poll)")"
-  fi
-  if [ "$timers_installed" -eq 1 ]; then
-    for t in "$PROJECT_DIR"/deploy/iva-memory-*.timer; do
-      [ -e "$t" ] || continue
-      tname="$(basename "$t")"
-      systemctl --user enable --now "$tname" || warn "$(t "couldn't enable $tname" "не удалось включить $tname")"
-    done
-    systemctl --user enable --now iva-update-check.timer \
-      || warn "$(t "couldn't enable iva-update-check.timer" "не удалось включить iva-update-check.timer")"
-    ok "$(t "Memory timers enabled: systemctl --user list-timers" "Таймеры памяти включены: systemctl --user list-timers")"
-  fi
+  node "$PROJECT_DIR/bin/iva.mjs" _activate-units \
+    || die "$(t "couldn't enable and start the systemd units; follow the journal hint above" "не удалось включить и запустить systemd-юниты; проверьте подсказку journal выше")"
+  ok "$(t "Bot enabled and online" "Бот включён и на связи")"
+  ok "$(t "Memory timers enabled and active: systemctl --user list-timers" "Таймеры памяти включены и активны: systemctl --user list-timers")"
   loginctl enable-linger "$USER" >/dev/null 2>&1 || warn "$(t "couldn't enable linger (the service won't start before login)" "не удалось включить linger (сервис не стартует до логина)")"
   ok "$(t "Service started: systemctl --user status iva" "Сервис запущен: systemctl --user status iva")"
 
@@ -644,7 +629,7 @@ echo "${c_green}${c_bold}└─────────────────�
 echo
 if [ "$SETUP_DONE" != true ]; then
   echo "  ${c_yellow}${c_bold}$(t "Configure the keys first:" "Сначала настройте ключи:")${c_reset}  cd $PROJECT_DIR && npm run setup"
-  echo "  $(t "Then rebuild and start:" "Затем пересоберите и запустите:") npm run build && (systemctl --user restart iva)"
+  echo "  $(t "Then rebuild and start:" "Затем пересоберите и запустите:") npm run build && iva restart"
   echo
 fi
 echo "  ${c_bold}$(t "Commands (${c_green}iva${c_reset}${c_bold} — from anywhere):" "Команды (${c_green}iva${c_reset}${c_bold} — из любого места):")${c_reset}"

--- a/scripts/lib/systemd-control.mjs
+++ b/scripts/lib/systemd-control.mjs
@@ -1,0 +1,135 @@
+const UNIT_RE = /^[A-Za-z0-9_.@:-]+$/;
+
+function safeUnit(unit) {
+  if (!UNIT_RE.test(unit)) throw new Error(`invalid systemd unit: ${unit}`);
+  return unit;
+}
+
+function resultOf(result) {
+  return {
+    code: result?.code ?? result?.status ?? 1,
+    out: String(result?.out ?? result?.stdout ?? "").trim(),
+  };
+}
+
+function journalHint(unit) {
+  return `journalctl --user -u ${safeUnit(unit)} -n 100 --no-pager`;
+}
+
+export class SystemdControlError extends Error {
+  constructor(message, { unit, code } = {}) {
+    const suffix = unit ? ` Check: ${journalHint(unit)}` : "";
+    super(`${message}${code === undefined ? "" : ` (exit ${code})`}.${suffix}`);
+    this.name = "SystemdControlError";
+    this.unit = unit;
+    this.code = code;
+  }
+}
+
+export function cleanupSystemdUnits({ units, disable, remove, reload, reset }) {
+  const errors = [];
+  const attempt = (label, action) => {
+    try {
+      action();
+    } catch (cause) {
+      errors.push(new Error(`${label}: ${cause?.message || String(cause)}`, { cause }));
+    }
+  };
+
+  const checkedUnits = units.map(safeUnit);
+  for (const unit of checkedUnits) attempt(`disable ${unit}`, () => disable(unit));
+  for (const unit of checkedUnits) attempt(`remove ${unit}`, () => remove(unit));
+  attempt("daemon-reload", reload);
+  attempt("reset-failed", reset);
+
+  if (errors.length > 0) {
+    const shown = errors.slice(0, 8).map((error) => error.message.replace(/\s+/g, " ").slice(0, 240));
+    const omitted = errors.length - shown.length;
+    const detail = `${shown.join("; ")}${omitted > 0 ? `; ${omitted} more failure(s)` : ""}`;
+    throw new AggregateError(errors, `systemd unit cleanup failed: ${detail}`);
+  }
+  return checkedUnits;
+}
+
+export function createSystemdControl({ run }) {
+  if (typeof run !== "function") throw new TypeError("systemd control requires run(args)");
+
+  const query = (...args) => resultOf(run(args));
+
+  function mutate(args, unit) {
+    const result = query(...args);
+    if (result.code !== 0) {
+      throw new SystemdControlError(`systemctl --user ${args.join(" ")} failed`, {
+        unit,
+        code: result.code,
+      });
+    }
+    return result;
+  }
+
+  function isEnabled(unit) {
+    safeUnit(unit);
+    const result = query("is-enabled", unit);
+    return result.code === 0 && result.out === "enabled";
+  }
+
+  function isActive(unit) {
+    safeUnit(unit);
+    const result = query("is-active", unit);
+    return result.code === 0 && result.out === "active";
+  }
+
+  function requireEnabledActive(unit) {
+    safeUnit(unit);
+    if (!isEnabled(unit)) {
+      throw new SystemdControlError(`${unit} did not become enabled`, { unit });
+    }
+    if (!isActive(unit)) {
+      throw new SystemdControlError(`${unit} did not become active`, { unit });
+    }
+  }
+
+  return {
+    query,
+    isEnabled,
+    isActive,
+    activate(units) {
+      for (const unit of units) {
+        safeUnit(unit);
+        mutate(["enable", "--now", unit], unit);
+        requireEnabledActive(unit);
+      }
+    },
+    restart(units) {
+      for (const unit of units) {
+        safeUnit(unit);
+        mutate(["restart", unit], unit);
+        if (!isActive(unit)) {
+          throw new SystemdControlError(`${unit} did not become active after restart`, { unit });
+        }
+      }
+    },
+    stop(units) {
+      for (const unit of units) {
+        safeUnit(unit);
+        mutate(["stop", unit], unit);
+      }
+    },
+    disableNow(units) {
+      for (const unit of units) {
+        safeUnit(unit);
+        mutate(["disable", "--now", unit], unit);
+      }
+    },
+    resetFailed(units = []) {
+      if (units.length === 0) return mutate(["reset-failed"]);
+      for (const unit of units) {
+        safeUnit(unit);
+        mutate(["reset-failed", unit], unit);
+      }
+    },
+    daemonReload() {
+      return mutate(["daemon-reload"]);
+    },
+  };
+}

--- a/scripts/lib/systemd-control.test.mjs
+++ b/scripts/lib/systemd-control.test.mjs
@@ -1,0 +1,332 @@
+import { strict as assert } from "node:assert";
+import test from "node:test";
+import { spawnSync } from "node:child_process";
+import {
+  chmod,
+  copyFile,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import * as systemdControl from "./systemd-control.mjs";
+
+const { createSystemdControl } = systemdControl;
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
+const SECRET = "iva-systemd-test-secret-do-not-log";
+
+async function fixture(t) {
+  const dir = await mkdtemp(join(tmpdir(), "iva-systemd-activation-"));
+  t.after(() => rm(dir, { recursive: true, force: true }));
+
+  const project = join(dir, "iva");
+  const home = join(dir, "home");
+  const fakeBin = join(dir, "bin");
+  const calls = join(dir, "systemctl.calls");
+  const state = join(dir, "systemd-state");
+  const envPath = join(project, ".env");
+  const userbotDir = join(project, "services/telegram-userbot");
+  await mkdir(join(project, "bin"), { recursive: true });
+  await mkdir(join(project, ".output/server"), { recursive: true });
+  await mkdir(join(userbotDir, ".venv/bin"), { recursive: true });
+  await mkdir(home, { recursive: true });
+  await mkdir(fakeBin, { recursive: true });
+  await mkdir(state, { recursive: true });
+  await copyFile(join(ROOT, "bin/iva.mjs"), join(project, "bin/iva.mjs"));
+  await symlink(join(ROOT, "scripts"), join(project, "scripts"), "dir");
+  await symlink(join(ROOT, "deploy"), join(project, "deploy"), "dir");
+  await writeFile(join(project, ".output/server/index.mjs"), "");
+  await copyFile(
+    join(ROOT, "services/telegram-userbot/requirements.lock"),
+    join(userbotDir, "requirements.lock"),
+  );
+  await writeFile(join(userbotDir, ".venv/bin/python"), "#!/bin/sh\nexit 0\n");
+  await chmod(join(userbotDir, ".venv/bin/python"), 0o755);
+  await writeFile(
+    envPath,
+    `MODEL_PROVIDER=codex\nOPENAI_API_KEY=${SECRET}\nTELEGRAM_API_ID=12345\nTELEGRAM_API_HASH=old-desired-hash\n`,
+    { mode: 0o600 },
+  );
+
+  const fakeUv = join(fakeBin, "uv");
+  await writeFile(fakeUv, "#!/bin/sh\nexit 0\n");
+  await chmod(fakeUv, 0o755);
+
+  const fakeSystemctl = join(fakeBin, "systemctl");
+  await writeFile(
+    fakeSystemctl,
+    [
+      "#!/bin/sh",
+      'printf "%s\\n" "$*" >> "$IVA_FAKE_SYSTEMCTL_CALLS"',
+      '[ "$1" = "--user" ] && shift',
+      'action="$1"',
+      "shift",
+      'if [ "${IVA_FAKE_SYSTEMCTL_EXIT:-0}" -ne 0 ] && { [ -z "${IVA_FAKE_FAIL_ACTION:-}" ] || [ "$IVA_FAKE_FAIL_ACTION" = "$action" ]; }; then',
+      '  printf "fake systemctl failure: %s\\n" "$IVA_FAKE_SECRET_OUTPUT" >&2',
+      '  exit "$IVA_FAKE_SYSTEMCTL_EXIT"',
+      "fi",
+      'case "$action" in',
+      "  enable)",
+      '    [ "${1:-}" = "--now" ] && shift',
+      '    unit="$1"',
+      '    : > "$IVA_FAKE_SYSTEMD_STATE/$unit.enabled"',
+      '    if [ "${IVA_FAKE_INACTIVE_UNIT:-}" != "$unit" ]; then : > "$IVA_FAKE_SYSTEMD_STATE/$unit.active"; fi',
+      "    ;;",
+      "  restart)",
+      '    unit="$1"',
+      '    if [ "${IVA_FAKE_INACTIVE_UNIT:-}" != "$unit" ]; then : > "$IVA_FAKE_SYSTEMD_STATE/$unit.active"; fi',
+      "    ;;",
+      "  stop)",
+      '    rm -f "$IVA_FAKE_SYSTEMD_STATE/$1.active"',
+      "    ;;",
+      "  disable)",
+      '    [ "${1:-}" = "--now" ] && shift',
+      '    rm -f "$IVA_FAKE_SYSTEMD_STATE/$1.enabled" "$IVA_FAKE_SYSTEMD_STATE/$1.active"',
+      "    ;;",
+      "  is-enabled)",
+      '    if [ -f "$IVA_FAKE_SYSTEMD_STATE/$1.enabled" ]; then echo enabled; else echo disabled; exit 1; fi',
+      "    ;;",
+      "  is-active)",
+      '    if [ -f "$IVA_FAKE_SYSTEMD_STATE/$1.active" ]; then echo active; else echo inactive; exit 3; fi',
+      "    ;;",
+      "esac",
+      "",
+    ].join("\n"),
+  );
+  await chmod(fakeSystemctl, 0o755);
+
+  const runCommand = (command, { args = [], exit = 0, failAction = "", inactiveUnit = "" } = {}) =>
+    spawnSync(process.execPath, [join(project, "bin/iva.mjs"), command, ...args], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        HOME: home,
+        NO_COLOR: "1",
+        PATH: `${fakeBin}:/usr/bin:/bin`,
+        IVA_FAKE_SYSTEMCTL_CALLS: calls,
+        IVA_FAKE_SYSTEMCTL_EXIT: String(exit),
+        IVA_FAKE_FAIL_ACTION: failAction,
+        IVA_FAKE_SECRET_OUTPUT: SECRET,
+        IVA_FAKE_SYSTEMD_STATE: state,
+        IVA_FAKE_INACTIVE_UNIT: inactiveUnit,
+      },
+    });
+
+  return {
+    calls,
+    envPath,
+    runStart: (exit = 0) => runCommand("start", { exit }),
+    runCommand,
+    async seedQuarantineFailure() {
+      const eveDir = join(project, ".eve");
+      await mkdir(join(eveDir, ".workflow-data"), { recursive: true });
+      await chmod(eveDir, 0o500);
+    },
+    async seedUnit(unit) {
+      await writeFile(join(state, `${unit}.enabled`), "");
+      await writeFile(join(state, `${unit}.active`), "");
+    },
+  };
+}
+
+test("iva start propagates a systemctl enable failure", async (t) => {
+  const { runStart } = await fixture(t);
+  const result = runStart(1);
+
+  assert.equal(result.status, 1, result.stderr || result.stdout);
+});
+
+test("iva start does not print success after a systemctl enable failure", async (t) => {
+  const { runStart } = await fixture(t);
+  const result = runStart(1);
+  const output = `${result.stdout}\n${result.stderr}`;
+
+  assert.doesNotMatch(output, /Started and enabled at boot/);
+});
+
+test("iva start is idempotent when systemctl reports success", async (t) => {
+  const { calls, runStart } = await fixture(t);
+  const first = runStart();
+  assert.equal(first.status, 0, first.stderr || first.stdout);
+  const firstCalls = (await readFile(calls, "utf8")).trim().split("\n");
+
+  const second = runStart();
+  assert.equal(second.status, 0, second.stderr || second.stdout);
+  const allCalls = (await readFile(calls, "utf8")).trim().split("\n");
+
+  assert.deepEqual(allCalls.slice(firstCalls.length), firstCalls);
+});
+
+test("iva start diagnostics do not expose .env secrets", async (t) => {
+  const { runStart } = await fixture(t);
+  const result = runStart(1);
+  const output = `${result.stdout}\n${result.stderr}`;
+
+  assert.doesNotMatch(output, new RegExp(SECRET));
+});
+
+test("iva start reports the exact unit journal after activation fails", async (t) => {
+  const { runStart } = await fixture(t);
+  const result = runStart(1);
+  const output = `${result.stdout}\n${result.stderr}`;
+
+  assert.match(output, /journalctl --user -u iva\.service -n 100 --no-pager/);
+  assert.doesNotMatch(output, /fake systemctl failure/);
+});
+
+test("iva start waits for enabled and active postconditions", async (t) => {
+  const { runCommand } = await fixture(t);
+  const result = runCommand("start", { inactiveUnit: "iva.service" });
+  const output = `${result.stdout}\n${result.stderr}`;
+
+  assert.equal(result.status, 1, output);
+  assert.match(output, /iva\.service did not become active/);
+  assert.doesNotMatch(output, /Started and enabled at boot/);
+});
+
+test("installer activation seam uses the same checked CLI path", async (t) => {
+  const { runCommand } = await fixture(t);
+  const result = runCommand("_activate-units", { exit: 1 });
+
+  assert.equal(result.status, 1, result.stderr || result.stdout);
+  const installer = await readFile(join(ROOT, "install.sh"), "utf8");
+  assert.match(installer, /bin\/iva\.mjs" _activate-units/);
+  assert.doesNotMatch(installer, /^\s*systemctl --user enable --now/m);
+});
+
+test("doctor reports checked activation failures and keeps its summary", async (t) => {
+  const { runCommand } = await fixture(t);
+  const result = runCommand("doctor", { exit: 1, failAction: "enable" });
+  const output = `${result.stdout}\n${result.stderr}`;
+
+  assert.equal(result.status, 1, output);
+  assert.match(output, /journalctl --user -u iva\.service -n 100 --no-pager/);
+  assert.match(output, /Summary:/);
+  assert.doesNotMatch(output, /Units installed, enabled and active/);
+});
+
+test("userbot setup restarts an already enabled and active unit for new desired config", async (t) => {
+  const { calls, envPath, runCommand, seedUnit } = await fixture(t);
+  await seedUnit("iva-telegram-userbot.service");
+  await writeFile(
+    envPath,
+    `MODEL_PROVIDER=codex\nOPENAI_API_KEY=${SECRET}\nTELEGRAM_API_ID=12345\nTELEGRAM_API_HASH=new-desired-hash\n`,
+    { mode: 0o600 },
+  );
+
+  const result = runCommand("userbot", { args: ["setup"] });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const systemctlCalls = (await readFile(calls, "utf8")).trim().split("\n");
+  const enableAt = systemctlCalls.indexOf("--user enable --now iva-telegram-userbot.service");
+  const restartAt = systemctlCalls.indexOf("--user restart iva-telegram-userbot.service");
+
+  assert.ok(enableAt >= 0, systemctlCalls.join("\n"));
+  assert.ok(restartAt > enableAt, systemctlCalls.join("\n"));
+});
+
+test("every systemd mutation rejects a non-zero command", () => {
+  const control = createSystemdControl({
+    run: () => ({ code: 1, out: "", err: `ignored ${SECRET}` }),
+  });
+
+  const rejectsSafely = (action) =>
+    assert.throws(action, (error) => {
+      assert.doesNotMatch(error.message, new RegExp(SECRET));
+      return true;
+    });
+
+  rejectsSafely(() => control.activate(["iva.service"]));
+  rejectsSafely(() => control.restart(["iva.service"]));
+  rejectsSafely(() => control.stop(["iva.service"]));
+  rejectsSafely(() => control.disableNow(["iva.service"]));
+  rejectsSafely(() => control.resetFailed(["iva.service"]));
+  rejectsSafely(() => control.daemonReload());
+});
+
+test("iva reset keeps quarantine-only and restart-only diagnostics distinct", async (t) => {
+  await t.test("quarantine failure only", async (t) => {
+    const { runCommand, seedQuarantineFailure } = await fixture(t);
+    await seedQuarantineFailure();
+    const result = runCommand("reset");
+    const output = `${result.stdout}\n${result.stderr}`;
+
+    assert.equal(result.status, 1, output);
+    assert.match(output, /Reset INCOMPLETE/);
+    assert.doesNotMatch(output, /systemctl --user restart .* failed/);
+  });
+
+  await t.test("restart failure only", async (t) => {
+    const { runCommand } = await fixture(t);
+    const result = runCommand("reset", { exit: 1, failAction: "restart" });
+    const output = `${result.stdout}\n${result.stderr}`;
+
+    assert.equal(result.status, 1, output);
+    assert.match(output, /systemctl --user restart iva\.service failed/);
+    assert.doesNotMatch(output, /Reset INCOMPLETE/);
+  });
+});
+
+test("iva reset reports both failures when quarantine and restart fail", async (t) => {
+  const { runCommand, seedQuarantineFailure } = await fixture(t);
+  await seedQuarantineFailure();
+  const result = runCommand("reset", { exit: 1, failAction: "restart" });
+  const output = `${result.stdout}\n${result.stderr}`;
+
+  assert.equal(result.status, 1, output);
+  assert.match(output, /systemctl --user restart iva\.service failed/);
+  assert.match(output, /Reset INCOMPLETE/);
+  assert.doesNotMatch(output, new RegExp(SECRET));
+  assert.doesNotMatch(output, /fake systemctl failure/);
+});
+
+test("unit removal finishes every cleanup step before reporting aggregated failures", () => {
+  const calls = [];
+  const units = ["iva.service", "iva-update-check.timer"];
+  let successReported = false;
+
+  assert.throws(
+    () => {
+      systemdControl.cleanupSystemdUnits({
+        units,
+        disable: (unit) => {
+          calls.push(`disable:${unit}`);
+          if (unit === "iva.service") throw new Error("disable failed");
+        },
+        remove: (unit) => {
+          calls.push(`remove:${unit}`);
+        },
+        reload: () => {
+          calls.push("reload");
+          throw new Error("reload failed");
+        },
+        reset: () => {
+          calls.push("reset");
+        },
+      });
+      successReported = true;
+    },
+    (error) => {
+      assert.ok(error instanceof AggregateError);
+      assert.equal(error.errors.length, 2);
+      assert.match(error.message, /disable iva\.service: disable failed/);
+      assert.match(error.message, /daemon-reload: reload failed/);
+      return true;
+    },
+  );
+
+  assert.equal(successReported, false);
+  assert.deepEqual(calls, [
+    "disable:iva.service",
+    "disable:iva-update-check.timer",
+    "remove:iva.service",
+    "remove:iva-update-check.timer",
+    "reload",
+    "reset",
+  ]);
+});

--- a/scripts/lib/telegram-status.mjs
+++ b/scripts/lib/telegram-status.mjs
@@ -15,6 +15,7 @@ const COPY = {
     protect: ["Saving your changes", "Changes saved", "Couldn't save your changes"],
     fetch: ["Getting the update", "Update received", "Couldn't get the update"],
     build: ["Building Iva", "Iva built", "Couldn't build Iva"],
+    timerFailure: "Iva is ready, but the automatic update timer could not be activated",
     final: "✅ Iva updated",
     preserved: "Local changes: preserved",
     failure: (version) => `Iva is still running ${version}.\nYour settings and changes are preserved.\nRetry: /update`,
@@ -23,6 +24,7 @@ const COPY = {
     protect: ["Сохраняю ваши изменения", "Изменения сохранены", "Не удалось сохранить изменения"],
     fetch: ["Получаю обновление", "Обновление получено", "Не удалось получить обновление"],
     build: ["Собираю Iva", "Iva собрана", "Не удалось собрать Iva"],
+    timerFailure: "Iva готова, но таймер автоматических обновлений не удалось активировать",
     final: "✅ Iva обновлена",
     preserved: "Локальные изменения: сохранены",
     failure: (version) => `Iva продолжает работать на ${version}.\nВаши настройки и изменения сохранены.\nПовторить: /update`,
@@ -133,6 +135,10 @@ export function createTelegramUpdateReporter({ token, job, env, fetchImpl = fetc
       const reason = copy[phase][2];
       currentPhase = null;
       await finish(`⚠️ ${reason}\n\n${copy.failure(beforeVersion)}`);
+    },
+    async postCommitFailure(message) {
+      currentPhase = null;
+      await finish(`⚠️ ${copy.timerFailure}\n\n${message}`);
     },
     async complete({ beforeVersion, afterVersion }) {
       const model = modelSummary(env);

--- a/scripts/lib/update-check.test.mjs
+++ b/scripts/lib/update-check.test.mjs
@@ -221,7 +221,19 @@ test("systemd templates schedule a persistent 10:00 local check and lifecycle co
   assert.match(service, /EnvironmentFile=__PROJECT_DIR__\/\.env/);
   assert.match(cli, /const TIMERS = \[\.\.\.MEMORY_TIMERS, UPDATE_TIMER\]/);
   assert.match(cli, /replaceAll\("__TIMEZONE__", timezone\)/);
-  assert.match(cli, /"enable", "--now", UPDATE_TIMER/);
-  assert.match(installer, /enable --now iva-update-check\.timer/);
+  assert.match(cli, /systemd\.activate\(\[UPDATE_TIMER\]\)/);
+  assert.match(installer, /bin\/iva\.mjs" _activate-units/);
   assert.match(pollService, /ExecStartPost=-\/usr\/bin\/systemctl --user enable --now iva-update-check\.timer/);
+});
+
+test("a post-commit timer failure exits without rollback or a false update claim", () => {
+  const cli = readFileSync(new URL("../../bin/iva.mjs", import.meta.url), "utf8");
+
+  assert.match(cli, /Iva is ready, but the automatic update timer could not be activated/);
+  assert.doesNotMatch(cli, /timerFailure: "Iva updated/);
+  assert.match(
+    cli,
+    /const finalizeUpdate = async \(\) => \{[\s\S]*?commitThenRunPostCommit[\s\S]*?terminal\.fail\(text\.timerFailure\)[\s\S]*?process\.exitCode = 1;[\s\S]*?return false;/,
+  );
+  assert.equal(cli.match(/if \(!\(await finalizeUpdate\(\)\)\) return;/g)?.length, 2);
 });

--- a/scripts/lib/update-safety.mjs
+++ b/scripts/lib/update-safety.mjs
@@ -99,6 +99,16 @@ export function releaseUpdateLock(lock) {
   rmSync(lock.path, { recursive: true, force: true });
 }
 
+export async function commitThenRunPostCommit({ commit, postCommit }) {
+  await commit();
+  try {
+    await postCommit();
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, error };
+  }
+}
+
 function parseVersion(text) {
   try {
     return JSON.parse(text).version || null;

--- a/scripts/lib/update-ui.test.mjs
+++ b/scripts/lib/update-ui.test.mjs
@@ -307,6 +307,26 @@ test("update lock is exclusive and owner-reentrant", () => {
   assert.equal(acquireUpdateLock(dir, "two").ok, true);
 });
 
+test("verified update commits before timer activation and contains a timer failure", async () => {
+  const updateSafety = await import("./update-safety.mjs");
+  assert.equal(typeof updateSafety.commitThenRunPostCommit, "function");
+
+  const calls = [];
+  const timerError = new Error("timer activation failed");
+  const result = await updateSafety.commitThenRunPostCommit({
+    commit: async () => {
+      calls.push("commit");
+    },
+    postCommit: async () => {
+      calls.push("timer");
+      throw timerError;
+    },
+  });
+
+  assert.deepEqual(calls, ["commit", "timer"]);
+  assert.deepEqual(result, { ok: false, error: timerError });
+});
+
 function git(cwd, ...args) {
   return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
 }


### PR DESCRIPTION
Closes #54

## RED

`node --test scripts/lib/systemd-control.test.mjs`

Initial RED: fake `systemctl` exit 1 let `iva start` exit 0 and print success. Review REDs then reproduced stale userbot state after repeated setup, teardown aborting after the first stale unit, rollback of a healthy update when only timer activation failed, and a reset that hid its simultaneous restart failure.

## GREEN

- One checked adapter owns systemd mutations for CLI, doctor and installer.
- Non-zero status propagates; success appears only after enabled/active postconditions.
- Diagnostics name the exact unit and fixed `journalctl` command while subprocess output and `.env` secrets stay out.
- Installer delegates activation to the same CLI seam.
- Userbot setup performs a checked restart after activation.
- Teardown completes every cleanup step and reports an aggregate failure.
- A post-commit timer failure preserves the healthy update and reports the remaining repair.
- Reset reports both quarantine and restart failures.

Focused systemd checks: 15/15. Typecheck, `bash -n install.sh`, Eve build and `git diff --check`: green locally. Complete GitHub `verify`: green at head `4b65c6b`.

## UX before/after

Before: installation/start could say success while services were down, repeated userbot setup could keep stale credentials, and partial failures could hide the useful diagnosis. After: failures are explicit, the exact unit journal is shown, and successful setup means the running process loaded the new state.

## Review gate

Two blind review rounds and CodeRabbit completed. Verified findings were reproduced through RED/GREEN cycles; all inline review threads are resolved. A proposed polling/stability expansion had no actual-systemd reproduction and is not part of this scoped adapter fix.