### PR TITLE
fix: make Telegram follow-up queue durable

### DIFF
--- a/agent/channels/telegram.ts
+++ b/agent/channels/telegram.ts
@@ -1,4 +1,8 @@
-import { telegramChannel, type TelegramMessageBody } from "eve/channels/telegram";
+import {
+  telegramChannel,
+  type TelegramChannelState,
+  type TelegramMessageBody,
+} from "eve/channels/telegram";
 import { POST } from "eve/channels";
 import { appendFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
@@ -21,6 +25,12 @@ import {
 import { tr } from "../../scripts/lib/i18n.mjs";
 import { buildTelegramReplyContext } from "../../scripts/lib/telegram-reply-context.mjs";
 import { handleTelegramResetRequest } from "../../scripts/lib/telegram-reset-route.mjs";
+import {
+  handleAcceptedTelegramWebhook,
+  TELEGRAM_ACCEPTANCE_ROUTE,
+  wrapTelegramQueueOnMessage,
+} from "../../scripts/lib/telegram-acceptance.mjs";
+import { publishTelegramTurnStarted } from "../../scripts/lib/telegram-turn-start.mjs";
 import { pathToFileURL } from "node:url";
 
 // Токен (TELEGRAM_BOT_TOKEN) и секрет вебхука (TELEGRAM_WEBHOOK_SECRET_TOKEN)
@@ -394,23 +404,22 @@ const telegram = telegramChannel({
     }
   },
   events: {
-    // Начало хода: статус-сообщение с кнопкой [⏹ Стоп] + запись running в run-status
-    // (по ней мост буферизует новые сообщения до конца хода).
+    // Начало хода: сначала публикуем running, затем отправляем медленное статус-сообщение.
+    // FIFO-мост не должен успеть принять следующую голову, пока Bot API отвечает.
     async "turn.started"(data, channel, ctx) {
       const tg = channel.telegram;
-      let statusMessageId: number | null = null;
-      try {
-        statusMessageId = await sendWorkingStatus(tg);
-      } catch (e) {
-        console.error("[telegram] статус-сообщение не отправилось:", e);
-      }
-      setChatStatus(chatKeyOf(tg.chatId, tg.messageThreadId), {
-        status: "running",
+      await publishTelegramTurnStarted({
+        chatKey: chatKeyOf(tg.chatId, tg.messageThreadId),
         continuationToken: channel.continuationToken,
         sessionId: ctx.session.id,
         turnId: data.turnId,
-        statusMessageId,
-        wasCancelled: null,
+        setStatusImpl: setChatStatus,
+        setStatusIfImpl: setChatStatusIf,
+        sendWorkingStatusImpl: () => sendWorkingStatus(tg),
+        removeWorkingStatusImpl: (messageId) =>
+          tg.request("deleteMessage", { chat_id: tg.chatId, message_id: messageId }),
+        onWorkingStatusError: (error) =>
+          console.error("[telegram] статус-сообщение не отправилось:", error),
       });
     },
     async "turn.completed"(_data, channel, ctx) {
@@ -517,7 +526,7 @@ const telegram = telegramChannel({
       }
     },
   },
-  async onMessage(ctx, message) {
+  onMessage: wrapTelegramQueueOnMessage(async (ctx, message) => {
     const userId = message.from?.id;
 
     // 1. Allowlist — главный барьер доступа.
@@ -543,10 +552,10 @@ const telegram = telegramChannel({
       return null; // дропаем апдейт
     }
 
-    // 1a-стоп. Наследие ESC-остановки: пометка о прерванном ходе + сообщения, которые
-    // мост копил, пока шёл ход (data/telegram-queue.json), и вложил в этот апдейт
-    // строками (message.raw.iva_buffered). Семантика Claude Code: буфер попадает в
-    // контекст, но обрабатывается только вместе со СЛЕДУЮЩИМ сообщением — этим.
+    // 1a-стоп. Пометка о прерванном ходе + совместимость с апдейтом от старого bridge,
+    // который приклеивал busy-time строки в message.raw.iva_buffered. Текущий bridge
+    // хранит исходные апдейты в durable FIFO и доставляет их самостоятельно; этот путь
+    // нужен только для безопасного rolling upgrade уже подготовленного carrier-апдейта.
     const stopKey = chatKeyOf(message.chat.id, message.messageThreadId);
     const operationalPreContext: string[] = [];
     if (getChatStatus(stopKey)?.wasCancelled) {
@@ -837,8 +846,18 @@ const telegram = telegramChannel({
       }
     }
     return withPre({ auth: buildAuth(message) });
-  },
+  }),
 });
+
+const telegramWebhookRoute = telegram.routes.find(
+  (route) =>
+    route.transport !== "websocket" &&
+    route.method === "POST" &&
+    route.path === "/eve/v1/telegram",
+);
+if (!telegramWebhookRoute || telegramWebhookRoute.transport === "websocket") {
+  throw new Error("telegramChannel did not expose its expected webhook route");
+}
 
 // The generic eveChannel reset endpoint owns the "eve" continuation namespace,
 // while these sessions belong to "telegram". Keep reset on the same authored
@@ -847,6 +866,8 @@ export default {
   ...telegram,
   routes: [
     ...telegram.routes,
+    POST<TelegramChannelState>(TELEGRAM_ACCEPTANCE_ROUTE, (request, args) =>
+      handleAcceptedTelegramWebhook(telegramWebhookRoute.handler, request, args)),
     POST("/eve/v1/telegram/reset", (req, { reset }) =>
       handleTelegramResetRequest(req, reset, process.env.TELEGRAM_WEBHOOK_SECRET_TOKEN)),
   ],

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -72,6 +72,67 @@
   result contract, cwd reporting and truncation marker. After bounded group cleanup, inherited
   output pipes are closed so a process outside the owned group cannot hold the tool call open.
 
+## IVA-008 durable Telegram follow-up FIFO
+
+- Busy-time follow-ups are stored in `data/telegram-queue.json` as schema version 1.
+  Every FIFO item has its own version, the Telegram `update_id`, enqueue time, and the
+  untouched raw update. The bridge does not download files or reconstruct quoted data
+  while queueing.
+- A queue write stages a unique 0600 file, fsyncs it, renames it atomically, and fsyncs
+  the parent directory. Write, rename, and durability failures propagate to the polling
+  loop. The Telegram offset advances only after enqueue succeeds. A duplicate retry also
+  repeats the atomic write, closing the window where rename was visible but directory
+  durability was not yet confirmed.
+- Delivery is at-least-once. Queued replay uses an authenticated authored route which
+  runs Eve's production Telegram handler and returns HTTP 204 only after its deferred
+  `send()` has resolved, or after the authored `onMessage` explicitly resolves to `null`
+  for a marked queue replay (for example a location saved to the daily log or a silent
+  sticker). The random replay marker exists only in the outbound copy and is removed
+  before authored message handling. Throws, malformed input, unmarked no-send paths and
+  rejected `send()` calls do not produce a receipt. The durable head stays present until
+  that receipt; an ordinary webhook HTTP 200 is not acceptance. A crash after acceptance
+  and before the removal write can replay that one head; later items cannot pass it. If
+  Before publishing an acknowledgement removal, the bridge fsyncs the original document
+  as a pending-ack backup beside the queue. Successful acknowledgement durably removes
+  that backup. Startup and every queue load restore any surviving backup first, closing
+  the SIGKILL window between removal rename and directory fsync. A failed rollback raises
+  a fatal durability error and stops polling.
+- The bridge drains one eligible head per idle private chat, group, or forum topic per
+  pass. One five-second budget covers the whole pass, and the next pass rotates past the
+  last attempted key, so many stalled heads cannot multiply polling latency or starve a
+  later chat. A failing head stays durable for a later pass. A short long-poll while
+  queues exist observes terminal events quickly. A stale run-status also becomes
+  drainable through the existing `isRunning()` TTL.
+- `turn.started` publishes `running` before the Bot API working-status request. After an
+  accepted queued turn, an in-memory per-key gate must observe that `running` state and
+  its later idle transition before the next FIFO head can start. Every per-chat status
+  write advances a generation, so a running-to-idle cycle completed between bridge polls
+  also releases the gate. If no status write is observable, the gate uses the same bounded
+  stale-run horizon as `isRunning()` and still refuses release while a run is visible.
+  Intentionally handled no-send updates are identified by the authored acceptance route
+  and bypass this turn gate.
+- Private `/new` and `/restart` write and fsync a per-chat reset intent before asking Eve
+  to reset. Queue cleanup and the idle tombstone happen after remote success, then the
+  intent is durably removed. Startup reconciles every remaining intent before polling or
+  queue draining, so a crash or ambiguous response after remote success cannot release
+  messages from the retired private session.
+- New updates join an existing FIFO even during the idle transition, preserving arrival
+  order. Replies to bot messages and callbacks retain their immediate HITL path.
+- Queue admission is fail-closed on `TELEGRAM_ALLOWED_USER_IDS`. Private owner messages
+  are eligible; group/topic messages additionally need a bot command or mention.
+  Mentions match the exact Telegram username with Unicode-aware token boundaries and
+  validated UTF-16 Telegram entities. Unaddressed group traffic is consumed without
+  entering later model context.
+- Each successful enqueue gets a reaction plus an explicit per-chat/topic queue count.
+  The count is sent after the durable write and offset update.
+- Legacy `{chatKey: string[]}` files migrate atomically. Each string becomes a versioned
+  item with a stable synthetic update id and remains present until accepted by Eve.
+  Group/topic text whose sender was not recorded is published to a unique, fsynced
+  `.legacy-unattributed-*` sidecar through a no-clobber hard link; the exact path is
+  logged and a later migration cannot overwrite an earlier archive.
+- Queue maps use own data properties for every chat key, including `__proto__`, so JSON
+  migration, enqueue, reload, and acknowledgement cannot silently lose that key.
+
 ## Aimasters.Me user-feedback backlog (2026-07-28)
 
 - Source evidence, issue triage, source-message links and links to attached screenshots/video are in

--- a/scripts/fixtures/telegram-poll-queue-harness.mjs
+++ b/scripts/fixtures/telegram-poll-queue-harness.mjs
@@ -1,0 +1,330 @@
+import { mock } from "node:test";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const [mode, dataDir, fault = "none"] = process.argv.slice(2);
+if (!mode || !dataDir) throw new Error("usage: harness <mode> <data-dir> [fault]");
+
+process.env.ASSISTANT_DATA_DIR = dataDir;
+process.env.ASSISTANT_HOST = "http://iva-red.invalid";
+process.env.TELEGRAM_BOT_TOKEN = "999:test-token";
+process.env.TELEGRAM_WEBHOOK_SECRET_TOKEN = "test-secret";
+process.env.TELEGRAM_ALLOWED_USER_IDS = "42";
+process.env.TELEGRAM_POLL_SETTLE_MS = "0";
+process.env.AGENT_LANGUAGE = "en";
+
+mkdirSync(dataDir, { recursive: true });
+const offsetFile = join(dataDir, "telegram-offset.json");
+const queueFile = join(dataDir, "telegram-queue.json");
+const resultFile = join(dataDir, "queue-harness-result.json");
+if (!existsSync(offsetFile)) writeFileSync(offsetFile, JSON.stringify({ offset: 100 }));
+let queueDirSyncAttempts = 0;
+let queueDirSyncSuccesses = 0;
+
+const status = await import("../lib/run-status.mjs");
+const privateKey = "1:";
+const groupKey = "-100:";
+const topicKey = "-100:7";
+
+if (
+  mode === "disk-failure" ||
+  mode === "dir-sync-retry" ||
+  mode === "auto-drain" ||
+  mode === "restart-persist" ||
+  mode === "routing"
+) {
+  status.setChatStatus(privateKey, {
+    status: "running",
+    continuationToken: "1::",
+    sessionId: "session-1",
+    turnId: "turn-1",
+  });
+} else if (mode === "restart-drain") {
+  status.setChatStatus(privateKey, {
+    status: "idle",
+    continuationToken: "1::",
+    sessionId: null,
+    turnId: null,
+  });
+}
+if (mode === "group-noise" || mode === "routing") {
+  status.setChatStatus(groupKey, {
+    status: "running",
+    continuationToken: "-100::reply-anchor",
+    sessionId: "session-group",
+    turnId: "turn-group",
+  });
+}
+if (mode === "routing") {
+  status.setChatStatus(topicKey, {
+    status: "running",
+    continuationToken: "-100:7:reply-anchor",
+    sessionId: "session-topic",
+    turnId: "turn-topic",
+  });
+}
+
+if (fault !== "none") {
+  const fsPromises = await import("node:fs/promises");
+  const namedExports = Object.fromEntries(
+    Object.entries(fsPromises).filter(([name]) => name !== "default"),
+  );
+  const originalWriteFile = fsPromises.writeFile;
+  const originalRename = fsPromises.rename;
+  const originalOpen = fsPromises.open;
+  namedExports.writeFile = async (path, ...args) => {
+    if (fault === "write" && String(path).startsWith(`${queueFile}.tmp-`)) {
+      throw Object.assign(new Error("injected queue write failure"), { code: "ENOSPC" });
+    }
+    return originalWriteFile(path, ...args);
+  };
+  namedExports.rename = async (from, to, ...args) => {
+    if (fault === "rename" && String(to) === queueFile) {
+      throw Object.assign(new Error("injected queue rename failure"), { code: "EIO" });
+    }
+    return originalRename(from, to, ...args);
+  };
+  namedExports.open = async (path, flags, ...args) => {
+    const handle = await originalOpen(path, flags, ...args);
+    if (fault !== "dir-sync-once" || String(path) !== dataDir || flags !== "r") {
+      return handle;
+    }
+    return {
+      sync: async () => {
+        queueDirSyncAttempts++;
+        if (queueDirSyncAttempts === 1) {
+          throw Object.assign(new Error("injected queue directory sync failure"), {
+            code: "EIO",
+          });
+        }
+        await handle.sync();
+        queueDirSyncSuccesses++;
+      },
+      close: () => handle.close(),
+    };
+  };
+  mock.module("node:fs/promises", {
+    defaultExport: fsPromises.default,
+    namedExports,
+  });
+}
+
+const privateUpdate = (updateId, text, chatId = 1) => ({
+  update_id: updateId,
+  message: {
+    message_id: updateId,
+    date: 1,
+    chat: { id: chatId, type: "private" },
+    from: { id: 42, is_bot: false, first_name: "Owner" },
+    text,
+  },
+});
+const groupNoiseUpdate = {
+  update_id: 102,
+  message: {
+    message_id: 102,
+    date: 1,
+    chat: { id: -100, type: "supergroup", title: "Test group" },
+    from: { id: 42, is_bot: false, first_name: "Owner" },
+    text: "side conversation, not addressed to Iva",
+  },
+};
+const groupUpdate = (updateId, text, threadId) => ({
+  update_id: updateId,
+  message: {
+    message_id: updateId,
+    date: 1,
+    chat: { id: -100, type: "supergroup", title: "Test group" },
+    from: { id: 42, is_bot: false, first_name: "Owner" },
+    text,
+    ...(threadId === undefined ? {} : { message_thread_id: threadId }),
+  },
+});
+
+const deliveries = [];
+const deliveryRoutes = [];
+const reactions = [];
+const queueStatuses = [];
+const requestedOffsets = [];
+let getUpdatesCalls = 0;
+
+const jsonResponse = (payload, statusCode = 200) => ({
+  ok: statusCode >= 200 && statusCode < 300,
+  status: statusCode,
+  headers: {
+    get: (name) =>
+      statusCode === 204 && String(name).toLowerCase() === "x-iva-telegram-acceptance"
+        ? "turn"
+        : null,
+  },
+  body: null,
+  json: async () => payload,
+});
+
+function readJson(path, fallback) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return fallback;
+  }
+}
+
+function finish() {
+  writeFileSync(
+    resultFile,
+    JSON.stringify({
+      deliveries,
+      deliveryRoutes,
+      reactions,
+      queueStatuses,
+      requestedOffsets,
+      queueDirSyncAttempts,
+      queueDirSyncSuccesses,
+      offset: readJson(offsetFile, null),
+      queue: readJson(queueFile, {}),
+    }),
+  );
+  process.exit(0);
+}
+
+if (mode === "fair-drain") {
+  writeFileSync(queueFile, JSON.stringify({
+    version: 1,
+    queues: {
+      "1:": [{
+        version: 1,
+        updateId: 101,
+        enqueuedAt: 1,
+        update: privateUpdate(101, "poison head", 1),
+      }],
+      "2:": [{
+        version: 1,
+        updateId: 102,
+        enqueuedAt: 2,
+        update: privateUpdate(102, "healthy head", 2),
+      }],
+    },
+  }));
+}
+
+globalThis.fetch = async (url, options = {}) => {
+  const target = String(url);
+  if (target.startsWith("http://iva-red.invalid/")) {
+    deliveryRoutes.push(new URL(target).pathname);
+    const delivery = JSON.parse(options.body);
+    deliveries.push(delivery);
+    if (
+      mode === "fair-drain" &&
+      new URL(target).pathname === "/eve/v1/telegram/accepted" &&
+      delivery.message?.chat?.id === 1
+    ) {
+      return jsonResponse({}, 503);
+    }
+    if (
+      (mode === "auto-drain" || mode === "restart-drain") &&
+      new URL(target).pathname === "/eve/v1/telegram/accepted"
+    ) {
+      status.setChatStatus(privateKey, {
+        status: "running",
+        sessionId: `session-${delivery.update_id}`,
+        turnId: `turn-${delivery.update_id}`,
+      });
+    }
+    return jsonResponse(
+      {},
+      new URL(target).pathname === "/eve/v1/telegram/accepted" ? 204 : 200,
+    );
+  }
+
+  const method = new URL(target).pathname.split("/").at(-1);
+  const body = options.body ? JSON.parse(options.body) : {};
+  if (method === "getUpdates") {
+    getUpdatesCalls++;
+    requestedOffsets.push(body.offset);
+
+    if (mode === "disk-failure") {
+      if (getUpdatesCalls === 1) return jsonResponse({ ok: true, result: [privateUpdate(101, "persist me")] });
+      finish();
+    }
+    if (mode === "dir-sync-retry") {
+      if (getUpdatesCalls <= 2) {
+        return jsonResponse({ ok: true, result: [privateUpdate(101, "persist me")] });
+      }
+      finish();
+    }
+    if (mode === "auto-drain") {
+      if (getUpdatesCalls === 1) {
+        return jsonResponse({
+          ok: true,
+          result: [privateUpdate(101, "first"), privateUpdate(102, "second")],
+        });
+      }
+      if (getUpdatesCalls === 2) {
+        status.setChatStatus(privateKey, {
+          status: "idle",
+          sessionId: null,
+          turnId: null,
+        });
+      }
+      if (getUpdatesCalls > 2 && status.isRunning(privateKey)) {
+        status.setChatStatus(privateKey, {
+          status: "idle",
+          sessionId: null,
+          turnId: null,
+        });
+      }
+      if (getUpdatesCalls >= 6) finish();
+      return jsonResponse({ ok: true, result: [] });
+    }
+    if (mode === "restart-persist") {
+      if (getUpdatesCalls === 1) {
+        return jsonResponse({
+          ok: true,
+          result: [privateUpdate(101, "first"), privateUpdate(102, "second")],
+        });
+      }
+      finish();
+    }
+    if (mode === "restart-drain") {
+      if (status.isRunning(privateKey)) {
+        status.setChatStatus(privateKey, {
+          status: "idle",
+          sessionId: null,
+          turnId: null,
+        });
+      }
+      if (getUpdatesCalls >= 6) finish();
+      return jsonResponse({ ok: true, result: [] });
+    }
+    if (mode === "group-noise") {
+      if (getUpdatesCalls === 1) return jsonResponse({ ok: true, result: [groupNoiseUpdate] });
+      finish();
+    }
+    if (mode === "routing") {
+      if (getUpdatesCalls === 1) {
+        return jsonResponse({
+          ok: true,
+          result: [
+            privateUpdate(101, "private follow-up"),
+            groupNoiseUpdate,
+            groupUpdate(103, "@my_bot group follow-up"),
+            groupUpdate(104, "/task topic follow-up", 7),
+          ],
+        });
+      }
+      finish();
+    }
+    if (mode === "fair-drain") finish();
+    throw new Error(`unknown harness mode: ${mode}`);
+  }
+  if (method === "setMessageReaction") reactions.push(body);
+  if (method === "sendMessage" && /^Queued \(\d+\)/.test(body.text || "")) {
+    queueStatuses.push(body);
+  }
+  return jsonResponse({ ok: true, result: { message_id: 1 } });
+};
+
+const pollPath = resolve("scripts/telegram-poll.mjs");
+process.argv[1] = pollPath;
+await import(pathToFileURL(pollPath).href);

--- a/scripts/fixtures/telegram-queue-ack-crash-child.mjs
+++ b/scripts/fixtures/telegram-queue-ack-crash-child.mjs
@@ -1,0 +1,18 @@
+import { writeFileSync } from "node:fs";
+import { rename } from "node:fs/promises";
+
+import { acknowledgeQueueHead } from "../lib/telegram-queue.mjs";
+
+const [queueFile, markerFile] = process.argv.slice(2);
+if (!queueFile || !markerFile) {
+  throw new Error("usage: telegram-queue-ack-crash-child <queue-file> <marker-file>");
+}
+
+await acknowledgeQueueHead(queueFile, "1:", 101, {
+  renameImpl: async (from, to) => {
+    await rename(from, to);
+    if (String(to) !== queueFile) return;
+    writeFileSync(markerFile, "queue removal published\n", { mode: 0o600 });
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);
+  },
+});

--- a/scripts/lib/run-status.mjs
+++ b/scripts/lib/run-status.mjs
@@ -176,7 +176,16 @@ function updateChatStatus(chatKey, patch, expected) {
     ) {
       return null;
     }
-    const next = { ...prev, ...patch, updatedAt: Date.now() };
+    const previousGeneration =
+      Number.isSafeInteger(prev.generation) && prev.generation >= 0
+        ? prev.generation
+        : 0;
+    const next = {
+      ...prev,
+      ...patch,
+      generation: previousGeneration + 1,
+      updatedAt: Date.now(),
+    };
     for (const key of Object.keys(next)) if (next[key] === null) delete next[key];
     writeCurrent(file, next);
     return next;

--- a/scripts/lib/run-status.test.mjs
+++ b/scripts/lib/run-status.test.mjs
@@ -125,6 +125,20 @@ test("conditional update checks sessionId under the same per-chat lock", () => {
   assert.equal(status.getChatStatus("cas:").status, "idle");
 });
 
+test("each accepted status write advances a monotonic per-chat generation", () => {
+  const first = status.setChatStatus("generation:", {
+    status: "running",
+    sessionId: "session-1",
+  });
+  const second = status.setChatStatus("generation:", {
+    status: "idle",
+    sessionId: null,
+  });
+
+  assert.equal(first.generation, 1);
+  assert.equal(second.generation, 2);
+});
+
 test("a stale per-chat lock is reclaimed after a crashed writer", () => {
   const key = "stale-lock:";
   const encoded = Buffer.from(key, "utf8").toString("base64url");

--- a/scripts/lib/telegram-acceptance.d.mts
+++ b/scripts/lib/telegram-acceptance.d.mts
@@ -1,0 +1,35 @@
+import type {
+  TelegramContext,
+  TelegramInboundResultOrPromise,
+  TelegramMessage,
+} from "eve/channels/telegram";
+
+export declare const TELEGRAM_ACCEPTANCE_ROUTE: "/eve/v1/telegram/accepted";
+export declare const TELEGRAM_QUEUE_RECEIPT_FIELD: "iva_durable_queue_receipt";
+export declare const TELEGRAM_ACCEPTANCE_KIND_HEADER: "x-iva-telegram-acceptance";
+
+export declare function addTelegramQueueReceipt(
+  update: Record<string, any>,
+  receipt?: string,
+): Record<string, any>;
+
+export declare function wrapTelegramQueueOnMessage(
+  onMessage: (
+    context: TelegramContext,
+    message: TelegramMessage,
+  ) => TelegramInboundResultOrPromise,
+): (
+  context: TelegramContext,
+  message: TelegramMessage,
+) => Promise<Awaited<TelegramInboundResultOrPromise>>;
+
+type AcceptanceArgs = {
+  send: (...args: any[]) => Promise<any>;
+  waitUntil: (task: Promise<unknown>) => void;
+};
+
+export declare function handleAcceptedTelegramWebhook<TArgs extends AcceptanceArgs>(
+  handler: (request: Request, args: TArgs) => Promise<Response>,
+  request: Request,
+  args: TArgs,
+): Promise<Response>;

--- a/scripts/lib/telegram-acceptance.mjs
+++ b/scripts/lib/telegram-acceptance.mjs
@@ -1,0 +1,111 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { randomBytes } from "node:crypto";
+
+export const TELEGRAM_ACCEPTANCE_ROUTE = "/eve/v1/telegram/accepted";
+export const TELEGRAM_QUEUE_RECEIPT_FIELD = "iva_durable_queue_receipt";
+export const TELEGRAM_ACCEPTANCE_KIND_HEADER = "x-iva-telegram-acceptance";
+
+const receiptContext = new AsyncLocalStorage();
+const RECEIPT_PATTERN = /^[a-f0-9]{32}$/u;
+
+function validReceipt(value) {
+  return typeof value === "string" && RECEIPT_PATTERN.test(value);
+}
+
+export function addTelegramQueueReceipt(
+  update,
+  receipt = randomBytes(16).toString("hex"),
+) {
+  if (
+    typeof update !== "object" ||
+    update === null ||
+    Array.isArray(update) ||
+    typeof update.message !== "object" ||
+    update.message === null ||
+    Array.isArray(update.message) ||
+    !validReceipt(receipt)
+  ) {
+    throw new Error("Telegram queue receipt requires a message update and a 128-bit hex id");
+  }
+  return {
+    ...update,
+    message: {
+      ...update.message,
+      [TELEGRAM_QUEUE_RECEIPT_FIELD]: receipt,
+    },
+  };
+}
+
+export function wrapTelegramQueueOnMessage(onMessage) {
+  return async (context, message) => {
+    const raw = message?.raw;
+    const receipt =
+      typeof raw === "object" &&
+      raw !== null &&
+      !Array.isArray(raw) &&
+      validReceipt(raw[TELEGRAM_QUEUE_RECEIPT_FIELD])
+        ? raw[TELEGRAM_QUEUE_RECEIPT_FIELD]
+        : null;
+    if (typeof raw === "object" && raw !== null) {
+      Reflect.deleteProperty(raw, TELEGRAM_QUEUE_RECEIPT_FIELD);
+    }
+
+    const result = await onMessage(context, message);
+    const active = receiptContext.getStore();
+    if (result === null && receipt !== null && active?.receipt === receipt) {
+      active.handled = true;
+    }
+    return result;
+  };
+}
+
+async function receiptFromRequest(request) {
+  try {
+    const body = await request.clone().json();
+    const receipt = body?.message?.[TELEGRAM_QUEUE_RECEIPT_FIELD];
+    return validReceipt(receipt) ? receipt : null;
+  } catch {
+    return null;
+  }
+}
+
+// telegramChannel acknowledges webhooks before its waitUntil dispatch has called
+// send(). The polling bridge needs a stronger receipt for durable FIFO replay:
+// this wrapper runs the authored channel handler unchanged, but waits until its
+// real Eve send has resolved before returning success.
+/**
+ * @param {(request: Request, args: any) => Promise<Response>} handler
+ * @param {Request} request
+ * @param {any} args
+ * @returns {Promise<Response>}
+ */
+export async function handleAcceptedTelegramWebhook(handler, request, args) {
+  const receipt = await receiptFromRequest(request);
+  return receiptContext.run({ receipt, handled: false }, async () => {
+    /** @type {Promise<unknown>[]} */
+    const background = [];
+    let accepted = false;
+
+    const response = await handler(request, {
+      ...args,
+      send: async (...sendArgs) => {
+        const session = await args.send(...sendArgs);
+        accepted = true;
+        return session;
+      },
+      waitUntil: (task) => {
+        background.push(Promise.resolve(task));
+      },
+    });
+
+    if (!response.ok) return response;
+    await Promise.allSettled(background);
+    const handled = receiptContext.getStore()?.handled === true;
+    return accepted || handled
+      ? new Response(null, {
+          status: 204,
+          headers: { [TELEGRAM_ACCEPTANCE_KIND_HEADER]: accepted ? "turn" : "handled" },
+        })
+      : new Response("Telegram update was not accepted by Eve", { status: 503 });
+  });
+}

--- a/scripts/lib/telegram-acceptance.test.mjs
+++ b/scripts/lib/telegram-acceptance.test.mjs
@@ -1,0 +1,314 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { telegramChannel } from "eve/channels/telegram";
+import {
+  createQueueItem,
+  enqueueItem,
+  queueHead,
+  removeQueueHead,
+} from "./telegram-queue.mjs";
+import {
+  addTelegramQueueReceipt,
+  handleAcceptedTelegramWebhook,
+  TELEGRAM_QUEUE_RECEIPT_FIELD,
+  wrapTelegramQueueOnMessage,
+} from "./telegram-acceptance.mjs";
+
+process.env.TELEGRAM_BOT_TOKEN ??= "999:test-token";
+process.env.TELEGRAM_WEBHOOK_SECRET_TOKEN ??= "test-secret";
+process.env.TELEGRAM_ALLOWED_USER_IDS = "42";
+process.env.TELEGRAM_POLL_SETTLE_MS = "0";
+const { drainReadyQueueHeads } = await import("../telegram-poll.mjs");
+
+const privateUpdate = (updateId, text) => ({
+  update_id: updateId,
+  message: {
+    message_id: updateId,
+    date: 1,
+    chat: { id: 1, type: "private" },
+    from: { id: 42, is_bot: false, first_name: "Owner" },
+    text,
+  },
+});
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((yes, no) => {
+    resolve = yes;
+    reject = no;
+  });
+  return { promise, resolve, reject };
+}
+
+function productionTelegramDelivery(
+  sendImpl,
+  {
+    webhookVerifier,
+    onMessage = () => ({ auth: null }),
+    marked = true,
+  } = {},
+) {
+  const channel = telegramChannel({
+    credentials: {
+      webhookVerifier: webhookVerifier ?? (async (_request, rawBody) => rawBody),
+    },
+    onMessage: wrapTelegramQueueOnMessage(onMessage),
+  });
+  const route = channel.routes.find(
+    (candidate) =>
+      candidate.transport !== "websocket" &&
+      candidate.method === "POST" &&
+      candidate.path === "/eve/v1/telegram",
+  );
+  assert.ok(route && route.transport !== "websocket");
+
+  return async (update) => {
+    const response = await handleAcceptedTelegramWebhook(
+      route.handler,
+      new Request("http://iva.test/eve/v1/telegram/accepted", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(marked ? addTelegramQueueReceipt(update) : update),
+      }),
+      {
+        send: (input, options) => sendImpl(update, input, options),
+        resolveActiveSession: async () => undefined,
+        cancel: async () => ({ status: "no_active_turn" }),
+        reset: async () => ({ status: "no_active_session" }),
+        getSession: () => {
+          throw new Error("not used");
+        },
+        receive: async () => {
+          throw new Error("not used");
+        },
+        params: {},
+        waitUntil: () => {},
+        requestIp: "127.0.0.1",
+      },
+    );
+    return response.ok
+      ? response.headers.get("x-iva-telegram-acceptance") === "handled"
+        ? "handled"
+        : true
+      : false;
+  };
+}
+
+test("intentional authored no-send accepts queued location, then the later text keeps FIFO order", async () => {
+  const location = {
+    ...privateUpdate(101, undefined),
+    message: {
+      ...privateUpdate(101, undefined).message,
+      location: { latitude: 41.311, longitude: 69.279 },
+    },
+  };
+  let document = enqueueItem(
+    enqueueItem(
+      { version: 1, queues: {} },
+      "1:",
+      createQueueItem(location, 1),
+    ).document,
+    "1:",
+    createQueueItem(privateUpdate(102, "after location"), 2),
+  ).document;
+  const sent = [];
+  const deliverImpl = productionTelegramDelivery(
+    async (update) => {
+      sent.push(update.update_id);
+      return { id: `session-${update.update_id}` };
+    },
+    {
+      onMessage: (_ctx, message) => {
+        assert.equal(Object.hasOwn(message.raw, TELEGRAM_QUEUE_RECEIPT_FIELD), false);
+        return message.raw.location ? null : { auth: null };
+      },
+    },
+  );
+  const acknowledgeImpl = async (key, updateId) => {
+    document = removeQueueHead(document, key, updateId);
+  };
+  const inFlight = new Map();
+
+  assert.equal(
+    await drainReadyQueueHeads({
+      loadImpl: async () => document,
+      runningImpl: () => false,
+      deliverImpl,
+      acknowledgeImpl,
+      settleUntil: new Map(),
+      inFlight,
+    }),
+    1,
+  );
+  assert.equal(queueHead(document, "1:").updateId, 102);
+  assert.deepEqual(sent, []);
+
+  assert.equal(
+    await drainReadyQueueHeads({
+      loadImpl: async () => document,
+      runningImpl: () => false,
+      deliverImpl,
+      acknowledgeImpl,
+      settleUntil: new Map(),
+      inFlight,
+    }),
+    0,
+  );
+  assert.deepEqual(sent, [102]);
+});
+
+test("intentional silent sticker no-send is accepted, while throw and unmarked null are rejected", async () => {
+  const sticker = {
+    ...privateUpdate(201, undefined),
+    message: {
+      ...privateUpdate(201, undefined).message,
+      sticker: { file_id: "silent-sticker" },
+    },
+  };
+  let sendCalls = 0;
+  const silent = productionTelegramDelivery(
+    async () => {
+      sendCalls++;
+      return { id: "must-not-send" };
+    },
+    { onMessage: () => null },
+  );
+  assert.equal(await silent(sticker), "handled");
+  assert.equal(sendCalls, 0);
+
+  const thrown = productionTelegramDelivery(
+    async () => {
+      sendCalls++;
+      return { id: "must-not-send" };
+    },
+    {
+      onMessage: () => {
+        throw new Error("injected authored handler failure");
+      },
+    },
+  );
+  assert.equal(await thrown(sticker), false);
+  assert.equal(sendCalls, 0);
+
+  const unmarked = productionTelegramDelivery(
+    async () => {
+      sendCalls++;
+      return { id: "must-not-send" };
+    },
+    { onMessage: () => null, marked: false },
+  );
+  assert.equal(await unmarked(sticker), false);
+  assert.equal(sendCalls, 0);
+});
+
+test("acceptance route preserves Telegram auth failure and rejects malformed no-send updates", async () => {
+  let sendCalls = 0;
+  const rejectedByVerifier = productionTelegramDelivery(
+    async () => {
+      sendCalls++;
+      return { id: "must-not-run" };
+    },
+    { webhookVerifier: async () => false },
+  );
+  assert.equal(await rejectedByVerifier(privateUpdate(1, "unauthorized")), false);
+  assert.equal(sendCalls, 0);
+
+  const channel = telegramChannel({
+    credentials: { webhookVerifier: async (_request, rawBody) => rawBody },
+    onMessage: () => ({ auth: null }),
+  });
+  const route = channel.routes.find(
+    (candidate) =>
+      candidate.transport !== "websocket" &&
+      candidate.method === "POST" &&
+      candidate.path === "/eve/v1/telegram",
+  );
+  assert.ok(route && route.transport !== "websocket");
+  const malformed = await handleAcceptedTelegramWebhook(
+    route.handler,
+    new Request("http://iva.test/eve/v1/telegram/accepted", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{broken",
+    }),
+    {
+      send: async () => {
+        sendCalls++;
+        return { id: "must-not-run" };
+      },
+      waitUntil: () => {},
+    },
+  );
+  assert.equal(malformed.ok, false);
+  assert.equal(malformed.status, 503);
+  assert.equal(sendCalls, 0);
+});
+
+test("production Telegram deferred failure retains the head and cannot start the next head", async () => {
+  let document = enqueueItem(
+    enqueueItem(
+      { version: 1, queues: {} },
+      "1:",
+      createQueueItem(privateUpdate(101, "first"), 1),
+    ).document,
+    "1:",
+    createQueueItem(privateUpdate(102, "second"), 2),
+  ).document;
+  const attempts = [];
+
+  const remaining = await drainReadyQueueHeads({
+    loadImpl: async () => document,
+    runningImpl: () => false,
+    deliverImpl: productionTelegramDelivery(async (update) => {
+      attempts.push(update.update_id);
+      throw new Error("injected Eve acceptance failure");
+    }),
+    acknowledgeImpl: async (key, updateId) => {
+      document = removeQueueHead(document, key, updateId);
+    },
+    settleUntil: new Map(),
+    inFlight: new Map(),
+  });
+
+  assert.equal(remaining, 2);
+  assert.equal(queueHead(document, "1:").updateId, 101);
+  assert.deepEqual(attempts, [101]);
+});
+
+test("production Telegram receipt removes exactly one head only after Eve send resolves", async () => {
+  let document = enqueueItem(
+    enqueueItem(
+      { version: 1, queues: {} },
+      "1:",
+      createQueueItem(privateUpdate(101, "first"), 1),
+    ).document,
+    "1:",
+    createQueueItem(privateUpdate(102, "second"), 2),
+  ).document;
+  const acceptance = deferred();
+  const attempts = [];
+
+  const drain = drainReadyQueueHeads({
+    loadImpl: async () => document,
+    runningImpl: () => false,
+    deliverImpl: productionTelegramDelivery(async (update) => {
+      attempts.push(update.update_id);
+      return acceptance.promise;
+    }),
+    acknowledgeImpl: async (key, updateId) => {
+      document = removeQueueHead(document, key, updateId);
+    },
+    settleUntil: new Map(),
+    inFlight: new Map(),
+  });
+
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(queueHead(document, "1:").updateId, 101);
+  assert.deepEqual(attempts, [101]);
+
+  acceptance.resolve({ id: "accepted-session" });
+  assert.equal(await drain, 1);
+  assert.equal(queueHead(document, "1:").updateId, 102);
+  assert.deepEqual(attempts, [101], "one drain pass must keep one in-flight head per chat");
+});

--- a/scripts/lib/telegram-queue.mjs
+++ b/scripts/lib/telegram-queue.mjs
@@ -1,0 +1,619 @@
+import {
+  mkdir,
+  link,
+  open,
+  readFile,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { createHash, randomBytes } from "node:crypto";
+import { dirname } from "node:path";
+
+export const TELEGRAM_QUEUE_VERSION = 1;
+export const TELEGRAM_QUEUE_ITEM_VERSION = 1;
+export const TELEGRAM_QUEUE_DURABILITY = "ETELEGRAM_QUEUE_DURABILITY";
+export const TELEGRAM_QUEUE_ACK_ROLLED_BACK = "ETELEGRAM_QUEUE_ACK_ROLLED_BACK";
+export const TELEGRAM_QUEUE_FATAL_DURABILITY = "ETELEGRAM_QUEUE_FATAL_DURABILITY";
+export const TELEGRAM_QUEUE_ACK_PENDING_SUFFIX = ".ack-pending";
+
+const MEDIA_KEYS = [
+  "photo",
+  "voice",
+  "audio",
+  "video",
+  "video_note",
+  "animation",
+  "sticker",
+  "document",
+  "location",
+  "contact",
+  "poll",
+];
+
+export function emptyQueueDocument() {
+  return { version: TELEGRAM_QUEUE_VERSION, queues: Object.fromEntries([]) };
+}
+
+function cloneJson(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function legacyUpdateId(chatKey, index, text) {
+  const digest = createHash("sha256")
+    .update(`${chatKey}\0${index}\0${text}`)
+    .digest();
+  return -(digest.readUInt32BE(0) || 1);
+}
+
+function normalizeItem(item, chatKey, index) {
+  if (typeof item === "string") {
+    return {
+      version: TELEGRAM_QUEUE_ITEM_VERSION,
+      updateId: legacyUpdateId(chatKey, index, item),
+      legacyText: item,
+      migratedFrom: "string",
+    };
+  }
+  if (
+    typeof item !== "object" ||
+    item === null ||
+    Array.isArray(item) ||
+    item.version !== TELEGRAM_QUEUE_ITEM_VERSION ||
+    !Number.isSafeInteger(item.updateId)
+  ) {
+    throw new Error(`invalid Telegram queue item for ${chatKey}[${index}]`);
+  }
+  const hasUpdate =
+    typeof item.update === "object" &&
+    item.update !== null &&
+    !Array.isArray(item.update) &&
+    item.update.update_id === item.updateId;
+  const hasLegacyText = typeof item.legacyText === "string";
+  if (!hasUpdate && !hasLegacyText) {
+    throw new Error(`Telegram queue item ${chatKey}[${index}] has no replayable payload`);
+  }
+  return cloneJson(item);
+}
+
+function normalizeQueues(queues, { legacy = false } = {}) {
+  if (typeof queues !== "object" || queues === null || Array.isArray(queues)) {
+    throw new Error("Telegram queue does not contain a queues object");
+  }
+  const entries = [];
+  for (const [chatKey, items] of Object.entries(queues)) {
+    if (!Array.isArray(items)) throw new Error(`Telegram queue ${chatKey} is not an array`);
+    const next = items.map((item, index) => normalizeItem(item, chatKey, index));
+    if (next.length) entries.push([chatKey, next]);
+  }
+  return {
+    // Object.fromEntries defines "__proto__" as an ordinary own data property.
+    document: { version: TELEGRAM_QUEUE_VERSION, queues: Object.fromEntries(entries) },
+    migrated: legacy,
+  };
+}
+
+export function normalizeQueueDocument(value) {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("Telegram queue does not contain an object");
+  }
+  if (value.version === TELEGRAM_QUEUE_VERSION && Object.hasOwn(value, "queues")) {
+    return normalizeQueues(value.queues);
+  }
+  // Pre-IVA-008 format: { "<chat>:<topic>": ["text", ...] }.
+  // Convert every string to a versioned item with a stable synthetic update id.
+  // The text stays byte-for-byte present until Eve accepts the migrated head.
+  return normalizeQueues(value, { legacy: true });
+}
+
+export function createQueueItem(update, now = Date.now()) {
+  if (
+    typeof update !== "object" ||
+    update === null ||
+    Array.isArray(update) ||
+    !Number.isSafeInteger(update.update_id)
+  ) {
+    throw new Error("queued Telegram update must have a safe integer update_id");
+  }
+  return {
+    version: TELEGRAM_QUEUE_ITEM_VERSION,
+    updateId: update.update_id,
+    enqueuedAt: now,
+    update: cloneJson(update),
+  };
+}
+
+export function queueCount(document, chatKey) {
+  if (chatKey !== undefined) {
+    return Object.hasOwn(document.queues, chatKey) ? document.queues[chatKey].length : 0;
+  }
+  return Object.values(document.queues).reduce((sum, items) => sum + items.length, 0);
+}
+
+export function queueKeys(document) {
+  return Object.keys(document.queues).filter((key) => document.queues[key]?.length);
+}
+
+export function queueHead(document, chatKey) {
+  return Object.hasOwn(document.queues, chatKey) ? document.queues[chatKey][0] ?? null : null;
+}
+
+function cloneQueueMap(queues) {
+  return Object.fromEntries(Object.entries(queues));
+}
+
+function defineQueue(queues, chatKey, items) {
+  Object.defineProperty(queues, chatKey, {
+    value: items,
+    enumerable: true,
+    configurable: true,
+    writable: true,
+  });
+}
+
+export function enqueueItem(document, chatKey, item) {
+  const queues = cloneQueueMap(document.queues);
+  const current = Object.hasOwn(queues, chatKey) ? queues[chatKey] : [];
+  const duplicate = current.some((candidate) => candidate.updateId === item.updateId);
+  if (duplicate) {
+    return { document, added: false, count: current.length };
+  }
+  defineQueue(queues, chatKey, [...current, item]);
+  return {
+    document: { version: TELEGRAM_QUEUE_VERSION, queues },
+    added: true,
+    count: queues[chatKey].length,
+  };
+}
+
+export function removeQueueHead(document, chatKey, updateId) {
+  const current = Object.hasOwn(document.queues, chatKey) ? document.queues[chatKey] : [];
+  if (!current.length || current[0].updateId !== updateId) {
+    throw new Error(`Telegram queue head changed for ${chatKey}; expected update ${updateId}`);
+  }
+  const queues = cloneQueueMap(document.queues);
+  if (current.length === 1) delete queues[chatKey];
+  else defineQueue(queues, chatKey, current.slice(1));
+  return { version: TELEGRAM_QUEUE_VERSION, queues };
+}
+
+export function clearQueueKey(document, chatKey) {
+  if (!Object.hasOwn(document.queues, chatKey)) return { document, changed: false };
+  const queues = cloneQueueMap(document.queues);
+  delete queues[chatKey];
+  return {
+    document: { version: TELEGRAM_QUEUE_VERSION, queues },
+    changed: true,
+  };
+}
+
+function splitChatKey(chatKey) {
+  const colon = chatKey.lastIndexOf(":");
+  if (colon < 0) return null;
+  const chat = chatKey.slice(0, colon);
+  const thread = chatKey.slice(colon + 1);
+  if (!chat.length) return null;
+  const chatNumber = Number(chat);
+  const threadNumber = thread === "" ? null : Number(thread);
+  return {
+    chatId: Number.isSafeInteger(chatNumber) ? chatNumber : chat,
+    threadId: Number.isSafeInteger(threadNumber) ? threadNumber : null,
+  };
+}
+
+export function materializeQueueItem(chatKey, item, { legacyAllowedUserIds } = {}) {
+  if (item.update) return cloneJson(item.update);
+  const route = splitChatKey(chatKey);
+  const allowed =
+    legacyAllowedUserIds instanceof Set
+      ? legacyAllowedUserIds
+      : new Set(legacyAllowedUserIds ?? []);
+  // The old string[] format did not retain a sender. A private Telegram chat id
+  // is also its participant's user id, so an allowlisted private route is the
+  // only legacy item whose author can be reconstructed. A group/topic key says
+  // nothing about which member wrote the text and must stay undelivered.
+  if (
+    !route ||
+    typeof route.chatId !== "number" ||
+    route.chatId <= 0 ||
+    !allowed.has(String(route.chatId))
+  ) {
+    return null;
+  }
+  const ownerId = route.chatId;
+  const messageId = Math.max(1, Math.abs(item.updateId));
+  return {
+    update_id: item.updateId,
+    message: {
+      message_id: messageId,
+      date: 0,
+      chat: {
+        id: route.chatId,
+        type: "private",
+      },
+      from: { id: ownerId, is_bot: false, first_name: "Owner" },
+      text: item.legacyText,
+      ...(route.threadId === null ? {} : { message_thread_id: route.threadId }),
+    },
+  };
+}
+
+const TELEGRAM_USERNAME = /^[A-Za-z0-9_]{5,32}$/u;
+const TOKEN_NEIGHBOR = /[\p{L}\p{N}_]/u;
+
+function normalizeBotUsername(botUsername) {
+  if (typeof botUsername !== "string") return "";
+  const username = botUsername.replace(/^@/, "");
+  return TELEGRAM_USERNAME.test(username) ? username : "";
+}
+
+function validEntityRange(text, entity) {
+  return (
+    typeof entity === "object" &&
+    entity !== null &&
+    Number.isSafeInteger(entity.offset) &&
+    Number.isSafeInteger(entity.length) &&
+    entity.offset >= 0 &&
+    entity.length > 0 &&
+    entity.offset + entity.length <= text.length
+  );
+}
+
+function codePointBefore(text, index) {
+  return Array.from(text.slice(0, index)).at(-1) ?? "";
+}
+
+function codePointAfter(text, index) {
+  return Array.from(text.slice(index))[0] ?? "";
+}
+
+function hasTokenBoundaries(text, start, end) {
+  return (
+    !TOKEN_NEIGHBOR.test(codePointBefore(text, start)) &&
+    !TOKEN_NEIGHBOR.test(codePointAfter(text, end))
+  );
+}
+
+function mentionAt(text, start, end, username) {
+  return (
+    text.slice(start, end).toLowerCase() === `@${username.toLowerCase()}` &&
+    hasTokenBoundaries(text, start, end)
+  );
+}
+
+function hasExactMention(text, entities, username) {
+  if (!username) return false;
+  if (entities !== undefined) {
+    if (!Array.isArray(entities)) return false;
+    return entities.some((entity) =>
+      entity?.type === "mention" &&
+      validEntityRange(text, entity) &&
+      mentionAt(text, entity.offset, entity.offset + entity.length, username));
+  }
+
+  const needleLength = username.length + 1;
+  let start = text.indexOf("@");
+  while (start >= 0) {
+    if (mentionAt(text, start, start + needleLength, username)) return true;
+    start = text.indexOf("@", start + 1);
+  }
+  return false;
+}
+
+function commandTokenTargetsBot(token, botUsername) {
+  const match = /^\/[A-Za-z0-9_]+(?:@(?<target>[A-Za-z0-9_]+))?$/u.exec(token);
+  if (!match) return false;
+  const target = match.groups?.target;
+  return (
+    target === undefined ||
+    (botUsername && target.toLowerCase() === botUsername.toLowerCase())
+  );
+}
+
+function isBotCommand(text, botUsername, entities) {
+  if (entities !== undefined) {
+    if (!Array.isArray(entities)) return false;
+    return entities.some((entity) => {
+      if (
+        entity?.type !== "bot_command" ||
+        entity.offset !== 0 ||
+        !validEntityRange(text, entity)
+      ) {
+        return false;
+      }
+      const end = entity.offset + entity.length;
+      return (
+        commandTokenTargetsBot(text.slice(entity.offset, end), botUsername) &&
+        (end === text.length || /\s/u.test(codePointAfter(text, end)))
+      );
+    });
+  }
+  const match = /^\/[A-Za-z0-9_]+(?:@[A-Za-z0-9_]+)?(?=\s|$)/u.exec(text);
+  return Boolean(match && commandTokenTargetsBot(match[0], botUsername));
+}
+
+function messageTextAndEntities(message) {
+  if (typeof message.text === "string") {
+    return { text: message.text, entities: message.entities };
+  }
+  if (typeof message.caption === "string") {
+    return { text: message.caption, entities: message.caption_entities };
+  }
+  return { text: "", entities: undefined };
+}
+
+function hasMessagePayload(message) {
+  const { text } = messageTextAndEntities(message);
+  return Boolean(
+    text.trim() ||
+    MEDIA_KEYS.some((key) => message[key] !== undefined),
+  );
+}
+
+export function isReplyToBot(message) {
+  return message.reply_to_message?.from?.is_bot === true;
+}
+
+export function shouldQueueBusyUpdate(
+  update,
+  {
+    allowedUserIds,
+    botUsername,
+  },
+) {
+  const message = update?.message;
+  if (!message || message.from?.is_bot === true || !hasMessagePayload(message)) return false;
+  const allowed = allowedUserIds instanceof Set ? allowedUserIds : new Set(allowedUserIds ?? []);
+  const from = String(message.from?.id ?? "");
+  if (!allowed.size || !allowed.has(from)) return false;
+  if (message.chat?.type === "private") return true;
+  if (message.chat?.type === "channel") return false;
+  const { text, entities } = messageTextAndEntities(message);
+  const username = normalizeBotUsername(botUsername);
+  return (
+    isBotCommand(text, username, entities) ||
+    hasExactMention(text, entities, username)
+  );
+}
+
+export async function loadQueueFile(
+  file,
+  options = {},
+) {
+  const {
+    strict = false,
+    readFileImpl = readFile,
+    renameImpl = rename,
+  } = options;
+  const quarantineNonce =
+    typeof options.nonce === "function"
+      ? options.nonce
+      : () => randomBytes(8).toString("hex");
+  const pendingFile = `${file}${TELEGRAM_QUEUE_ACK_PENDING_SUFFIX}`;
+  let pendingRaw;
+  try {
+    pendingRaw = await readFileImpl(pendingFile, "utf8");
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+  }
+  if (pendingRaw !== undefined) {
+    // A pending document is the last fully durable pre-ack state. Restore it
+    // before any caller can observe the possibly published removal.
+    const recovered = normalizeQueueDocument(JSON.parse(pendingRaw)).document;
+    const recoveryOptions = { ...options };
+    if (typeof recoveryOptions.nonce === "function") delete recoveryOptions.nonce;
+    await writeQueueFileAtomic(file, recovered, recoveryOptions);
+    await removeFileDurable(pendingFile, options);
+    return {
+      document: recovered,
+      migrated: false,
+      quarantined: null,
+      recoveredPendingAcknowledgement: true,
+    };
+  }
+
+  let raw;
+  try {
+    raw = await readFileImpl(file, "utf8");
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return { document: emptyQueueDocument(), migrated: false, quarantined: null };
+    }
+    throw error;
+  }
+  try {
+    const normalized = normalizeQueueDocument(JSON.parse(raw));
+    return { ...normalized, quarantined: null };
+  } catch (error) {
+    if (strict) throw error;
+    const backup = `${file}.corrupt-${Date.now()}-${quarantineNonce()}`;
+    await renameImpl(file, backup);
+    return { document: emptyQueueDocument(), migrated: false, quarantined: backup, error };
+  }
+}
+
+async function removeFileDurable(
+  file,
+  {
+    rmImpl = rm,
+    openImpl = open,
+  } = {},
+) {
+  await rmImpl(file, { force: true });
+  const directory = await openImpl(dirname(file), "r");
+  try {
+    await directory.sync();
+  } finally {
+    await directory.close();
+  }
+}
+
+export async function writeQueueFileAtomic(
+  file,
+  document,
+  {
+    mkdirImpl = mkdir,
+    writeFileImpl = writeFile,
+    renameImpl = rename,
+    linkImpl = link,
+    rmImpl = rm,
+    openImpl = open,
+    nonce = randomBytes(8).toString("hex"),
+    replace = true,
+  } = {},
+) {
+  const normalized = normalizeQueueDocument(document).document;
+  const parent = dirname(file);
+  await mkdirImpl(parent, { recursive: true });
+  const tmp = `${file}.tmp-${process.pid}-${nonce}`;
+  let replaced = false;
+  try {
+    await writeFileImpl(tmp, JSON.stringify(normalized), {
+      encoding: "utf8",
+      flag: "wx",
+      mode: 0o600,
+    });
+    const staged = await openImpl(tmp, "r+");
+    try {
+      await staged.sync();
+    } finally {
+      await staged.close();
+    }
+    if (replace) await renameImpl(tmp, file);
+    else await linkImpl(tmp, file);
+    replaced = true;
+    const directory = await openImpl(parent, "r");
+    try {
+      await directory.sync();
+    } finally {
+      await directory.close();
+    }
+  } catch (cause) {
+    if (replaced) {
+      const error = new Error(
+        `Telegram queue file was published, but durability could not be confirmed: ${cause.message}`,
+        { cause },
+      );
+      error.code = TELEGRAM_QUEUE_DURABILITY;
+      throw error;
+    }
+    throw cause;
+  } finally {
+    await rmImpl(tmp, { force: true }).catch(() => {});
+  }
+}
+
+async function writeLegacyQuarantine(file, document, options) {
+  const now = options.quarantineNow?.() ?? Date.now();
+  const nonce = options.quarantineNonce?.() ?? randomBytes(8).toString("hex");
+  const stem = `${file}.legacy-unattributed-${now}-${nonce}`;
+
+  for (let attempt = 0; attempt < 1000; attempt++) {
+    const path = attempt === 0 ? stem : `${stem}-${attempt}`;
+    try {
+      // A hard link publishes the fully fsynced staging inode and fails with
+      // EEXIST instead of replacing an earlier migration's evidence.
+      await writeQueueFileAtomic(path, document, { ...options, replace: false });
+      return path;
+    } catch (error) {
+      if (error?.code !== "EEXIST") throw error;
+    }
+  }
+  throw new Error(`could not reserve a unique legacy Telegram quarantine path for ${file}`);
+}
+
+export async function migrateQueueFile(file, options = {}) {
+  const loaded = await loadQueueFile(file, options);
+  if (loaded.migrated) {
+    const activeEntries = [];
+    const unattributedEntries = [];
+    for (const [chatKey, items] of Object.entries(loaded.document.queues)) {
+      const route = splitChatKey(chatKey);
+      const target =
+        route && typeof route.chatId === "number" && route.chatId > 0
+          ? activeEntries
+          : unattributedEntries;
+      target.push([chatKey, items]);
+    }
+    const active = {
+      version: TELEGRAM_QUEUE_VERSION,
+      queues: Object.fromEntries(activeEntries),
+    };
+    if (unattributedEntries.length) {
+      // Preserve old group/topic text outside the active FIFO before removing it
+      // from automatic replay. The old format has no sender identity, so those
+      // entries cannot be delivered faithfully. Writing this sidecar first means
+      // every crash order leaves either the original queue or its durable copy.
+      const quarantine = await writeLegacyQuarantine(
+        file,
+        {
+          version: TELEGRAM_QUEUE_VERSION,
+          queues: Object.fromEntries(unattributedEntries),
+        },
+        options,
+      );
+      options.onLegacyQuarantine?.(quarantine);
+    }
+    await writeQueueFileAtomic(file, active, options);
+    return active;
+  }
+  return loaded.document;
+}
+
+export async function enqueueQueueFile(file, chatKey, update, options = {}) {
+  const loaded = await loadQueueFile(file, options);
+  const result = enqueueItem(
+    loaded.document,
+    chatKey,
+    createQueueItem(update, options.now?.() ?? Date.now()),
+  );
+  // A previous rename can be visible even when its parent-directory fsync failed.
+  // Rewrite duplicate retries too, so offset advancement always follows a write
+  // whose file and directory durability were both confirmed in this attempt.
+  await writeQueueFileAtomic(file, result.document, options);
+  return { ...result, document: result.document, quarantined: loaded.quarantined };
+}
+
+export async function acknowledgeQueueHead(file, chatKey, updateId, options = {}) {
+  const loaded = await loadQueueFile(file, { ...options, strict: true });
+  const document = removeQueueHead(loaded.document, chatKey, updateId);
+  const pendingFile = `${file}${TELEGRAM_QUEUE_ACK_PENDING_SUFFIX}`;
+
+  // Publish the original queue durably before making head removal visible.
+  // If SIGKILL lands anywhere after this point, loadQueueFile restores it and
+  // intentionally permits one at-least-once duplicate.
+  await writeQueueFileAtomic(pendingFile, loaded.document, options);
+  try {
+    await writeQueueFileAtomic(file, document, options);
+    await removeFileDurable(pendingFile, options);
+  } catch (error) {
+    try {
+      await writeQueueFileAtomic(file, loaded.document, options);
+      await removeFileDurable(pendingFile, options);
+    } catch (rollbackError) {
+      const fatal = new Error(
+        `Telegram queue acknowledgement and rollback durability are unknown: ${rollbackError.message}`,
+        { cause: rollbackError },
+      );
+      fatal.code = TELEGRAM_QUEUE_FATAL_DURABILITY;
+      fatal.acknowledgementError = error;
+      throw fatal;
+    }
+    const rolledBack = new Error(
+      `Telegram queue acknowledgement was not durable; original head ${updateId} was restored`,
+      { cause: error },
+    );
+    rolledBack.code = TELEGRAM_QUEUE_ACK_ROLLED_BACK;
+    throw rolledBack;
+  }
+  return document;
+}
+
+export async function clearQueueFileKey(file, chatKey, options = {}) {
+  const loaded = await loadQueueFile(file, { ...options, strict: true });
+  const result = clearQueueKey(loaded.document, chatKey);
+  if (result.changed || loaded.migrated) {
+    await writeQueueFileAtomic(file, result.document, options);
+  }
+  return result.document;
+}

--- a/scripts/lib/telegram-queue.test.mjs
+++ b/scripts/lib/telegram-queue.test.mjs
@@ -1,0 +1,795 @@
+import test, { after } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { spawn } from "node:child_process";
+import {
+  mkdtemp,
+  link,
+  open,
+  readdir,
+  readFile,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import {
+  acknowledgeQueueHead,
+  createQueueItem,
+  enqueueItem,
+  enqueueQueueFile,
+  loadQueueFile,
+  materializeQueueItem,
+  migrateQueueFile,
+  normalizeQueueDocument,
+  queueCount,
+  queueHead,
+  queueKeys,
+  removeQueueHead,
+  shouldQueueBusyUpdate,
+  TELEGRAM_QUEUE_ACK_ROLLED_BACK,
+  TELEGRAM_QUEUE_FATAL_DURABILITY,
+} from "./telegram-queue.mjs";
+
+process.env.TELEGRAM_BOT_TOKEN ??= "999:test-token";
+process.env.TELEGRAM_WEBHOOK_SECRET_TOKEN ??= "test-secret";
+process.env.TELEGRAM_ALLOWED_USER_IDS = "42";
+process.env.TELEGRAM_POLL_SETTLE_MS = "0";
+const statusDataDir = mkdtempSync(join(tmpdir(), "iva-telegram-queue-status-"));
+process.env.ASSISTANT_DATA_DIR = statusDataDir;
+after(() => rmSync(statusDataDir, { recursive: true, force: true }));
+const status = await import("./run-status.mjs");
+const { drainReadyQueueHeads } = await import("../telegram-poll.mjs");
+
+const privateUpdate = (updateId, text) => ({
+  update_id: updateId,
+  message: {
+    message_id: updateId,
+    date: 1,
+    chat: { id: 1, type: "private" },
+    from: { id: 42, is_bot: false, first_name: "Owner" },
+    text,
+  },
+});
+
+async function queueFile(t) {
+  const dir = await mkdtemp(join(tmpdir(), "iva-telegram-queue-"));
+  t.after(() => rm(dir, { recursive: true, force: true }));
+  return join(dir, "telegram-queue.json");
+}
+
+async function waitForFile(file, timeoutMs = 2_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (existsSync(file)) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  assert.fail(`timed out waiting for ${file}`);
+}
+
+test("versioned FIFO items preserve update ids, order and duplicate retries across reload", async (t) => {
+  const file = await queueFile(t);
+  await enqueueQueueFile(file, "1:", privateUpdate(101, "first"), { now: () => 1 });
+  await enqueueQueueFile(file, "1:", privateUpdate(102, "second"), { now: () => 2 });
+  const duplicate = await enqueueQueueFile(file, "1:", privateUpdate(101, "first"), {
+    now: () => 3,
+  });
+
+  assert.equal(duplicate.added, false);
+  const { document } = await loadQueueFile(file, { strict: true });
+  assert.equal(document.version, 1);
+  assert.equal(queueCount(document, "1:"), 2);
+  assert.deepEqual(
+    document.queues["1:"].map((item) => [item.version, item.updateId, item.enqueuedAt]),
+    [
+      [1, 101, 1],
+      [1, 102, 2],
+    ],
+  );
+});
+
+test("failed head removal leaves the whole FIFO byte-for-byte intact", async (t) => {
+  const file = await queueFile(t);
+  await enqueueQueueFile(file, "1:", privateUpdate(101, "first"));
+  await enqueueQueueFile(file, "1:", privateUpdate(102, "second"));
+  const before = await readFile(file, "utf8");
+
+  await assert.rejects(
+    acknowledgeQueueHead(file, "1:", 101, {
+      renameImpl: async () => {
+        throw new Error("injected ack rename failure");
+      },
+    }),
+    /injected ack rename failure/,
+  );
+
+  assert.equal(await readFile(file, "utf8"), before);
+  const { document } = await loadQueueFile(file, { strict: true });
+  assert.equal(queueHead(document, "1:").updateId, 101);
+});
+
+test("ack directory-sync failure durably rolls back the original FIFO head", async (t) => {
+  const file = await queueFile(t);
+  await enqueueQueueFile(file, "1:", privateUpdate(101, "first"));
+  await enqueueQueueFile(file, "1:", privateUpdate(102, "second"));
+  let directorySyncs = 0;
+
+  await assert.rejects(
+    acknowledgeQueueHead(file, "1:", 101, {
+      openImpl: async (path, flags) => {
+        const handle = await open(path, flags);
+        if (String(path) !== dirname(file) || flags !== "r") return handle;
+        return {
+          sync: async () => {
+            directorySyncs++;
+            if (directorySyncs === 2) throw new Error("injected ack directory sync failure");
+            await handle.sync();
+          },
+          close: () => handle.close(),
+        };
+      },
+    }),
+    (error) => error?.code === TELEGRAM_QUEUE_ACK_ROLLED_BACK,
+  );
+
+  assert.equal(
+    directorySyncs,
+    4,
+    "pending publication, failed removal, rollback and pending cleanup must all be ordered",
+  );
+  const { document } = await loadQueueFile(file, { strict: true });
+  assert.deepEqual(
+    document.queues["1:"].map((item) => item.updateId),
+    [101, 102],
+  );
+});
+
+test("SIGKILL after acknowledgement rename restores the pending original queue on load", async (t) => {
+  const file = await queueFile(t);
+  const marker = join(dirname(file), "ack-renamed");
+  await enqueueQueueFile(file, "1:", privateUpdate(101, "first"));
+  await enqueueQueueFile(file, "1:", privateUpdate(102, "second"));
+  const child = spawn(
+    process.execPath,
+    [
+      join(import.meta.dirname, "../fixtures/telegram-queue-ack-crash-child.mjs"),
+      file,
+      marker,
+    ],
+    { stdio: ["ignore", "ignore", "pipe"] },
+  );
+  let stderr = "";
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+  t.after(() => {
+    if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+  });
+
+  await waitForFile(marker);
+  child.kill("SIGKILL");
+  const result = await new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("exit", (code, signal) => resolve({ code, signal }));
+  });
+  assert.deepEqual(result, { code: null, signal: "SIGKILL" }, stderr);
+
+  const { document } = await loadQueueFile(file, { strict: true });
+  assert.deepEqual(
+    document.queues["1:"].map((item) => item.updateId),
+    [101, 102],
+    "recovery may duplicate accepted head 101 but must not lose it",
+  );
+  assert.equal(existsSync(`${file}.ack-pending`), false);
+});
+
+test("failed ack rollback becomes fatal and stops drain before another queue", async (t) => {
+  const file = await queueFile(t);
+  await enqueueQueueFile(file, "1:", privateUpdate(101, "first"));
+  await enqueueQueueFile(file, "1:", privateUpdate(102, "second"));
+  let directorySyncs = 0;
+
+  await assert.rejects(
+    acknowledgeQueueHead(file, "1:", 101, {
+      openImpl: async (path, flags) => {
+        const handle = await open(path, flags);
+        if (String(path) !== dirname(file) || flags !== "r") return handle;
+        return {
+          sync: async () => {
+            directorySyncs++;
+            if (directorySyncs >= 2) {
+              throw new Error("injected persistent directory sync failure");
+            }
+            await handle.sync();
+          },
+          close: () => handle.close(),
+        };
+      },
+    }),
+    (error) => error?.code === TELEGRAM_QUEUE_FATAL_DURABILITY,
+  );
+
+  const fatal = Object.assign(new Error("ack durability is unknown"), {
+    code: TELEGRAM_QUEUE_FATAL_DURABILITY,
+  });
+  const delivered = [];
+  const document = {
+    version: 1,
+    queues: Object.fromEntries([
+      ["1:", [createQueueItem(privateUpdate(101, "first"), 1)]],
+      ["2:", [createQueueItem(privateUpdate(201, "must not pass"), 2)]],
+    ]),
+  };
+  await assert.rejects(
+    drainReadyQueueHeads({
+      loadImpl: async () => document,
+      runningImpl: () => false,
+      deliverImpl: async (update) => {
+        delivered.push(update.update_id);
+        return true;
+      },
+      acknowledgeImpl: async () => {
+        throw fatal;
+      },
+      settleUntil: new Map(),
+    }),
+    (error) => error === fatal,
+  );
+  assert.deepEqual(delivered, [101]);
+});
+
+test("drain keeps the head before acceptance and advances exactly one item after acceptance", async () => {
+  let document = enqueueItem(
+    enqueueItem(
+      { version: 1, queues: {} },
+      "1:",
+      createQueueItem(privateUpdate(101, "first"), 1),
+    ).document,
+    "1:",
+    createQueueItem(privateUpdate(102, "second"), 2),
+  ).document;
+  const delivered = [];
+  const loadImpl = async () => document;
+  const acknowledgeImpl = async (key, updateId) => {
+    document = removeQueueHead(document, key, updateId);
+  };
+
+  const rejectedCount = await drainReadyQueueHeads({
+    loadImpl,
+    runningImpl: () => false,
+    deliverImpl: async (update) => {
+      delivered.push(update.update_id);
+      return false;
+    },
+    acknowledgeImpl,
+    settleUntil: new Map(),
+  });
+  assert.equal(rejectedCount, 2);
+  assert.equal(queueHead(document, "1:").updateId, 101);
+
+  const acceptedCount = await drainReadyQueueHeads({
+    loadImpl,
+    runningImpl: () => false,
+    deliverImpl: async (update) => {
+      delivered.push(update.update_id);
+      return true;
+    },
+    acknowledgeImpl,
+    settleUntil: new Map(),
+  });
+  assert.equal(acceptedCount, 1);
+  assert.equal(queueHead(document, "1:").updateId, 102);
+  assert.deepEqual(delivered, [101, 101], "a retry may duplicate only the durable head");
+});
+
+test("an accepted head must observe its turn running and then idle before the next FIFO head", async () => {
+  let document = enqueueItem(
+    enqueueItem(
+      { version: 1, queues: {} },
+      "1:",
+      createQueueItem(privateUpdate(101, "first"), 1),
+    ).document,
+    "1:",
+    createQueueItem(privateUpdate(102, "second"), 2),
+  ).document;
+  let running = false;
+  const delivered = [];
+  const inFlight = new Map();
+  const options = {
+    loadImpl: async () => document,
+    runningImpl: () => running,
+    deliverImpl: async (update) => {
+      delivered.push(update.update_id);
+      return true;
+    },
+    acknowledgeImpl: async (key, updateId) => {
+      document = removeQueueHead(document, key, updateId);
+    },
+    settleUntil: new Map(),
+    inFlight,
+  };
+
+  assert.equal(await drainReadyQueueHeads(options), 1);
+  assert.deepEqual(delivered, [101]);
+
+  await drainReadyQueueHeads(options);
+  assert.deepEqual(delivered, [101], "idle before turn.started must keep the next head gated");
+
+  running = true;
+  await drainReadyQueueHeads(options);
+  assert.deepEqual(delivered, [101], "the accepted turn itself must keep the next head gated");
+
+  running = false;
+  assert.equal(await drainReadyQueueHeads(options), 0);
+  assert.deepEqual(delivered, [101, 102]);
+});
+
+test("a completed run-status generation releases a turn whose running state fell between polls", async () => {
+  let document = enqueueItem(
+    enqueueItem(
+      { version: 1, queues: {} },
+      "1:",
+      createQueueItem(privateUpdate(101, "first"), 1),
+    ).document,
+    "1:",
+    createQueueItem(privateUpdate(102, "second"), 2),
+  ).document;
+  let currentStatus = { status: "idle", generation: 10 };
+  const delivered = [];
+  const options = {
+    loadImpl: async () => document,
+    statusImpl: () => currentStatus,
+    runningImpl: () => currentStatus.status === "running",
+    deliverImpl: async (update) => {
+      delivered.push(update.update_id);
+      if (update.update_id === 101) {
+        // turn.started and turn.completed both happened while acceptance was pending.
+        currentStatus = { status: "idle", generation: 12 };
+      }
+      return true;
+    },
+    acknowledgeImpl: async (key, updateId) => {
+      document = removeQueueHead(document, key, updateId);
+    },
+    settleUntil: new Map(),
+    inFlight: new Map(),
+  };
+
+  assert.equal(await drainReadyQueueHeads(options), 1);
+  assert.equal(await drainReadyQueueHeads(options), 0);
+  assert.deepEqual(delivered, [101, 102]);
+});
+
+test("an accepted turn with no observable status transition releases only after the stale bound", async () => {
+  let document = enqueueItem(
+    enqueueItem(
+      { version: 1, queues: {} },
+      "1:",
+      createQueueItem(privateUpdate(101, "first"), 1),
+    ).document,
+    "1:",
+    createQueueItem(privateUpdate(102, "second"), 2),
+  ).document;
+  let nowMs = 1_000;
+  const delivered = [];
+  const options = {
+    loadImpl: async () => document,
+    statusImpl: () => ({ status: "idle", generation: 5 }),
+    runningImpl: () => false,
+    deliverImpl: async (update) => {
+      delivered.push(update.update_id);
+      return true;
+    },
+    acknowledgeImpl: async (key, updateId) => {
+      document = removeQueueHead(document, key, updateId);
+    },
+    now: () => nowMs,
+    settleUntil: new Map(),
+    inFlight: new Map(),
+    gateWaitMs: 100,
+  };
+
+  await drainReadyQueueHeads(options);
+  nowMs += 99;
+  await drainReadyQueueHeads(options);
+  assert.deepEqual(delivered, [101]);
+
+  nowMs += 1;
+  await drainReadyQueueHeads(options);
+  assert.deepEqual(delivered, [101, 102]);
+});
+
+test("a drain pass has one global delivery budget and rotates a stalled first key", async () => {
+  let nowMs = 0;
+  const attempts = [];
+  const rotationState = { afterKey: null };
+  const document = {
+    version: 1,
+    queues: Object.fromEntries(
+      [1, 2, 3].map((chatId) => {
+        const update = privateUpdate(chatId, `head ${chatId}`);
+        update.message.chat.id = chatId;
+        return [`${chatId}:`, [createQueueItem(update, chatId)]];
+      }),
+    ),
+  };
+  const options = {
+    loadImpl: async () => document,
+    runningImpl: () => false,
+    deliverImpl: async (update, { timeoutMs }) => {
+      attempts.push([update.message.chat.id, timeoutMs]);
+      nowMs += timeoutMs;
+      return false;
+    },
+    acknowledgeImpl: async () => assert.fail("a stalled head must remain durable"),
+    now: () => nowMs,
+    settleUntil: new Map(),
+    inFlight: new Map(),
+    rotationState,
+    passBudgetMs: 5_000,
+    deliveryTimeoutMs: 5_000,
+  };
+
+  await drainReadyQueueHeads(options);
+  assert.deepEqual(attempts, [[1, 5_000]]);
+
+  await drainReadyQueueHeads(options);
+  assert.deepEqual(
+    attempts,
+    [
+      [1, 5_000],
+      [2, 5_000],
+    ],
+    "the next pass must give the next chat the global timeout budget",
+  );
+
+  await drainReadyQueueHeads(options);
+  assert.deepEqual(
+    attempts,
+    [
+      [1, 5_000],
+      [2, 5_000],
+      [3, 5_000],
+    ],
+  );
+});
+
+test("a missing terminal event becomes drainable after the run-status TTL", async () => {
+  const key = "9:";
+  status.setChatStatus(key, {
+    status: "running",
+    continuationToken: "9::",
+    sessionId: "orphaned-session",
+    turnId: "orphaned-turn",
+  });
+  const staleAt = status.getChatStatus(key).updatedAt + status.RUN_STALE_MS + 1;
+  let document = enqueueItem(
+    { version: 1, queues: {} },
+    key,
+    createQueueItem(privateUpdate(301, "recover after stale status"), 1),
+  ).document;
+  const delivered = [];
+
+  const remaining = await drainReadyQueueHeads({
+    loadImpl: async () => document,
+    runningImpl: (chatKey) => status.isRunning(chatKey, staleAt),
+    deliverImpl: async (update) => {
+      delivered.push(update.update_id);
+      return true;
+    },
+    acknowledgeImpl: async (chatKey, updateId) => {
+      document = removeQueueHead(document, chatKey, updateId);
+    },
+    settleUntil: new Map(),
+  });
+
+  assert.deepEqual(delivered, [301]);
+  assert.equal(remaining, 0);
+});
+
+test("legacy string arrays preserve private owner text but never invent a group author", async (t) => {
+  const file = await queueFile(t);
+  await writeFile(
+    file,
+    JSON.stringify({
+      "42:": ["first", "second"],
+      "-100:7": ["topic follow-up"],
+    }),
+  );
+
+  const document = await migrateQueueFile(file);
+  assert.equal(document.version, 1);
+  assert.equal(queueCount(document), 2);
+  assert.deepEqual(
+    document.queues["42:"].map((item) => item.legacyText),
+    ["first", "second"],
+  );
+  const privateReplay = materializeQueueItem("42:", document.queues["42:"][0], {
+    legacyAllowedUserIds: new Set(["42"]),
+  });
+  assert.equal(privateReplay.message.text, "first");
+  assert.equal(privateReplay.message.chat.id, 42);
+  assert.equal(privateReplay.message.from.id, 42);
+  const legacyGroupItem = normalizeQueueDocument({
+    "-100:7": ["topic follow-up"],
+  }).document.queues["-100:7"][0];
+  assert.equal(
+    materializeQueueItem("-100:7", legacyGroupItem, {
+      legacyAllowedUserIds: new Set(["42"]),
+    }),
+    null,
+  );
+
+  const persisted = JSON.parse(await readFile(file, "utf8"));
+  assert.equal(persisted.version, 1);
+  assert.equal(queueCount(persisted), 2);
+  const [quarantineName] = (await readdir(dirname(file))).filter((name) =>
+    name.includes(".legacy-unattributed-"));
+  const quarantined = JSON.parse(await readFile(join(dirname(file), quarantineName), "utf8"));
+  assert.equal(queueCount(quarantined), 1);
+  assert.equal(quarantined.queues["-100:7"][0].legacyText, "topic follow-up");
+});
+
+test("legacy group quarantine failure leaves the original queue active for retry", async (t) => {
+  const file = await queueFile(t);
+  const original = JSON.stringify({
+    "42:": ["private follow-up"],
+    "-100:": ["group text with unknown author"],
+  });
+  await writeFile(file, original);
+
+  await assert.rejects(
+    migrateQueueFile(file, {
+      linkImpl: async (source, target) => {
+        if (target.includes(".legacy-unattributed-")) {
+          throw new Error("quarantine link failed");
+        }
+        await link(source, target);
+      },
+    }),
+    /quarantine link failed/,
+  );
+
+  assert.equal(await readFile(file, "utf8"), original);
+  assert.deepEqual(
+    (await readdir(dirname(file))).filter((name) => name.includes(".legacy-unattributed-")),
+    [],
+  );
+});
+
+test("failed active migration keeps both the old queue and its group quarantine", async (t) => {
+  const file = await queueFile(t);
+  const original = JSON.stringify({
+    "42:": ["private follow-up"],
+    "-100:": ["group text with unknown author"],
+  });
+  await writeFile(file, original);
+
+  await assert.rejects(
+    migrateQueueFile(file, {
+      renameImpl: async (source, target) => {
+        if (target === file) throw new Error("active rename failed");
+        await rename(source, target);
+      },
+    }),
+    /active rename failed/,
+  );
+
+  assert.equal(await readFile(file, "utf8"), original);
+  const [quarantineName] = (await readdir(dirname(file))).filter((name) =>
+    name.includes(".legacy-unattributed-"));
+  const quarantined = JSON.parse(await readFile(join(dirname(file), quarantineName), "utf8"));
+  assert.equal(quarantined.queues["-100:"][0].legacyText, "group text with unknown author");
+});
+
+test("separate legacy migrations never overwrite an earlier group quarantine", async (t) => {
+  const file = await queueFile(t);
+  const first = JSON.stringify({ "-100:": ["first byte set"] });
+  const second = JSON.stringify({ "-100:": ["second byte set"] });
+  const logged = [];
+  const options = {
+    quarantineNow: () => 123,
+    quarantineNonce: () => "same",
+    onLegacyQuarantine: (path) => logged.push(path),
+  };
+
+  await writeFile(file, first);
+  await migrateQueueFile(file, options);
+  await writeFile(file, second);
+  await migrateQueueFile(file, options);
+
+  assert.equal(logged.length, 2);
+  assert.notEqual(logged[0], logged[1]);
+  assert.match(logged[0], /\.legacy-unattributed-/);
+  assert.match(logged[1], /\.legacy-unattributed-/);
+  const preserved = await Promise.all(
+    logged.map(async (path) => JSON.parse(await readFile(path, "utf8"))),
+  );
+  assert.deepEqual(
+    preserved.map((document) => document.queues["-100:"][0].legacyText),
+    ["first byte set", "second byte set"],
+  );
+});
+
+test("drain leaves legacy group text with unknown author undelivered", async () => {
+  let document = normalizeQueueDocument({
+    "-100:": ["unaddressed group text"],
+  }).document;
+  const delivered = [];
+  const acknowledged = [];
+
+  const remaining = await drainReadyQueueHeads({
+    loadImpl: async () => document,
+    runningImpl: () => false,
+    legacyAllowedUserIds: new Set(["42"]),
+    deliverImpl: async (update) => {
+      delivered.push(update);
+      return true;
+    },
+    acknowledgeImpl: async (chatKey, updateId) => {
+      acknowledged.push([chatKey, updateId]);
+      document = removeQueueHead(document, chatKey, updateId);
+    },
+    settleUntil: new Map(),
+  });
+
+  assert.deepEqual(delivered, []);
+  assert.deepEqual(acknowledged, []);
+  assert.equal(remaining, 1);
+  assert.equal(queueHead(document, "-100:").legacyText, "unaddressed group text");
+});
+
+test("queued media and quoted metadata replay from the durable update without transformation", async (t) => {
+  const file = await queueFile(t);
+  const update = {
+    update_id: 201,
+    message: {
+      message_id: 9,
+      date: 1,
+      chat: { id: 1, type: "private" },
+      from: { id: 42, is_bot: false, first_name: "Owner" },
+      caption: "look at this",
+      photo: [{ file_id: "small" }, { file_id: "large" }],
+      reply_to_message: {
+        message_id: 8,
+        from: { id: 7, is_bot: false, first_name: "Quoted" },
+        text: "quoted source",
+      },
+    },
+  };
+  await enqueueQueueFile(file, "1:", update);
+  const { document } = await loadQueueFile(file, { strict: true });
+
+  assert.deepEqual(materializeQueueItem("1:", queueHead(document, "1:")), update);
+});
+
+test("busy routing is fail-closed and keeps addressed private, group and topic updates", () => {
+  const allowedUserIds = new Set(["42"]);
+  const options = { allowedUserIds, botUsername: "my_bot" };
+  const group = (text, threadId, userId = 42) => ({
+    update_id: 1,
+    message: {
+      message_id: 1,
+      date: 1,
+      chat: { id: -100, type: "supergroup" },
+      from: { id: userId, is_bot: false },
+      text,
+      ...(threadId === undefined ? {} : { message_thread_id: threadId }),
+    },
+  });
+
+  assert.equal(shouldQueueBusyUpdate(privateUpdate(1, "private"), options), true);
+  assert.equal(
+    shouldQueueBusyUpdate(
+      {
+        ...privateUpdate(1, "untrusted"),
+        message: { ...privateUpdate(1, "untrusted").message, from: { id: 7 } },
+      },
+      options,
+    ),
+    false,
+  );
+  assert.equal(shouldQueueBusyUpdate(group("group noise"), options), false);
+  assert.equal(shouldQueueBusyUpdate(group("@my_bot addressed"), options), true);
+  assert.equal(shouldQueueBusyUpdate(group("/task topic", 7), options), true);
+  assert.equal(shouldQueueBusyUpdate(group("@my_bot untrusted", 7, 7), options), false);
+  assert.equal(shouldQueueBusyUpdate(group("x@my_botany.example"), options), false);
+  assert.equal(shouldQueueBusyUpdate(group("@my_bot_suffix"), options), false);
+});
+
+test("group routing validates exact Telegram entities across Unicode and malformed input", () => {
+  const options = { allowedUserIds: new Set(["42"]), botUsername: "my_bot" };
+  const group = (text, entities) => ({
+    update_id: 1,
+    message: {
+      message_id: 1,
+      date: 1,
+      chat: { id: -100, type: "supergroup" },
+      from: { id: 42, is_bot: false },
+      text,
+      entities,
+    },
+  });
+
+  const unicodeText = "🙂 ask @my_bot now";
+  assert.equal(
+    shouldQueueBusyUpdate(
+      group(unicodeText, [{
+        type: "mention",
+        offset: unicodeText.indexOf("@my_bot"),
+        length: "@my_bot".length,
+      }]),
+      options,
+    ),
+    true,
+  );
+  assert.equal(shouldQueueBusyUpdate(group("İ @MY_BOT", undefined), options), true);
+  assert.equal(
+    shouldQueueBusyUpdate(
+      group("Ж@my_bot", [{ type: "mention", offset: 1, length: 7 }]),
+      options,
+    ),
+    false,
+  );
+  assert.equal(
+    shouldQueueBusyUpdate(
+      group("@my_bot_suffix", [{ type: "mention", offset: 0, length: 7 }]),
+      options,
+    ),
+    false,
+  );
+  assert.equal(
+    shouldQueueBusyUpdate(
+      group("@my_bot", [{ type: "mention", offset: -1, length: 999 }]),
+      options,
+    ),
+    false,
+  );
+  assert.equal(
+    shouldQueueBusyUpdate(
+      group("/task@my_bot", [{
+        type: "bot_command",
+        offset: 0,
+        length: "/task@my_bot".length,
+      }]),
+      options,
+    ),
+    true,
+  );
+  assert.equal(
+    shouldQueueBusyUpdate(
+      group("/task@my_bot_suffix", [{
+        type: "bot_command",
+        offset: 0,
+        length: "/task@my_bot".length,
+      }]),
+      options,
+    ),
+    false,
+  );
+  assert.doesNotThrow(() =>
+    shouldQueueBusyUpdate(group("@my_bot", { offset: 0, length: 7 }), options));
+  assert.equal(
+    shouldQueueBusyUpdate(group("@my_bot", { offset: 0, length: 7 }), options),
+    false,
+  );
+});
+
+test("__proto__ is persisted as a queue data key without prototype mutation or loss", async (t) => {
+  const file = await queueFile(t);
+  await enqueueQueueFile(file, "__proto__", privateUpdate(401, "prototype-safe"));
+
+  const { document } = await loadQueueFile(file, { strict: true });
+  assert.equal(Object.hasOwn(document.queues, "__proto__"), true);
+  assert.equal(Object.getPrototypeOf(document.queues), Object.prototype);
+  assert.equal(queueCount(document, "__proto__"), 1);
+  assert.equal(queueHead(document, "__proto__").updateId, 401);
+  assert.deepEqual(queueKeys(document), ["__proto__"]);
+
+  await acknowledgeQueueHead(file, "__proto__", 401);
+  const after = await loadQueueFile(file, { strict: true });
+  assert.equal(Object.hasOwn(after.document.queues, "__proto__"), false);
+  assert.equal(queueCount(after.document), 0);
+});

--- a/scripts/lib/telegram-reset-intent.mjs
+++ b/scripts/lib/telegram-reset-intent.mjs
@@ -1,0 +1,120 @@
+import { randomBytes } from "node:crypto";
+import { mkdir, open, readFile, readdir, rename, rm, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+export const TELEGRAM_RESET_INTENT_VERSION = 1;
+
+function intentPath(directory, chatKey) {
+  return join(directory, `${Buffer.from(chatKey, "utf8").toString("base64url")}.json`);
+}
+
+function normalizeIntent(value, source) {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    Array.isArray(value) ||
+    value.version !== TELEGRAM_RESET_INTENT_VERSION ||
+    typeof value.chatKey !== "string" ||
+    !value.chatKey ||
+    typeof value.continuationToken !== "string" ||
+    !value.continuationToken ||
+    !Number.isSafeInteger(value.requestedAt) ||
+    value.requestedAt < 0
+  ) {
+    throw new Error(`invalid Telegram reset intent in ${source}`);
+  }
+  return {
+    version: TELEGRAM_RESET_INTENT_VERSION,
+    chatKey: value.chatKey,
+    continuationToken: value.continuationToken,
+    requestedAt: value.requestedAt,
+  };
+}
+
+async function syncDirectory(path) {
+  const directory = await open(path, "r");
+  try {
+    await directory.sync();
+  } finally {
+    await directory.close();
+  }
+}
+
+async function ensureIntentDirectory(directory) {
+  const parent = dirname(directory);
+  await mkdir(parent, { recursive: true });
+  await mkdir(directory, { recursive: true });
+  await syncDirectory(parent);
+}
+
+export async function persistTelegramResetIntent(
+  directory,
+  chatKey,
+  continuationToken,
+  { now = Date.now, nonce = () => randomBytes(8).toString("hex") } = {},
+) {
+  const intent = normalizeIntent(
+    {
+      version: TELEGRAM_RESET_INTENT_VERSION,
+      chatKey,
+      continuationToken,
+      requestedAt: now(),
+    },
+    "new reset request",
+  );
+  await ensureIntentDirectory(directory);
+  const target = intentPath(directory, chatKey);
+  const tmp = `${target}.tmp-${process.pid}-${nonce()}`;
+  try {
+    await writeFile(tmp, JSON.stringify(intent), {
+      encoding: "utf8",
+      flag: "wx",
+      mode: 0o600,
+    });
+    const staged = await open(tmp, "r+");
+    try {
+      await staged.sync();
+    } finally {
+      await staged.close();
+    }
+    await rename(tmp, target);
+    await syncDirectory(directory);
+  } finally {
+    await rm(tmp, { force: true }).catch(() => {});
+  }
+  return intent;
+}
+
+export async function loadTelegramResetIntents(directory) {
+  let entries;
+  try {
+    entries = await readdir(directory, { withFileTypes: true });
+  } catch (error) {
+    if (error?.code === "ENOENT") return [];
+    throw error;
+  }
+  const intents = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+    const path = join(directory, entry.name);
+    const intent = normalizeIntent(JSON.parse(await readFile(path, "utf8")), path);
+    if (intentPath(directory, intent.chatKey) !== path) {
+      throw new Error(`Telegram reset intent filename does not match its chat key: ${path}`);
+    }
+    intents.push(intent);
+  }
+  return intents.sort(
+    (left, right) =>
+      left.requestedAt - right.requestedAt || left.chatKey.localeCompare(right.chatKey),
+  );
+}
+
+export async function clearTelegramResetIntent(directory, chatKey) {
+  try {
+    await rm(intentPath(directory, chatKey));
+  } catch (error) {
+    if (error?.code === "ENOENT") return;
+    throw error;
+  }
+  await syncDirectory(directory);
+}

--- a/scripts/lib/telegram-turn-start.d.mts
+++ b/scripts/lib/telegram-turn-start.d.mts
@@ -1,0 +1,19 @@
+export interface PublishTelegramTurnStartedOptions {
+  chatKey: string;
+  continuationToken: string;
+  sessionId: string;
+  turnId: string;
+  setStatusImpl: (chatKey: string, patch: Record<string, unknown>) => unknown;
+  setStatusIfImpl: (
+    chatKey: string,
+    expected: Record<string, unknown>,
+    patch: Record<string, unknown>,
+  ) => unknown;
+  sendWorkingStatusImpl: () => Promise<number | null | undefined>;
+  removeWorkingStatusImpl?: (messageId: number) => Promise<unknown>;
+  onWorkingStatusError?: (error: unknown) => void;
+}
+
+export function publishTelegramTurnStarted(
+  options: PublishTelegramTurnStartedOptions,
+): Promise<void>;

--- a/scripts/lib/telegram-turn-start.mjs
+++ b/scripts/lib/telegram-turn-start.mjs
@@ -1,0 +1,42 @@
+export async function publishTelegramTurnStarted({
+  chatKey,
+  continuationToken,
+  sessionId,
+  turnId,
+  setStatusImpl,
+  setStatusIfImpl,
+  sendWorkingStatusImpl,
+  removeWorkingStatusImpl = async () => {},
+  onWorkingStatusError = () => {},
+}) {
+  setStatusImpl(chatKey, {
+    status: "running",
+    continuationToken,
+    sessionId,
+    turnId,
+    statusMessageId: null,
+    wasCancelled: null,
+  });
+
+  let statusMessageId;
+  try {
+    statusMessageId = await sendWorkingStatusImpl();
+  } catch (error) {
+    onWorkingStatusError(error);
+    return;
+  }
+  if (statusMessageId === null || statusMessageId === undefined) return;
+
+  const attached = setStatusIfImpl(
+    chatKey,
+    { status: "running", sessionId, turnId },
+    { statusMessageId },
+  );
+  if (!attached) {
+    try {
+      await removeWorkingStatusImpl(statusMessageId);
+    } catch (error) {
+      onWorkingStatusError(error);
+    }
+  }
+}

--- a/scripts/lib/telegram-turn-start.test.mjs
+++ b/scripts/lib/telegram-turn-start.test.mjs
@@ -1,0 +1,91 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { publishTelegramTurnStarted } from "./telegram-turn-start.mjs";
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+test("turn.started publishes running before the working-status request can block", async () => {
+  const working = deferred();
+  const events = [];
+  let status = { status: "idle" };
+
+  const publishing = publishTelegramTurnStarted({
+    chatKey: "1:",
+    continuationToken: "1::",
+    sessionId: "session-1",
+    turnId: "turn-1",
+    setStatusImpl: (_key, patch) => {
+      events.push("running");
+      status = { ...status, ...patch };
+      return status;
+    },
+    setStatusIfImpl: (_key, expected, patch) => {
+      assert.equal(status.status, expected.status);
+      assert.equal(status.sessionId, expected.sessionId);
+      assert.equal(status.turnId, expected.turnId);
+      events.push("status-message");
+      status = { ...status, ...patch };
+      return status;
+    },
+    sendWorkingStatusImpl: async () => {
+      events.push("working-request");
+      return working.promise;
+    },
+  });
+
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(status.status, "running");
+  assert.equal(status.statusMessageId, null);
+  assert.deepEqual(events, ["running", "working-request"]);
+
+  working.resolve(77);
+  await publishing;
+  assert.equal(status.statusMessageId, 77);
+  assert.deepEqual(events, ["running", "working-request", "status-message"]);
+});
+
+test("a late working-status response cannot attach to a completed or newer turn", async () => {
+  const working = deferred();
+  let status = { status: "idle" };
+  const removed = [];
+
+  const publishing = publishTelegramTurnStarted({
+    chatKey: "1:",
+    continuationToken: "1::",
+    sessionId: "session-1",
+    turnId: "turn-1",
+    setStatusImpl: (_key, patch) => {
+      status = { ...status, ...patch };
+      return status;
+    },
+    setStatusIfImpl: (_key, expected, patch) => {
+      if (
+        status.status !== expected.status ||
+        status.sessionId !== expected.sessionId ||
+        status.turnId !== expected.turnId
+      ) {
+        return null;
+      }
+      status = { ...status, ...patch };
+      return status;
+    },
+    sendWorkingStatusImpl: () => working.promise,
+    removeWorkingStatusImpl: async (messageId) => {
+      removed.push(messageId);
+    },
+  });
+
+  status = { status: "idle", sessionId: "session-2", turnId: "turn-2" };
+  working.resolve(78);
+  await publishing;
+
+  assert.deepEqual(removed, [78]);
+  assert.equal(status.statusMessageId, undefined);
+});

--- a/scripts/telegram-poll-queue-durable.test.mjs
+++ b/scripts/telegram-poll-queue-durable.test.mjs
@@ -1,0 +1,180 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const ROOT = resolve(import.meta.dirname, "..");
+const HARNESS = join(ROOT, "scripts/fixtures/telegram-poll-queue-harness.mjs");
+
+function makeDataDir(t, label) {
+  const path = mkdtempSync(join(tmpdir(), `iva-008-${label}-`));
+  t.after(() => rmSync(path, { recursive: true, force: true }));
+  return path;
+}
+
+function runHarness(mode, dataDir, fault = "none") {
+  const result = spawnSync(
+    process.execPath,
+    ["--experimental-test-module-mocks", HARNESS, mode, dataDir, fault],
+    {
+      cwd: ROOT,
+      env: { ...process.env },
+      encoding: "utf8",
+      timeout: 10_000,
+    },
+  );
+  assert.equal(
+    result.status,
+    0,
+    `harness failed (${mode}/${fault})\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  );
+  return JSON.parse(readFileSync(join(dataDir, "queue-harness-result.json"), "utf8"));
+}
+
+for (const fault of ["write", "rename"]) {
+  test(`busy queue ${fault} failure does not advance Telegram offset`, (t) => {
+    const dataDir = makeDataDir(t, `disk-${fault}`);
+    const result = runHarness("disk-failure", dataDir, fault);
+
+    assert.equal(
+      result.offset.offset,
+      100,
+      "the same Telegram update must be retried until its FIFO item is durable",
+    );
+    assert.deepEqual(result.deliveries, []);
+  });
+}
+
+test("directory sync failure requires a durable duplicate retry before offset advances", (t) => {
+  const dataDir = makeDataDir(t, "dir-sync-retry");
+  const result = runHarness("dir-sync-retry", dataDir, "dir-sync-once");
+
+  assert.deepEqual(
+    result.requestedOffsets,
+    [100, 100, 102],
+    "the update must be requested again before its offset is committed",
+  );
+  assert.equal(result.queueDirSyncAttempts, 2);
+  assert.equal(
+    result.queueDirSyncSuccesses,
+    1,
+    "the duplicate retry must repeat the atomic write through a successful parent-dir fsync",
+  );
+  assert.equal(result.offset.offset, 102);
+  assert.equal(result.queue.queues["1:"].length, 1);
+  assert.equal(result.queue.queues["1:"][0].updateId, 101);
+});
+
+test("queued follow-ups auto-drain in FIFO order when the current turn becomes idle", (t) => {
+  const dataDir = makeDataDir(t, "auto-drain");
+  const result = runHarness("auto-drain", dataDir);
+
+  assert.deepEqual(
+    result.deliveries.map((update) => [update.update_id, update.message?.text]),
+    [
+      [101, "first"],
+      [102, "second"],
+    ],
+  );
+  assert.deepEqual(result.deliveryRoutes, [
+    "/eve/v1/telegram/accepted",
+    "/eve/v1/telegram/accepted",
+  ]);
+  assert.deepEqual(
+    result.queue,
+    { version: 1, queues: {} },
+    "accepted FIFO items must be removed only after Eve accepts them",
+  );
+  assert.deepEqual(
+    result.queueStatuses.map((status) => status.text),
+    [
+      "Queued (1). I'll start it automatically when the current task finishes.",
+      "Queued (2). I'll start it automatically when the current task finishes.",
+    ],
+  );
+});
+
+test("a restarted bridge recovers and drains the persisted FIFO without a third user message", (t) => {
+  const dataDir = makeDataDir(t, "restart");
+  const beforeRestart = runHarness("restart-persist", dataDir);
+  assert.equal(
+    Object.values(beforeRestart.queue.queues).flat().length,
+    2,
+    "the first process must leave both busy-time follow-ups durable",
+  );
+
+  const afterRestart = runHarness("restart-drain", dataDir);
+  assert.deepEqual(
+    afterRestart.deliveries.map((update) => [update.update_id, update.message?.text]),
+    [
+      [101, "first"],
+      [102, "second"],
+    ],
+  );
+  assert.deepEqual(afterRestart.queue, { version: 1, queues: {} });
+});
+
+test("a persistently failing queue head does not block other chats or Telegram polling", (t) => {
+  const dataDir = makeDataDir(t, "fair-drain");
+  const result = runHarness("fair-drain", dataDir);
+
+  assert.deepEqual(
+    result.deliveries.map((update) => [update.message.chat.id, update.update_id]),
+    [
+      [1, 101],
+      [2, 102],
+    ],
+    "one failed acceptance attempt must yield to the next chat key",
+  );
+  assert.deepEqual(
+    Object.fromEntries(
+      Object.entries(result.queue.queues).map(([key, items]) => [
+        key,
+        items.map((item) => item.updateId),
+      ]),
+    ),
+    { "1:": [101] },
+    "the poison head stays durable while an accepted head is acknowledged",
+  );
+  assert.deepEqual(
+    result.requestedOffsets,
+    [100],
+    "the bridge must return to getUpdates after a bounded drain pass",
+  );
+});
+
+test("unaddressed group noise is excluded from a busy conversation FIFO", (t) => {
+  const dataDir = makeDataDir(t, "group-noise");
+  const result = runHarness("group-noise", dataDir);
+
+  assert.equal(result.queue.queues?.["-100:"], undefined);
+  assert.deepEqual(result.deliveries, []);
+  assert.deepEqual(result.reactions, []);
+  assert.equal(result.offset.offset, 103, "ignored group noise is consumed exactly once");
+});
+
+test("busy FIFO routes private, group and forum-topic updates without absorbing group noise", (t) => {
+  const dataDir = makeDataDir(t, "routing");
+  const result = runHarness("routing", dataDir);
+  const queues = result.queue.queues;
+
+  assert.deepEqual(
+    Object.fromEntries(
+      Object.entries(queues).map(([key, items]) => [
+        key,
+        items.map((item) => [item.version, item.updateId, item.update.message?.text]),
+      ]),
+    ),
+    {
+      "1:": [[1, 101, "private follow-up"]],
+      "-100:": [[1, 103, "@my_bot group follow-up"]],
+      "-100:7": [[1, 104, "/task topic follow-up"]],
+    },
+  );
+  assert.equal(queues["-100:7"][0].update.message.message_thread_id, 7);
+  assert.equal(result.offset.offset, 105);
+  assert.equal(result.reactions.length, 3);
+  assert.equal(result.queueStatuses.length, 3);
+});

--- a/scripts/telegram-poll-reset.test.mjs
+++ b/scripts/telegram-poll-reset.test.mjs
@@ -9,7 +9,17 @@ process.env.ASSISTANT_DATA_DIR = dataDir;
 process.env.TELEGRAM_BOT_TOKEN = "test-token";
 process.env.TELEGRAM_WEBHOOK_SECRET_TOKEN = "test-secret";
 
-const [{ completeScopedResetState, loadQueue, writeQueueAtomic }, status] = await Promise.all([
+const [{
+  clearPrivateResetIntent,
+  completeScopedResetState,
+  drainReadyQueueHeads,
+  loadPrivateResetIntents,
+  loadQueue,
+  performScopedReset,
+  persistPrivateResetIntent,
+  reconcileScopedResetIntents,
+  writeQueueAtomic,
+}, status] = await Promise.all([
   import(`./telegram-poll.mjs?reset-test=${Date.now()}`),
   import(`./lib/run-status.mjs?reset-test=${Date.now()}`),
 ]);
@@ -48,10 +58,10 @@ test("private reset clears only the target chat status and queue", async () => {
   assert.equal(untouched.sessionId, "session-b");
   assert.equal(untouched.continuationToken, "chat-b:7:reply");
 
-  assert.deepEqual(
-    JSON.parse(readFileSync(join(dataDir, "telegram-queue.json"), "utf8")),
-    { "chat-b:7": ["keep me"] },
-  );
+  const queue = JSON.parse(readFileSync(join(dataDir, "telegram-queue.json"), "utf8"));
+  assert.equal(queue.version, 1);
+  assert.deepEqual(Object.keys(queue.queues), ["chat-b:7"]);
+  assert.equal(queue.queues["chat-b:7"][0].legacyText, "keep me");
 });
 
 test("group reset preserves the shared topic queue", async () => {
@@ -100,6 +110,101 @@ test("failed private queue cleanup does not expose an idle tombstone", async () 
   );
   assert.equal(status.getChatStatus("chat-c:").status, "running");
   assert.equal(status.getChatStatus("chat-c:").sessionId, "session-c");
+});
+
+test("private reset intent is durable before remote reset and clears after local cleanup", async () => {
+  const events = [];
+  await performScopedReset("chat-intent:", "chat-intent::", {
+    clearQueue: true,
+    persistIntentImpl: async () => events.push("intent"),
+    requestResetImpl: async () => events.push("remote"),
+    completeStateImpl: async () => events.push("cleanup"),
+    clearIntentImpl: async () => events.push("clear-intent"),
+  });
+
+  assert.deepEqual(events, ["intent", "remote", "cleanup", "clear-intent"]);
+});
+
+test("startup reconciliation prevents a remotely reset private queue from draining after a crash", async () => {
+  const key = "chat-crash:";
+  const continuationToken = "chat-crash::";
+  status.setChatStatus(key, {
+    status: "running",
+    continuationToken,
+    sessionId: "old-session",
+    turnId: "old-turn",
+  });
+  await writeQueueAtomic({
+    version: 1,
+    queues: {
+      [key]: [{
+        version: 1,
+        updateId: 901,
+        enqueuedAt: 1,
+        update: {
+          update_id: 901,
+          message: {
+            message_id: 901,
+            date: 1,
+            chat: { id: 901, type: "private" },
+            from: { id: 42, is_bot: false, first_name: "Owner" },
+            text: "must be discarded after reset",
+          },
+        },
+      }],
+    },
+  });
+  await persistPrivateResetIntent(key, continuationToken);
+
+  const remoteRetries = [];
+  await reconcileScopedResetIntents({
+    requestResetImpl: async (intent) => {
+      remoteRetries.push(intent);
+    },
+  });
+
+  assert.deepEqual(
+    remoteRetries.map(({ chatKey, continuationToken: token }) => [chatKey, token]),
+    [[key, continuationToken]],
+  );
+  assert.deepEqual(await loadPrivateResetIntents(), []);
+  assert.equal(status.getChatStatus(key).status, "idle");
+  assert.equal(status.getChatStatus(key).sessionId, undefined);
+  assert.equal((await loadQueue()).queues[key], undefined);
+
+  const delivered = [];
+  assert.equal(
+    await drainReadyQueueHeads({
+      deliverImpl: async (update) => {
+        delivered.push(update.update_id);
+        return true;
+      },
+      settleUntil: new Map(),
+      inFlight: new Map(),
+    }),
+    0,
+  );
+  assert.deepEqual(delivered, [], "startup must reconcile reset intent before any old head can drain");
+});
+
+test("failed reset reconciliation keeps its durable intent for the next startup", async () => {
+  const key = "chat-retry:";
+  await persistPrivateResetIntent(key, "chat-retry::");
+
+  await assert.rejects(
+    reconcileScopedResetIntents({
+      requestResetImpl: async () => {
+        throw new Error("eve unavailable");
+      },
+    }),
+    /eve unavailable/,
+  );
+
+  assert.deepEqual(
+    (await loadPrivateResetIntents()).map(({ chatKey }) => chatKey),
+    [key],
+  );
+  await clearPrivateResetIntent(key);
 });
 
 test("queue rename failure keeps the previous whole queue byte-for-byte", async () => {
@@ -154,7 +259,7 @@ test("ordinary queue load quarantines corrupt bytes and continues", async () => 
   const corrupt = '{"chat-g:": ["unfinished"';
   writeFileSync(queueFile, corrupt);
 
-  assert.deepEqual(await loadQueue(), {});
+  assert.deepEqual(await loadQueue(), { version: 1, queues: {} });
 
   const backups = readdirSync(dataDir).filter((name) =>
     name.startsWith("telegram-queue.json.corrupt-"),

--- a/scripts/telegram-poll.mjs
+++ b/scripts/telegram-poll.mjs
@@ -8,7 +8,7 @@
 // so we fetch updates from Telegram ourselves (getUpdates, long-poll) and POST them to
 // the local eve route with the same secret — Telegram sees an ordinary bot, no proxy needed.
 // The channel/agent are unchanged. Webhook and polling are mutually exclusive → deleteWebhook on start.
-import { readFile, writeFile, mkdir, rename, rm, readdir, stat } from "node:fs/promises";
+import { readFile, writeFile, mkdir, rm, readdir, stat } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { execFile } from "node:child_process";
 import { join, dirname } from "node:path";
@@ -30,10 +30,40 @@ import { acquireUpdateLock, releaseUpdateLock } from "./lib/update-safety.mjs";
 import { inspectUpstream, markVersionNotified, updateOffer } from "./lib/update-check.mjs";
 // ESC-остановка: канал пишет в data/run-status.d, идёт ли сейчас ход по чату;
 // мост по нему буферизует входящие (см. очередь ниже) и обслуживает /stop.
-import { getChatStatus, isRunning, setChatStatus } from "./lib/run-status.mjs";
+import {
+  getChatStatus,
+  isRunning,
+  RUN_STALE_MS,
+  setChatStatus,
+} from "./lib/run-status.mjs";
 import { classifyDeliverStatus } from "./lib/deliver-policy.mjs";
 import { alreadyDelivered, parseOffsetFile, serializeOffsetFile } from "./lib/offset-store.mjs";
 import { continuationTokenForControl, requestTelegramReset } from "./lib/telegram-reset.mjs";
+import {
+  clearTelegramResetIntent,
+  loadTelegramResetIntents,
+  persistTelegramResetIntent,
+} from "./lib/telegram-reset-intent.mjs";
+import {
+  addTelegramQueueReceipt,
+  TELEGRAM_ACCEPTANCE_KIND_HEADER,
+  TELEGRAM_ACCEPTANCE_ROUTE,
+} from "./lib/telegram-acceptance.mjs";
+import {
+  acknowledgeQueueHead,
+  clearQueueFileKey,
+  enqueueQueueFile,
+  isReplyToBot,
+  loadQueueFile,
+  materializeQueueItem,
+  migrateQueueFile,
+  queueCount,
+  queueHead,
+  queueKeys,
+  shouldQueueBusyUpdate,
+  TELEGRAM_QUEUE_FATAL_DURABILITY,
+  writeQueueFileAtomic,
+} from "./lib/telegram-queue.mjs";
 // Двуязычие: единый источник языка (getLang) + одна таблица команд (COMMANDS) для /help
 // и синего командного меню Telegram. tr(en, ru) — функция (язык не замораживаем в const).
 import { getLang, tr, helpText, botCommands } from "./lib/i18n.mjs";
@@ -47,6 +77,7 @@ const NODE = process.execPath;
 
 const TOKEN = process.env.TELEGRAM_BOT_TOKEN;
 const BOT_USER_ID = /^(\d+):/.exec(TOKEN ?? "")?.[1] ?? null;
+const BOT_USERNAME = process.env.TELEGRAM_BOT_USERNAME ?? "my_bot";
 const SECRET = process.env.TELEGRAM_WEBHOOK_SECRET_TOKEN;
 const PORT = process.env.IVA_PORT ?? "8723";
 const HOST = (process.env.ASSISTANT_HOST ?? `http://127.0.0.1:${PORT}`).replace(/\/$/, "");
@@ -57,6 +88,7 @@ const DATA_DIR = DATA_DIR_RAW.startsWith("/") ? DATA_DIR_RAW : join(ROOT, DATA_D
 const ENV_PATH = join(ROOT, ".env");
 const DATA_DIR_ABS = DATA_DIR;
 const ROUTE = `${HOST}/eve/v1/telegram`;
+const ACCEPTANCE_ROUTE = `${HOST}${TELEGRAM_ACCEPTANCE_ROUTE}`;
 const RESET_ROUTE = `${ROUTE}/reset`;
 const API = `https://api.telegram.org/bot${TOKEN}`;
 const OFFSET_FILE = join(DATA_DIR, "telegram-offset.json");
@@ -184,23 +216,58 @@ async function downloadTelegramFile(fileId, maxBytes) {
 // не даёт надёжного признака «апдейт битый навсегда» (тот же 409 может быть временным
 // конфликтом хука), поэтому и эти статусы ретраятся, но ОГРАНИЧЕННО: DROP_ATTEMPTS
 // попыток (~5 минут), затем апдейт выбрасывается, чтобы не заморозить все чаты.
-// Returns true when eve accepted the update, false when it was dropped.
+// Direct delivery keeps that policy. Durable queue replay opts into one bounded attempt
+// per drain pass: its on-disk head is the retry mechanism, so one bad chat cannot starve
+// other queues or Telegram polling.
+// Returns true when eve accepted the update, false when it was dropped or retained.
 const CONFIG_RETRY_MS = 60_000;
 const DROP_ATTEMPTS = 30;
-async function deliver(update) {
+async function deliver(
+  update,
+  {
+    route = ROUTE,
+    acceptedStatus,
+    queueReceipt = false,
+    retry = true,
+    timeoutMs,
+  } = {},
+) {
+  const outgoing = queueReceipt ? addTelegramQueueReceipt(update) : update;
   for (let attempt = 1; ; attempt++) {
     let wait = Math.min(15000, 1000 * attempt);
     try {
-      const res = await fetch(ROUTE, {
+      const res = await fetch(route, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
           "X-Telegram-Bot-Api-Secret-Token": SECRET,
         },
-        body: JSON.stringify(update),
+        body: JSON.stringify(outgoing),
+        ...(timeoutMs === undefined ? {} : { signal: AbortSignal.timeout(timeoutMs) }),
       });
-      if (res.ok) return true;
+      if (res.ok && (acceptedStatus === undefined || res.status === acceptedStatus)) {
+        return queueReceipt && res.headers.get(TELEGRAM_ACCEPTANCE_KIND_HEADER) === "handled"
+          ? "handled"
+          : true;
+      }
+      if (res.ok) {
+        if (!retry) {
+          log(
+            `deliver: acceptance route replied ${res.status}, expected ${acceptedStatus}; queue head retained`,
+          );
+          return false;
+        }
+        log(
+          `deliver: acceptance route replied ${res.status}, expected ${acceptedStatus} (attempt ${attempt}) — retrying`,
+        );
+        await sleep(wait);
+        continue;
+      }
       const cls = classifyDeliverStatus(res.status);
+      if (!retry) {
+        log(`deliver: eve replied ${res.status}; queue head retained for a later pass`);
+        return false;
+      }
       if (cls === "drop") {
         if (attempt < DROP_ATTEMPTS) {
           log(`deliver: eve replied ${res.status} (attempt ${attempt}/${DROP_ATTEMPTS}) — retrying (may be transient)`);
@@ -221,6 +288,10 @@ async function deliver(update) {
         log(`deliver: eve replied ${res.status} (attempt ${attempt}) — retrying`);
       }
     } catch (e) {
+      if (!retry) {
+        log(`deliver: eve unavailable (${e.message}); queue head retained for a later pass`);
+        return false;
+      }
       log(`deliver: eve unavailable (${e.message}, attempt ${attempt}) — waiting for server`);
     }
     await sleep(wait);
@@ -264,16 +335,25 @@ const lastDeliverAt = new Map();
 // Доставка с пейсингом: выдержать SETTLE_MS с последней доставки в этот чат, доставить,
 // отметить время. ЕДИНЫЙ путь для главного цикла и для меню (deps.deliver) — оба делят
 // lastDeliverAt, поэтому доставка из меню сдвигает паузу для следующего реального сообщения.
-async function pacedDeliver(update) {
+async function pacedDeliver(update, options) {
+  const deadline =
+    options?.timeoutMs === undefined ? null : Date.now() + Math.max(0, options.timeoutMs);
   const key = chatKey(update);
   if (key !== null && SETTLE_MS > 0) {
     const prev = lastDeliverAt.get(key);
     if (prev !== undefined) {
       const wait = SETTLE_MS - (Date.now() - prev);
-      if (wait > 0) await sleep(wait);
+      if (wait > 0) {
+        if (deadline !== null && wait >= deadline - Date.now()) return false;
+        await sleep(wait);
+      }
     }
   }
-  const accepted = await deliver(update); // wait for delivery — ordered and lossless
+  const deliverOptions =
+    deadline === null
+      ? options
+      : { ...options, timeoutMs: Math.max(1, Math.floor(deadline - Date.now())) };
+  const accepted = await deliver(update, deliverOptions); // wait for delivery — ordered and lossless
   if (key !== null) lastDeliverAt.set(key, Date.now());
   return accepted; // false = апдейт выброшен как битый, eve его НЕ получила
 }
@@ -305,81 +385,44 @@ async function edit(chatId, messageId, text, replyMarkup) {
 const sc = (...args) =>
   new Promise((resolve) => execFile("systemctl", ["--user", ...args], (err) => resolve(!err)));
 
-// ── ESC-stop message queue (Claude Code semantics) ─────────────────────────
-// While a turn is running for a chat, ordinary message updates are NOT delivered to eve:
-// they are appended to data/telegram-queue.json and acknowledged with a 👀 reaction.
-// eve would otherwise buffer them in-memory and auto-process the batch as soon as the
-// turn parks (its docs call that drain best-effort) — we want the stricter semantics:
-// queued messages enter the context only WITH the next fresh message. When the agent is
-// idle again, the next message carries the queue along as update.message.iva_buffered
-// (the channel turns it into context lines).
+// ── Durable busy-time FIFO ──────────────────────────────────────────────────
+// Each accepted Telegram update is written as a versioned item (including update_id and
+// the untouched raw update) before its Telegram offset advances. The bridge then replays
+// one head per idle chat/topic. It removes that head only after Eve accepts the webhook:
+// a crash can duplicate the head, but cannot lose it or reorder later items around it.
 const QUEUE_FILE = join(DATA_DIR, "telegram-queue.json");
+const RESET_INTENT_DIR = join(DATA_DIR, "telegram-reset-intents");
+const queueSettleUntil = new Map();
+const queueInFlight = new Map();
+const queueDrainRotation = { afterKey: null };
+const undrainableLegacyLogged = new Set();
+const QUEUE_DELIVERY_TIMEOUT_MS = 5_000;
+const QUEUE_DRAIN_BUDGET_MS = 5_000;
+
+function statusGeneration(status) {
+  return Number.isSafeInteger(status?.generation) && status.generation >= 0
+    ? status.generation
+    : 0;
+}
 
 export async function loadQueue({ strict = false } = {}) {
-  let raw;
-  try {
-    raw = await readFile(QUEUE_FILE, "utf8");
-  } catch (error) {
-    if (error?.code === "ENOENT") return {};
-    throw error;
+  const loaded = await loadQueueFile(QUEUE_FILE, { strict });
+  if (loaded.quarantined) {
+    log(`damaged Telegram queue moved to ${loaded.quarantined}:`, loaded.error.message);
   }
-  try {
-    const queue = JSON.parse(raw);
-    if (typeof queue !== "object" || queue === null || Array.isArray(queue)) {
-      throw new Error(`${QUEUE_FILE} does not contain a JSON object`);
-    }
-    return queue;
-  } catch (error) {
-    if (strict) throw error;
-    const backup = `${QUEUE_FILE}.corrupt-${Date.now()}-${randomBytes(4).toString("hex")}`;
-    // Ordinary polling must stay live, but returning {} before the damaged
-    // bytes are safely moved would let the next save overwrite evidence/data.
-    await rename(QUEUE_FILE, backup);
-    log(`damaged Telegram queue moved to ${backup}:`, error.message);
-    return {};
-  }
+  return loaded.document;
 }
 
-export async function writeQueueAtomic(
-  queue,
-  {
-    writeFileImpl = writeFile,
-    renameImpl = rename,
-    rmImpl = rm,
-    nonce = randomBytes(8).toString("hex"),
-  } = {},
-) {
-  await mkdir(DATA_DIR, { recursive: true });
-  const tmp = `${QUEUE_FILE}.tmp-${process.pid}-${nonce}`;
-  try {
-    await writeFileImpl(tmp, JSON.stringify(queue), {
-      encoding: "utf8",
-      flag: "wx",
-      mode: 0o600,
-    });
-    await renameImpl(tmp, QUEUE_FILE);
-  } finally {
-    await rmImpl(tmp, { force: true }).catch(() => {});
-  }
-}
-
-async function saveQueue(q) {
-  try {
-    await writeQueueAtomic(q);
-  } catch (e) {
-    log("queue save failed:", e.message);
-  }
+export async function writeQueueAtomic(queue, options = {}) {
+  await writeQueueFileAtomic(QUEUE_FILE, queue, options);
 }
 
 // A scoped reset intentionally discards only messages queued for this chat/topic.
 // Other conversations keep both their queues and their Eve histories.
 async function clearChatQueue(chatKey) {
-  const q = await loadQueue({ strict: true });
-  if (!(chatKey in q)) return;
-  delete q[chatKey];
   // Reset cleanup must fail loudly: completeScopedResetState keeps the old
-  // running status until this atomic rename succeeds.
-  await writeQueueAtomic(q);
+  // running status until this atomic rewrite succeeds.
+  await clearQueueFileKey(QUEUE_FILE, chatKey);
 }
 
 export async function completeScopedResetState(
@@ -410,23 +453,220 @@ export async function completeScopedResetState(
   });
 }
 
-// One queued message → one context line. Media can't be re-fed later (the channel
-// processes files only on live delivery), so it degrades to a placeholder + caption.
-const MEDIA_KEYS = [
-  "photo", "voice", "audio", "video", "video_note",
-  "animation", "sticker", "document", "location", "contact", "poll",
-];
-function bufferEntryOf(msg) {
-  const text = (msg.text || "").trim();
-  if (text) return text;
-  const kind = MEDIA_KEYS.find((k) => msg[k] !== undefined);
-  const caption = (msg.caption || "").trim();
-  if (!kind) return caption || null;
-  const note = tr(
-    `[${kind} — sent while a turn was running; the attachment wasn't processed, ask to resend it if you need it]`,
-    `[${kind} — прислано пока шёл ход; вложение не обработано, попроси прислать заново, если оно нужно]`,
-  );
-  return caption ? `${note} ${tr("Caption:", "Подпись:")} ${caption}` : note;
+export async function persistPrivateResetIntent(chatKey, continuationToken) {
+  return persistTelegramResetIntent(RESET_INTENT_DIR, chatKey, continuationToken);
+}
+
+export async function loadPrivateResetIntents() {
+  return loadTelegramResetIntents(RESET_INTENT_DIR);
+}
+
+export async function clearPrivateResetIntent(chatKey) {
+  return clearTelegramResetIntent(RESET_INTENT_DIR, chatKey);
+}
+
+const requestResetFromIntent = ({ continuationToken }) =>
+  requestTelegramReset({
+    url: RESET_ROUTE,
+    secret: SECRET,
+    continuationToken,
+  });
+
+export async function performScopedReset(
+  chatKey,
+  continuationToken,
+  {
+    clearQueue = false,
+    persistIntentImpl = persistPrivateResetIntent,
+    requestResetImpl = requestResetFromIntent,
+    completeStateImpl = completeScopedResetState,
+    clearIntentImpl = clearPrivateResetIntent,
+  } = {},
+) {
+  const intent = { chatKey, continuationToken };
+  if (clearQueue) {
+    try {
+      await persistIntentImpl(chatKey, continuationToken);
+    } catch (error) {
+      error.resetPhase = "intent";
+      throw error;
+    }
+  }
+  try {
+    await requestResetImpl(intent);
+  } catch (error) {
+    error.resetPhase = "remote";
+    throw error;
+  }
+  try {
+    await completeStateImpl(chatKey, continuationToken, { clearQueue });
+  } catch (error) {
+    error.resetPhase = "cleanup";
+    throw error;
+  }
+  if (clearQueue) {
+    try {
+      await clearIntentImpl(chatKey);
+    } catch (error) {
+      error.resetPhase = "intent-cleanup";
+      throw error;
+    }
+  }
+}
+
+export async function reconcileScopedResetIntents({
+  loadIntentsImpl = loadPrivateResetIntents,
+  requestResetImpl = requestResetFromIntent,
+  completeStateImpl = completeScopedResetState,
+  clearIntentImpl = clearPrivateResetIntent,
+} = {}) {
+  const intents = await loadIntentsImpl();
+  for (const intent of intents) {
+    await requestResetImpl(intent);
+    await completeStateImpl(intent.chatKey, intent.continuationToken, { clearQueue: true });
+    await clearIntentImpl(intent.chatKey);
+  }
+  return intents.length;
+}
+
+async function acknowledgeQueued(update, count) {
+  const message = update.message;
+  await tg("setMessageReaction", {
+    chat_id: message.chat.id,
+    message_id: message.message_id,
+    reaction: [{ type: "emoji", emoji: "👀" }],
+  }).catch((error) => log("reaction failed:", error.message));
+  await tg("sendMessage", {
+    chat_id: message.chat.id,
+    text: tr(
+      `Queued (${count}). I'll start it automatically when the current task finishes.`,
+      `В очереди: ${count}. Начну автоматически, когда текущая задача завершится.`,
+    ),
+    ...(message.message_thread_id === undefined
+      ? {}
+      : { message_thread_id: message.message_thread_id }),
+  }).catch((error) => log("queue status failed:", error.message));
+}
+
+export async function drainReadyQueueHeads({
+  loadImpl = loadQueue,
+  runningImpl = isRunning,
+  statusImpl = getChatStatus,
+  deliverImpl = (update, { timeoutMs }) =>
+    pacedDeliver(update, {
+      route: ACCEPTANCE_ROUTE,
+      acceptedStatus: 204,
+      queueReceipt: true,
+      retry: false,
+      timeoutMs,
+    }),
+  acknowledgeImpl = (key, updateId) => acknowledgeQueueHead(QUEUE_FILE, key, updateId),
+  legacyAllowedUserIds = ALLOWED,
+  now = Date.now,
+  settleUntil = queueSettleUntil,
+  inFlight = queueInFlight,
+  rotationState = queueDrainRotation,
+  passBudgetMs = QUEUE_DRAIN_BUDGET_MS,
+  deliveryTimeoutMs = QUEUE_DELIVERY_TIMEOUT_MS,
+  gateWaitMs = RUN_STALE_MS,
+} = {}) {
+  const snapshot = await loadImpl();
+  const keys = queueKeys(snapshot);
+  const previousIndex = keys.indexOf(rotationState.afterKey);
+  const orderedKeys =
+    previousIndex < 0
+      ? keys
+      : [...keys.slice(previousIndex + 1), ...keys.slice(0, previousIndex + 1)];
+  const deadline = now() + passBudgetMs;
+  let exhausted = false;
+  let lastAttempted = null;
+
+  for (const key of orderedKeys) {
+    if (now() >= deadline) {
+      exhausted = true;
+      break;
+    }
+    const currentStatus = statusImpl(key);
+    const currentGeneration = statusGeneration(currentStatus);
+    const running = runningImpl(key);
+    const phase = inFlight.get(key);
+    if (phase?.state === "delivering") continue;
+    if (phase?.state === "awaiting-running") {
+      if (running) {
+        inFlight.set(key, { ...phase, state: "running", generation: currentGeneration });
+        continue;
+      }
+      const generationAdvanced = currentGeneration > phase.baselineGeneration;
+      const waitExpired = now() - phase.acceptedAt >= gateWaitMs;
+      if (!generationAdvanced && !waitExpired) continue;
+      inFlight.delete(key);
+    }
+    if (phase?.state === "running") {
+      if (running) continue;
+      inFlight.delete(key);
+    }
+    if (running || (settleUntil.get(key) ?? 0) > now()) continue;
+    const item = queueHead(snapshot, key);
+    const update = materializeQueueItem(key, item, { legacyAllowedUserIds });
+    if (!update) {
+      if (!undrainableLegacyLogged.has(key)) {
+        log(`queued legacy messages for ${key} cannot be replayed because their author is not verifiable`);
+        undrainableLegacyLogged.add(key);
+      }
+      continue;
+    }
+    const timeoutMs = Math.max(1, Math.min(deliveryTimeoutMs, deadline - now()));
+    lastAttempted = key;
+    const baselineGeneration = currentGeneration;
+    inFlight.set(key, { state: "delivering", baselineGeneration });
+    let accepted = false;
+    try {
+      accepted = await deliverImpl(update, { timeoutMs });
+    } catch (error) {
+      log(`queued update ${item.updateId} delivery failed:`, error.message);
+    }
+    if (!accepted) {
+      inFlight.delete(key);
+      continue;
+    }
+    if (accepted === "handled") {
+      inFlight.delete(key);
+    } else {
+      const acceptedStatus = statusImpl(key);
+      const acceptedGeneration = statusGeneration(acceptedStatus);
+      if (runningImpl(key)) {
+        inFlight.set(key, {
+          state: "running",
+          baselineGeneration,
+          generation: acceptedGeneration,
+        });
+      } else if (acceptedGeneration > baselineGeneration) {
+        // A complete running -> idle cycle happened while acceptance was pending.
+        inFlight.delete(key);
+      } else {
+        inFlight.set(key, {
+          state: "awaiting-running",
+          baselineGeneration,
+          acceptedAt: now(),
+        });
+      }
+    }
+    // Keep a just-accepted head until its removal is itself durable. If this write
+    // fails, the next pass deliberately replays the same head (at-least-once).
+    try {
+      await acknowledgeImpl(key, item.updateId);
+      settleUntil.set(key, now() + Math.max(SETTLE_MS, 0));
+    } catch (error) {
+      if (error?.code === TELEGRAM_QUEUE_FATAL_DURABILITY) {
+        inFlight.delete(key);
+        rotationState.afterKey = null;
+        throw error;
+      }
+      log(`queued update ${item.updateId} ack failed; head retained or restored:`, error.message);
+    }
+  }
+  rotationState.afterKey = exhausted ? lastAttempted : null;
+  return queueCount(await loadImpl());
 }
 
 // ── self-update (/update) ──────────────────────────────────────────────────
@@ -1207,46 +1447,35 @@ async function handleControl(update) {
     return true;
   }
 
+  const clearsPrivateQueue = msg?.chat?.type === "private";
   try {
-    await requestTelegramReset({
-      url: RESET_ROUTE,
-      secret: SECRET,
-      continuationToken,
-    });
-  } catch (e) {
-    log(`scoped reset failed for ${key}:`, e.message);
-    if (status) {
-      await edit(
-        chatId,
-        status.message_id,
-        tr(
-          "⚠️ Couldn't reset this conversation. Nothing else was cleared.",
-          "⚠️ Не удалось сбросить этот диалог. Остальные данные не затронуты.",
-        ),
-      );
-    }
-    return true;
-  }
-
-  try {
-    await completeScopedResetState(key, continuationToken, {
+    await performScopedReset(key, continuationToken, {
       // Group/forum queues are keyed only by chat/topic while Eve sessions also
       // include conversationId. Clearing the shared queue here would lose
       // messages belonging to other group conversation anchors.
-      clearQueue: msg?.chat?.type === "private",
+      clearQueue: clearsPrivateQueue,
     });
   } catch (e) {
-    log(`scoped reset cleanup failed for ${key}:`, e.message);
+    log(`scoped reset ${e.resetPhase ?? "unknown"} failed for ${key}:`, e.message);
     if (status) {
       await edit(
         chatId,
         status.message_id,
-        tr(
-          "⚠️ Conversation reset, but local cleanup failed. Send /new again before sending anything else.",
-          "⚠️ Диалог сброшен, но локальная очистка не завершилась. Отправьте /new ещё раз до новых сообщений.",
-        ),
+        e.resetPhase === "remote"
+          ? tr(
+              "⚠️ Couldn't confirm this conversation reset. Recovery will retry automatically.",
+              "⚠️ Не удалось подтвердить сброс диалога. Восстановление повторит его автоматически.",
+            )
+          : tr(
+              "⚠️ Conversation reset recovery is incomplete. Iva will retry it before accepting queued work.",
+              "⚠️ Восстановление после сброса не завершено. Iva повторит его до приёма задач из очереди.",
+            ),
       );
     }
+    // A private reset request is ambiguous after any I/O failure: Eve may have
+    // committed it even when the response was lost. Stop this polling process so
+    // startup reconciliation consumes the durable intent before any old head.
+    if (clearsPrivateQueue) throw e;
     return true;
   }
 
@@ -1272,6 +1501,17 @@ async function main() {
   if (!SECRET) throw new Error("no TELEGRAM_WEBHOOK_SECRET_TOKEN — the channel won't accept updates");
   log(`telegram-poll start → ${ROUTE}`);
   await removeStaleUpdateJobs();
+  // Upgrade the old {chatKey: string[]} queue atomically before polling. A failed
+  // migration stops the bridge, so Telegram retains new updates until the old bytes
+  // are safely represented as versioned FIFO items.
+  await migrateQueueFile(QUEUE_FILE, {
+    onLegacyQuarantine: (path) =>
+      log(`legacy Telegram group messages moved to ${path}; sender identity was unavailable`),
+  });
+  const reconciledResets = await reconcileScopedResetIntents();
+  if (reconciledResets > 0) {
+    log(`reconciled ${reconciledResets} durable private Telegram reset intent(s)`);
+  }
   // First run (no offset file) — drop the accumulated install backlog (drop_pending=true),
   // so old messages don't replay in a batch → parallel sessions on one chat (HookConflict).
   // On subsequent starts we do NOT drop the backlog (don't lose messages that arrived while the bridge was down).
@@ -1290,13 +1530,17 @@ async function main() {
   }
 
   for (;;) {
+    // One head per idle chat/topic per pass. While any queue remains, use a short
+    // Telegram long-poll so terminal/stale run-status changes trigger drain quickly.
+    const pendingQueueCount = await drainReadyQueueHeads();
+    const pollSeconds = pendingQueueCount > 0 ? 1 : 30;
     let data;
     try {
       data = await tg("getUpdates", {
         offset,
-        timeout: 30,
+        timeout: pollSeconds,
         allowed_updates: ["message", "callback_query"],
-      }, { timeoutMs: 40_000 }); // above the 30s long-poll window
+      }, { timeoutMs: pollSeconds > 1 ? 40_000 : 10_000 });
     } catch (e) {
       log("getUpdates network:", e.message);
       await sleep(3000);
@@ -1311,6 +1555,7 @@ async function main() {
       await sleep(3000);
       continue;
     }
+    let queueWriteFailed = false;
     for (const update of data.result || []) {
       // Переигровка после краша (Telegram = at-least-once): этот апдейт уже уходил в eve
       // в прошлой жизни процесса — второй раз не доставляем, только двигаем offset.
@@ -1327,37 +1572,39 @@ async function main() {
         continue;
       }
       const key = chatKey(update);
-      let drainedKey = null; // чей буфер приклеен к этому апдейту — чистится после доставки
-      // ESC-stop queue gate (messages only): while a turn is running for this chat, buffer
-      // the message instead of delivering. callback_query always passes (eve HITL buttons
-      // and ⏹ Стоп must reach a busy agent). Replies to bot messages also pass — that's
-      // how HITL ForceReply answers arrive; queueing one would deadlock the waiting turn.
-      if (update.message && key !== null && update.message.reply_to_message?.from?.is_bot !== true) {
-        if (isRunning(key)) {
-          const entry = bufferEntryOf(update.message);
-          if (entry !== null) {
-            const q = await loadQueue();
-            (q[key] ??= []).push(entry);
-            await saveQueue(q);
-            // Silent ack: a 👀 reaction on the user's message (no extra chat message).
-            await tg("setMessageReaction", {
-              chat_id: update.message.chat.id,
-              message_id: update.message.message_id,
-              reaction: [{ type: "emoji", emoji: "👀" }],
-            }).catch((e) => log("reaction failed:", e.message));
+      // Busy-time queue gate (messages only). callback_query and replies to bot
+      // messages pass immediately because Eve HITL/ForceReply answers would deadlock
+      // in the FIFO. A pre-existing FIFO also captures new eligible updates while an
+      // idle transition is being observed, preserving order around the drain boundary.
+      if (update.message && key !== null && !isReplyToBot(update.message)) {
+        const queue = await loadQueue();
+        const mustQueue =
+          isRunning(key) || queueInFlight.has(key) || queueCount(queue, key) > 0;
+        if (mustQueue) {
+          if (!shouldQueueBusyUpdate(update, {
+            allowedUserIds: ALLOWED,
+            botUsername: BOT_USERNAME,
+          })) {
+            // Untrusted private messages and unaddressed group noise must never enter
+            // the owner's later model context. Consume them exactly once.
+            offset = update.update_id + 1;
+            await saveOffset(offset, delivered);
+            continue;
+          }
+          let queued;
+          try {
+            queued = await enqueueQueueFile(QUEUE_FILE, key, update);
+          } catch (error) {
+            // Do not advance past this update or process later updates in the same
+            // Telegram batch. getUpdates will retry it at the current durable offset.
+            log(`queue enqueue failed for update ${update.update_id}:`, error.message);
+            queueWriteFailed = true;
+            break;
           }
           offset = update.update_id + 1;
           await saveOffset(offset, delivered);
+          await acknowledgeQueued(update, queued.count);
           continue;
-        }
-        // Idle again: the next fresh message carries the queued ones along. The queue is
-        // cleared AFTER successful delivery (below) — clearing it here would lose the
-        // buffered messages if the process dies before deliver() succeeds.
-        const q = await loadQueue();
-        const pending = q[key];
-        if (Array.isArray(pending) && pending.length) {
-          update.message.iva_buffered = pending;
-          drainedKey = key;
         }
       }
       // Don't deliver the next update of the same chat until eve has parked the previous turn
@@ -1366,23 +1613,15 @@ async function main() {
       const accepted = await pacedDeliver(update);
       offset = update.update_id + 1;
       if (accepted) {
-        // Порядок персиста: СНАЧАЛА маркер delivered, ПОТОМ очистка буфера. Краш между
-        // ними оставляет буфер на месте при уже записанном маркере → на переигровке
-        // апдейт пропустится, буфер приклеится к следующему сообщению — дубль возможен,
-        // потеря нет. Обратный порядок (буфер раньше маркера) терял бы очередь.
         delivered = update.update_id;
         await saveOffset(offset, delivered);
-        if (drainedKey !== null) {
-          const q = await loadQueue();
-          delete q[drainedKey];
-          await saveQueue(q);
-        }
       } else {
-        // Апдейт выброшен как битый: буфер НЕ трогаем (приклеится к следующему сообщению),
-        // маркер не ставим — offset двигаем, чтобы не молоть тот же апдейт.
+        // Direct malformed updates retain the existing bounded-drop behavior.
+        // Durable FIFO heads use a separate path and are never removed on false.
         await saveOffset(offset, delivered);
       }
     }
+    if (queueWriteFailed) await sleep(3000);
   }
 }
 


### PR DESCRIPTION
Closes #51

## What changed
- Replaces the old in-memory/string follow-up buffer with a versioned durable per-chat/topic FIFO carrying Telegram `update_id` and untouched raw updates.
- Advances Telegram offset only after atomic file+directory durability; retries duplicate writes safely.
- Removes a head only after the authored Eve acceptance route returns an exact receipt. A durable pending-ack backup closes the rename-to-directory-fsync crash window; restart may replay, never lose.
- Auto-drains after idle/restart with per-key FIFO, monotonic run-status generation, bounded stale release, one global 5s drain budget and rotating cross-chat fairness.
- Keeps private/group/topic routing fail-closed, excludes unaddressed group noise, and preserves no-send location/contact/poll/silent-media handling.
- Adds fsync-durable private reset intent and startup reconciliation so a crash after remote `/new` cannot replay messages the reset discarded.
- Migrates legacy private strings and quarantines unverifiable group/topic entries without overwrite.

## TDD evidence
RED repros covered disk/rename/fsync failure, SIGKILL after ack rename, crash after remote reset, restart recovery, duplicate delivery, poison 503 cross-chat starvation, missed running->idle transitions, N-key drain delay, group noise, Unicode mentions, `__proto__`, malformed/auth/no-send paths and accepted-send failure.

GREEN on rebased head `852e1a9`:
- complete Node suite - 329/329
- `npm run typecheck` - pass
- `npx eve build` - pass
- autograph - 256/256
- userbot guardrails - pass
- `git diff --check origin/main...HEAD` - pass

## UX before/after
Follow-ups sent during a running turn now show a durable queue count, start automatically in FIFO order, survive restart/reset crash windows and cannot freeze unrelated chats.

## Review boundary
All reproduced data-loss, overlap and starvation blockers were fixed. Scope is frozen at the issue contract; GitHub CI is the final merge gate.

CodeRabbit CLI: skipped because the authenticated account has no assigned seat.