### PR TITLE
fix(config): validate models against live providers

### DIFF
--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -1,5 +1,22 @@
 # Implementation notes
 
+## Strict live model validation (IVA-005 / #55)
+
+- Ollama Cloud, OpenCode Go and Codex selections come only from a successful, non-empty
+  live catalog. Static IDs remain suggestions and cannot resurrect a retired model.
+- OpenRouter uses the same shared validator with a minimal chat request carrying a
+  `ping` function definition. Any HTTP 200 accepts the key, slug and tools request even
+  when a reasoning model exhausts the small probe budget before visible output.
+- Telegram shows a stale configured model for reference but never as a button, rejects
+  forged indices, and validates again before one atomic provider/model/effort/key update.
+- A newly entered key stays in wizard memory until the model passes validation. Network,
+  authentication, empty/malformed catalog and changed-catalog failures leave `.env`
+  untouched and render Retry/Back controls, including the `/think` catalog path.
+- Interactive setup calls the same validator immediately before its atomic full-file
+  write, so a provider change during later setup steps cannot persist a stale selection.
+  Keeping byte-equivalent existing settings skips that rewrite; any changed keep-path
+  value validates the configured model first.
+
 ## Structured Telegram reply context (IVA-009 / #53)
 
 - Eve keeps quoted text and media only in `raw.reply_to_message`; IVA now adds one

--- a/scripts/lib/model-catalog.mjs
+++ b/scripts/lib/model-catalog.mjs
@@ -1,6 +1,6 @@
-// Provider/model/effort catalog for the /model and /think Telegram wizards.
-// Static model lists are the offline fallback. Codex returns model IDs and each
-// model's supported reasoning levels in the same /models response.
+// Provider/model/effort metadata for the /model and /think Telegram wizards.
+// Static lists are suggestions only; selectable catalog providers must come from
+// a successful live response. Codex also returns model-specific reasoning levels.
 import { listCodexModelCatalog } from "./codex-oauth.mjs";
 import {
   CANONICAL_REASONING_EFFORTS,
@@ -15,6 +15,15 @@ export const FALLBACK_EFFORTS = FALLBACK_REASONING_EFFORTS;
 
 // A hung provider endpoint must not stall the bridge's single getUpdates loop.
 const FETCH_TIMEOUT_MS = 10_000;
+
+export class ModelCatalogError extends Error {
+  constructor(code, message, { status, cause } = {}) {
+    super(message, { cause });
+    this.name = "ModelCatalogError";
+    this.code = code;
+    this.status = status;
+  }
+}
 
 export const CATALOG = {
   ollama: {
@@ -93,10 +102,34 @@ const optionsFor = (provider, models) =>
     reasoningLevels: providerFallbackReasoningLevels(provider),
   }));
 
-// Live model options with static fallback. Codex performs exactly one /models request
-// and keeps its model-specific reasoning levels on the in-memory wizard state.
-// 401/403 from key providers remains an actionable auth error; network/format failures
-// use static model buttons and the provider's conservative reasoning fallback.
+const validOptions = (provider, entries) => {
+  if (!Array.isArray(entries)) {
+    throw new ModelCatalogError("catalog_invalid", "provider returned a malformed model catalog");
+  }
+  const seen = new Set();
+  const options = [];
+  for (const entry of entries) {
+    const id = typeof entry?.id === "string" ? entry.id.trim() : "";
+    if (!id) {
+      throw new ModelCatalogError("catalog_invalid", "provider returned a malformed model entry");
+    }
+    if (seen.has(id)) continue;
+    seen.add(id);
+    options.push({
+      id,
+      reasoningLevels: Array.isArray(entry.reasoningLevels)
+        ? [...entry.reasoningLevels]
+        : providerFallbackReasoningLevels(provider),
+    });
+  }
+  if (!options.length) {
+    throw new ModelCatalogError("catalog_invalid", "provider returned an empty model catalog");
+  }
+  return options;
+};
+
+// Selectable options come only from the live provider catalog. Static lists remain
+// display metadata and OpenRouter suggestions; they must never resurrect retired models.
 export async function fetchModelOptions(provider, key, {
   dataDir,
   listCodexCatalog = listCodexModelCatalog,
@@ -107,24 +140,41 @@ export async function fetchModelOptions(provider, key, {
   try {
     if (provider === "codex") {
       const live = await listCodexCatalog(dataDir ? { dataDir } : {});
-      return live.length ? live : optionsFor(provider, cat.models);
+      return validOptions(provider, live);
     }
     if (cat.base && provider !== "openrouter") {
       const res = await fetchFn(`${cat.base}/models`, {
         headers: { Authorization: `Bearer ${key}` },
         signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
       });
-      if (res.status === 401 || res.status === 403) throw Object.assign(new Error("key rejected"), { auth: true });
-      if (!res.ok) return optionsFor(provider, cat.models);
-      const ids = ((await res.json()).data || [])
-        .map((model) => typeof model?.id === "string" ? model.id.trim() : "")
-        .filter(Boolean)
-        .sort();
-      return ids.length ? optionsFor(provider, ids) : optionsFor(provider, cat.models);
+      if (res.status === 401 || res.status === 403) {
+        throw new ModelCatalogError("auth_rejected", `provider rejected credentials (${res.status})`, {
+          status: res.status,
+        });
+      }
+      if (!res.ok) {
+        throw new ModelCatalogError("catalog_unavailable", `model catalog returned HTTP ${res.status}`, {
+          status: res.status,
+        });
+      }
+      let body;
+      try {
+        body = await res.json();
+      } catch (cause) {
+        throw new ModelCatalogError("catalog_invalid", "provider returned invalid catalog JSON", {
+          cause,
+        });
+      }
+      if (!body || typeof body !== "object" || !Array.isArray(body.data)) {
+        throw new ModelCatalogError("catalog_invalid", "provider returned a malformed model catalog");
+      }
+      return validOptions(provider, body.data).sort((a, b) => a.id.localeCompare(b.id));
     }
   } catch (e) {
-    if (e.auth) throw e;
-    return optionsFor(provider, cat.models);
+    if (e instanceof ModelCatalogError) throw e;
+    throw new ModelCatalogError("catalog_unavailable", "couldn't load the live model catalog", {
+      cause: e,
+    });
   }
   return optionsFor(provider, cat.models); // openrouter and anything else: static curated list
 }

--- a/scripts/lib/model-catalog.test.mjs
+++ b/scripts/lib/model-catalog.test.mjs
@@ -1,19 +1,20 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
-  CATALOG,
   FALLBACK_EFFORTS,
+  ModelCatalogError,
   fetchModelOptions,
 } from "./model-catalog.mjs";
 
-test("Codex network/malformed failure falls back to models with low/medium/high", async () => {
-  const options = await fetchModelOptions("codex", undefined, {
-    listCodexCatalog: async () => {
-      throw new Error("offline");
-    },
-  });
-  assert.deepEqual(options.map((option) => option.id), CATALOG.codex.models);
-  assert.ok(options.every((option) => JSON.stringify(option.reasoningLevels) === JSON.stringify(FALLBACK_EFFORTS)));
+test("Codex catalog failure cannot create selectable fallback models", async () => {
+  await assert.rejects(
+    fetchModelOptions("codex", undefined, {
+      listCodexCatalog: async () => {
+        throw new Error("offline");
+      },
+    }),
+    (error) => error instanceof ModelCatalogError && error.code === "catalog_unavailable",
+  );
 });
 
 test("Ollama Cloud and OpenCode Go expose their OpenAI-compatible reasoning contract", async () => {

--- a/scripts/lib/model-validation.mjs
+++ b/scripts/lib/model-validation.mjs
@@ -1,0 +1,141 @@
+import {
+  CATALOG,
+  ModelCatalogError,
+  fetchModelOptions,
+} from "./model-catalog.mjs";
+
+const FETCH_TIMEOUT_MS = 10_000;
+
+export class ModelValidationError extends Error {
+  constructor(code, message, { status, cause } = {}) {
+    super(message, { cause });
+    this.name = "ModelValidationError";
+    this.code = code;
+    this.status = status;
+  }
+}
+
+const validationError = (error) => {
+  if (error instanceof ModelValidationError) return error;
+  if (error instanceof ModelCatalogError) {
+    return new ModelValidationError(error.code, error.message, {
+      status: error.status,
+      cause: error,
+    });
+  }
+  return new ModelValidationError("catalog_unavailable", "provider validation failed", {
+    cause: error,
+  });
+};
+
+export async function probeOpenRouterModel({
+  model,
+  key,
+}, {
+  fetchFn = fetch,
+  errorReason,
+} = {}) {
+  let response;
+  try {
+    response = await fetchFn(`${CATALOG.openrouter.base}/chat/completions`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${key}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model,
+        messages: [{ role: "user", content: "Call the ping tool." }],
+        tools: [{
+          type: "function",
+          function: {
+            name: "ping",
+            description: "health check",
+            parameters: { type: "object", properties: {} },
+          },
+        }],
+        tool_choice: "auto",
+        max_tokens: 32,
+      }),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+  } catch (cause) {
+    throw new ModelValidationError("catalog_unavailable", "OpenRouter request failed", {
+      cause,
+    });
+  }
+  if (response.status === 401 || response.status === 403) {
+    throw new ModelValidationError("auth_rejected", `OpenRouter rejected credentials (${response.status})`, {
+      status: response.status,
+    });
+  }
+  let body;
+  try {
+    body = await response.json();
+  } catch (cause) {
+    throw new ModelValidationError("catalog_invalid", "OpenRouter returned invalid JSON", {
+      status: response.status,
+      cause,
+    });
+  }
+  if (!response.ok) {
+    const detail = errorReason?.(body, response.status) ??
+      (typeof body?.error?.message === "string" ? body.error.message : "");
+    const reason = detail ? `: ${detail}` : "";
+    throw new ModelValidationError(
+      "model_unavailable",
+      `OpenRouter rejected model ${model}${reason}`,
+      { status: response.status },
+    );
+  }
+  const message = body?.choices?.[0]?.message;
+  const answered = Boolean(
+    (typeof message?.content === "string" && message.content.trim()) ||
+    (Array.isArray(message?.tool_calls) && message.tool_calls.length),
+  );
+  // A reasoning model can spend the entire small probe allowance before it
+  // emits visible content. HTTP 200 still proves that the key, slug and tools
+  // request were accepted, matching setup's long-standing probe contract.
+  return { id: model, reasoningLevels: [], answered };
+}
+
+export async function validateModelSelection({
+  provider,
+  model,
+  key,
+  dataDir,
+}, {
+  fetchFn = fetch,
+  listCodexCatalog,
+} = {}) {
+  if (
+    typeof provider !== "string" ||
+    !Object.hasOwn(CATALOG, provider) ||
+    typeof model !== "string" ||
+    !model.trim() ||
+    /[\r\n]/.test(model)
+  ) {
+    throw new ModelValidationError("invalid_selection", "invalid provider or model selection");
+  }
+  const selected = model.trim();
+  if (provider === "openrouter") {
+    return probeOpenRouterModel({ model: selected, key }, { fetchFn });
+  }
+  try {
+    const options = await fetchModelOptions(provider, key, {
+      dataDir,
+      fetchFn,
+      ...(listCodexCatalog ? { listCodexCatalog } : {}),
+    });
+    const match = options.find((option) => option.id === selected);
+    if (!match) {
+      throw new ModelValidationError(
+        "model_unavailable",
+        `${selected} is not present in the live ${CATALOG[provider].label} catalog`,
+      );
+    }
+    return match;
+  } catch (error) {
+    throw validationError(error);
+  }
+}

--- a/scripts/lib/model-validation.test.mjs
+++ b/scripts/lib/model-validation.test.mjs
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  ModelValidationError,
+  validateModelSelection,
+} from "./model-validation.mjs";
+
+const response = (body, status = 200) =>
+  new Response(typeof body === "string" ? body : JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+
+test("catalog providers require exact live membership", async () => {
+  for (const provider of ["ollama", "opencode"]) {
+    const selected = await validateModelSelection(
+      { provider, model: "live/model", key: "secret" },
+      {
+        fetchFn: async () => response({ data: [{ id: "live/model" }] }),
+      },
+    );
+    assert.equal(selected.id, "live/model");
+    await assert.rejects(
+      validateModelSelection(
+        { provider, model: "retired", key: "secret" },
+        { fetchFn: async () => response({ data: [{ id: "live/model" }] }) },
+      ),
+      (error) => error instanceof ModelValidationError && error.code === "model_unavailable",
+    );
+  }
+
+  await assert.rejects(
+    validateModelSelection(
+      { provider: "codex", model: "retired" },
+      { listCodexCatalog: async () => [{ id: "live", reasoningLevels: ["high"] }] },
+    ),
+    (error) => error instanceof ModelValidationError && error.code === "model_unavailable",
+  );
+});
+
+test("catalog outage, auth, empty and malformed responses fail closed", async () => {
+  const cases = [
+    {
+      code: "catalog_unavailable",
+      fetchFn: async () => {
+        throw new Error("offline");
+      },
+    },
+    { code: "auth_rejected", fetchFn: async () => response({}, 401) },
+    { code: "auth_rejected", fetchFn: async () => response({}, 403) },
+    { code: "catalog_invalid", fetchFn: async () => response({ data: [] }) },
+    { code: "catalog_invalid", fetchFn: async () => response({ data: "broken" }) },
+    { code: "catalog_invalid", fetchFn: async () => response({ data: [{ name: "missing-id" }] }) },
+    { code: "catalog_invalid", fetchFn: async () => response("{", 200) },
+  ];
+  for (const item of cases) {
+    await assert.rejects(
+      validateModelSelection(
+        { provider: "ollama", model: "live", key: "secret" },
+        { fetchFn: item.fetchFn },
+      ),
+      (error) => error instanceof ModelValidationError && error.code === item.code,
+    );
+  }
+  await assert.rejects(
+    validateModelSelection(
+      { provider: "codex", model: "live" },
+      { listCodexCatalog: async () => [] },
+    ),
+    (error) => error instanceof ModelValidationError && error.code === "catalog_invalid",
+  );
+});
+
+test("OpenRouter validation sends a minimal tool-call request", async () => {
+  let request;
+  const result = await validateModelSelection(
+    { provider: "openrouter", model: "vendor/model", key: "secret" },
+    {
+      fetchFn: async (url, init) => {
+        request = { url, init, body: JSON.parse(init.body) };
+        return response({ choices: [{ message: { tool_calls: [{ id: "1" }] } }] });
+      },
+    },
+  );
+  assert.equal(result.id, "vendor/model");
+  assert.match(request.url, /chat\/completions$/);
+  assert.equal(request.body.model, "vendor/model");
+  assert.equal(request.body.tools[0].function.name, "ping");
+  assert.equal(request.body.max_tokens, 32);
+
+  const exhausted = await validateModelSelection(
+    { provider: "openrouter", model: "vendor/reasoning", key: "secret" },
+    {
+      fetchFn: async () => response({
+        choices: [{
+          finish_reason: "length",
+          message: { content: "", reasoning: "hidden budget exhausted" },
+        }],
+      }),
+    },
+  );
+  assert.equal(exhausted.id, "vendor/reasoning");
+
+  await assert.rejects(
+    validateModelSelection(
+      { provider: "openrouter", model: "vendor/no-tools", key: "secret" },
+      { fetchFn: async () => response({ error: { message: "No tool use" } }, 400) },
+    ),
+    (error) => error instanceof ModelValidationError && error.code === "model_unavailable",
+  );
+});
+
+test("OpenRouter classifies non-JSON auth failures before parsing the body", async () => {
+  for (const status of [401, 403]) {
+    await assert.rejects(
+      validateModelSelection(
+        { provider: "openrouter", model: "vendor/model", key: "bad" },
+        {
+          fetchFn: async () => new Response("unauthorized", {
+            status,
+            headers: { "content-type": "text/plain" },
+          }),
+        },
+      ),
+      (error) =>
+        error instanceof ModelValidationError &&
+        error.code === "auth_rejected" &&
+        error.status === status,
+    );
+  }
+});
+
+test("empty and malformed selections are rejected before provider I/O", async () => {
+  let calls = 0;
+  const fetchFn = async () => {
+    calls += 1;
+    return response({ data: [{ id: "x" }] });
+  };
+  for (const model of ["", " \n ", null]) {
+    await assert.rejects(
+      validateModelSelection({ provider: "ollama", model, key: "secret" }, { fetchFn }),
+      (error) => error instanceof ModelValidationError && error.code === "invalid_selection",
+    );
+  }
+  await assert.rejects(
+    validateModelSelection({ provider: "__proto__", model: "x", key: "secret" }, { fetchFn }),
+    (error) => error instanceof ModelValidationError && error.code === "invalid_selection",
+  );
+  assert.equal(calls, 0);
+});

--- a/scripts/lib/setup-keep.mjs
+++ b/scripts/lib/setup-keep.mjs
@@ -1,0 +1,7 @@
+export function keptSetupWritePlan(existing, next) {
+  const keys = new Set([...Object.keys(existing), ...Object.keys(next)]);
+  for (const key of keys) {
+    if (!Object.is(existing[key], next[key])) return "validate-and-write";
+  }
+  return "skip";
+}

--- a/scripts/lib/setup-keep.test.mjs
+++ b/scripts/lib/setup-keep.test.mjs
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { keptSetupWritePlan } from "./setup-keep.mjs";
+
+test("keeping byte-equivalent setup skips the full model-config rewrite", () => {
+  const existing = {
+    AGENT_LANGUAGE: "en",
+    MODEL_PROVIDER: "openrouter",
+    OPENROUTER_API_KEY: "secret",
+    OPENROUTER_MODEL: "retired/model",
+  };
+
+  assert.equal(keptSetupWritePlan(existing, { ...existing }), "skip");
+  assert.equal(
+    keptSetupWritePlan(existing, { ...existing, AGENT_LANGUAGE: "ru" }),
+    "validate-and-write",
+  );
+});

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -13,6 +13,11 @@ import { defaultChecker, PortSelector } from "./lib/ports.mjs";
 import { generateAssistantBearer, isAssistantBearer } from "./lib/assistant-auth.mjs";
 import { writeEnvAtomicSync } from "./lib/env-file.mjs";
 import { authFilePath, readAuth, runDeviceCodeLogin, runBrowserLogin, listCodexModels } from "./lib/codex-oauth.mjs";
+import {
+  probeOpenRouterModel,
+  validateModelSelection,
+} from "./lib/model-validation.mjs";
+import { keptSetupWritePlan } from "./lib/setup-keep.mjs";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const ENV_PATH = join(ROOT, ".env");
@@ -244,22 +249,18 @@ export function openrouterErrReason(j, status) {
 }
 async function openrouterModelCheck(key, model) {
   try {
-    const res = await fetch(`${OPENROUTER_BASE}/chat/completions`, {
-      method: "POST",
-      headers: { Authorization: `Bearer ${key}`, "Content-Type": "application/json" },
-      body: JSON.stringify({
-        model,
-        messages: [{ role: "user", content: "Call the ping tool." }],
-        tools: [{ type: "function", function: { name: "ping", description: "health check", parameters: { type: "object", properties: {} } } }],
-        tool_choice: "auto",
-        max_tokens: 32,
-      }),
+    const result = await probeOpenRouterModel({ model, key }, {
+      errorReason: openrouterErrReason,
     });
-    const j = await res.json().catch(() => ({}));
-    if (!res.ok) {
-      const reason = openrouterErrReason(j, res.status);
-      // Совет про function calling — только когда причина реально про инструменты; иначе он вводит
-      // в заблуждение (напр. региональная 403 от провайдера к tool calling отношения не имеет).
+    if (!result.answered) {
+      console.log(
+        `${C.y}${t("(model replied empty — maybe a reasoning model / max_tokens; proceeding)", "(модель ответила пусто — возможно reasoning-модель / max_tokens; продолжаю)")}${C.x}`,
+      );
+    }
+    return null;
+  } catch (e) {
+    if (e?.code === "model_unavailable" || e?.code === "auth_rejected") {
+      const reason = e.message;
       const toolIssue = /tool use|function call|no endpoints found that support tool/i.test(reason);
       const hint = toolIssue
         ? t(
@@ -272,16 +273,6 @@ async function openrouterModelCheck(key, model) {
           );
       return t(`the model can't be used: ${reason}. ${hint}`, `модель не подходит: ${reason}. ${hint}`);
     }
-    // 200 = ключ+слаг+tools ок. «Ответила» = есть content ИЛИ tool_calls (модель могла сразу дёрнуть tool).
-    const msg = j?.choices?.[0]?.message;
-    const answered = (msg?.content && msg.content.trim()) || (Array.isArray(msg?.tool_calls) && msg.tool_calls.length);
-    if (!answered) {
-      console.log(
-        `${C.y}${t("(model replied empty — maybe a reasoning model / max_tokens; proceeding)", "(модель ответила пусто — возможно reasoning-модель / max_tokens; продолжаю)")}${C.x}`,
-      );
-    }
-    return null; // слаг валиден и tool-совместим
-  } catch (e) {
     return t(`request failed: ${e.message}`, `запрос не прошёл: ${e.message}`);
   }
 }
@@ -377,7 +368,15 @@ async function main() {
     console.log(`  • ${t("Access", "Доступ")}:    ${existing.TELEGRAM_ALLOWED_USER_IDS}`);
     console.log(`  • Deepgram:  ${existing.DEEPGRAM_LANGUAGE || "multi"}   ·   TZ: ${existing.ASSISTANT_TIMEZONE || "?"}`);
     if (!(await askYesNo(`\n  ${t("Reconfigure from scratch?", "Перенастроить заново?")}`, false))) {
-      await writeEnv(out); // persist the language choice even when keeping everything else
+      if (keptSetupWritePlan(existing, out) === "validate-and-write") {
+        await validateModelSelection({
+            provider: prov0,
+            model: existing[provModel],
+            key: provKey ? existing[provKey] : undefined,
+            dataDir: dataDirAbs(existing),
+          });
+        await writeEnv(out);
+      }
       console.log(`${C.g}  ${t("Keeping current settings — nothing to enter.", "Оставляю текущие настройки как есть — ничего вводить не нужно.")}${C.x}`);
       rl.close();
       return;
@@ -657,6 +656,20 @@ async function main() {
   const localHost = /^https?:\/\/(127\.0\.0\.1|localhost)(:\d+)?\/?$/i.test(out.ASSISTANT_HOST || "");
   out.ASSISTANT_HOST = !out.ASSISTANT_HOST || localHost ? `http://127.0.0.1:${out.IVA_PORT}` : out.ASSISTANT_HOST;
   // ── Write .env ────────────────────────────────────────────────────
+  const selected = {
+    ollama: { model: "OLLAMA_MODEL", key: "OLLAMA_API_KEY" },
+    opencode: { model: "OPENCODE_MODEL", key: "OPENCODE_API_KEY" },
+    openrouter: { model: "OPENROUTER_MODEL", key: "OPENROUTER_API_KEY" },
+    codex: { model: "CODEX_MODEL", key: null },
+  }[out.MODEL_PROVIDER];
+  process.stdout.write(`  ${t("validating the selected model again…", "ещё раз проверяю выбранную модель…")} `);
+  await validateModelSelection({
+    provider: out.MODEL_PROVIDER,
+    model: out[selected.model],
+    key: selected.key ? out[selected.key] : undefined,
+    dataDir: dataDirAbs(out),
+  });
+  console.log(`${C.g}${t("ok", "ок")}${C.x}`);
   await writeEnv(out);
 
   const chosenModel =

--- a/scripts/telegram-poll.mjs
+++ b/scripts/telegram-poll.mjs
@@ -21,9 +21,12 @@ import {
   EFFORTS,
   fetchModelOptions,
   checkKey,
-  providerFallbackReasoningLevels,
   providerSupportsReasoning,
 } from "./lib/model-catalog.mjs";
+import {
+  ModelValidationError,
+  validateModelSelection,
+} from "./lib/model-validation.mjs";
 import { getAccessToken, runDeviceCodeLogin } from "./lib/codex-oauth.mjs";
 import { compactNumber, modelSummary } from "./lib/model-summary.mjs";
 import { acquireUpdateLock, releaseUpdateLock } from "./lib/update-safety.mjs";
@@ -808,11 +811,13 @@ export function wizardActionAllowed(st, action) {
   if (action.startsWith("prov:")) return st.step === "provider";
   if (action.startsWith("m:")) return st.step === "models";
   if (action.startsWith("eff:")) return st.step === "effort";
+  if (action === "retry" || action === "back") return st.step === "model_error";
   if (action.startsWith("rs:")) return st.step === "saved";
   return false;
 }
 
 export function selectWizardModel(st, rawIndex) {
+  if (!/^(0|[1-9]\d*)$/.test(String(rawIndex))) return null;
   const index = Number(rawIndex);
   if (!Number.isInteger(index) || index < 0) return null;
   const option = st.modelOptions?.[index];
@@ -832,6 +837,15 @@ export function selectWizardEffort(st, value) {
   return true;
 }
 
+export function selectableWizardOptions(options, current, limit = 30) {
+  const live = Array.isArray(options) ? options : [];
+  const currentOption = live.find((option) => option.id === current);
+  return [
+    ...(currentOption ? [currentOption] : []),
+    ...live.filter((option) => option !== currentOption),
+  ].slice(0, limit);
+}
+
 async function currentConfig() {
   const env = await readEnvValues(ENV_PATH);
   const provider = CATALOG[env.MODEL_PROVIDER] ? env.MODEL_PROVIDER : "ollama";
@@ -846,6 +860,10 @@ async function currentConfig() {
 const btn = (text, callback_data) => ({ text, callback_data });
 // cancelRow/menuRow — функции (tr на месте вызова), не module-level const с переведённой строкой.
 const cancelRow = () => [btn(tr("Cancel", "Отмена"), "iva_model:cancel")];
+const retryBackRows = () => [[
+  btn(tr("Retry", "Повторить"), "iva_model:retry"),
+  btn(tr("‹ Back", "‹ Назад"), "iva_model:back"),
+]];
 // Ряд «‹ Меню» на терминальных экранах визарда — возврат в /menu. r:o усыновляет
 // это сообщение даже без живого стейта (движок меню само-чинится после рестарта моста).
 const menuRow = () => [[btn(tr("‹ Menu", "‹ Меню"), "iva_menu:r:o")]];
@@ -887,6 +905,8 @@ async function handleModelCmd(chatId, from, { msgId } = {}) {
 async function handleThinkCmd(chatId, from, { msgId } = {}) {
   const { provider, model, effort } = await currentConfig();
   const st = newWizard(chatId, from, "think");
+  st.provider = provider;
+  st.model = model;
   st.msgId = msgId ?? null;
   if (!providerSupportsReasoning(provider)) {
     await endWizard(st, tr(
@@ -907,14 +927,13 @@ async function handleThinkCmd(chatId, from, { msgId } = {}) {
     st,
     () => fetchModelOptions(provider, cat.keyVar ? env[cat.keyVar] : undefined, { dataDir: DATA_DIR_ABS }),
   );
-  if (loaded.stale) return;
-  if (!loaded.ok) return endWizard(st, tr(
-    "Couldn't load thinking levels. Send /think to try again.",
-    "Не удалось загрузить уровни размышлений. Отправь /think, чтобы попробовать снова.",
-  ), menuRow());
-  const options = loaded.value;
-  const option = options.find((candidate) => candidate.id === model)
-    || { id: model, reasoningLevels: providerFallbackReasoningLevels(provider) };
+  const options = await resolveThinkCatalogLoad(st, loaded);
+  if (options === null) return;
+  const option = options.find((candidate) => candidate.id === model);
+  if (!option) return showModelValidationError(
+    st,
+    new ModelValidationError("model_unavailable", `${model} is not in the live catalog`),
+  );
   st.modelOptions = [option];
   st.model = model;
   st.efforts = [...option.reasoningLevels];
@@ -922,6 +941,19 @@ async function handleThinkCmd(chatId, from, { msgId } = {}) {
   await wizScreen(st,
     tr(`Thinking level for ${model}: ${effortLabel(effort)}.`, `Уровень размышлений для ${model}: ${effortLabel(effort)}.`),
     effortRows("iva_think", true, st.efforts));
+}
+
+export async function resolveThinkCatalogLoad(
+  st,
+  loaded,
+  showErrorImpl = showModelValidationError,
+) {
+  if (loaded.stale) return null;
+  if (!loaded.ok) {
+    await showErrorImpl(st, loaded.error);
+    return null;
+  }
+  return loaded.value;
 }
 
 async function showProviderScreen(st) {
@@ -933,6 +965,7 @@ async function showProviderScreen(st) {
 
 async function pickProvider(st, provider) {
   st.provider = provider;
+  st.pendingKey = null;
   const cat = CATALOG[provider];
   if (cat.auth === "oauth") {
     st.step = "loading";
@@ -951,7 +984,8 @@ async function pickProvider(st, provider) {
   }
   const env = await readEnvValues(ENV_PATH);
   if (!wizardIsCurrent(st)) return;
-  if (!env[cat.keyVar]) {
+  if (!env[cat.keyVar] || st.reenterKey === provider) {
+    st.reenterKey = null;
     // В группе ключ вводить нельзя (его не удалить) — отказ до установки awaitText.
     if (!isPrivateChat(st)) return refuseSecretInGroup(st);
     // awaitText обобщает старый awaitKey (см. handleControl): диспатчер по pending.awaitText
@@ -983,39 +1017,43 @@ async function showModelScreen(st) {
   if (!wizardIsCurrent(st)) return;
   const loaded = await runWizardRequest(
     st,
-    () => fetchModelOptions(st.provider, cat.keyVar ? env[cat.keyVar] : undefined, { dataDir: DATA_DIR_ABS }),
+    () => fetchModelOptions(
+      st.provider,
+      cat.keyVar ? (st.pendingKey ?? env[cat.keyVar]) : undefined,
+      { dataDir: DATA_DIR_ABS },
+    ),
   );
   if (loaded.stale) return;
   if (!loaded.ok) {
-    // fetchModelOptions only throws when the live /models probe rejected the stored key (401/403) —
-    // re-enter the key flow instead of offering a list the dead key can't use.
-    // В группе новый ключ вводить нельзя (его не удалить) — отказ до установки awaitText.
-    if (!isPrivateChat(st)) return refuseSecretInGroup(st);
-    st.awaitText = { kind: "apikey", secret: true, data: {} };
-    st.step = "awaiting_key";
-    await wizScreen(st,
-      tr(
-        `The saved ${cat.label} key was rejected. Send a new key in the next message — I'll delete it from the chat right away.`,
-        `Сохранённый ключ ${cat.label} не принят. Пришли новый ключ следующим сообщением — я сразу удалю его из чата.`,
-      ),
-      [cancelRow()]);
-    return;
+    return showModelValidationError(st, loaded.error);
   }
   const options = loaded.value;
-  // Keep the currently configured model selectable even when the live list is long.
   const current = env[cat.modelVar];
-  const currentOption = current
-    ? options.find((option) => option.id === current)
-      || { id: current, reasoningLevels: providerFallbackReasoningLevels(st.provider) }
-    : null;
-  st.modelOptions = [
-    ...(currentOption ? [currentOption] : []),
-    ...options.filter((option) => option.id !== current),
-  ].slice(0, 30);
+  st.modelOptions = selectableWizardOptions(options, current);
   st.step = "models";
   const rows = st.modelOptions.map((option, i) => [btn(option.id, `iva_model:m:${i}`)]);
   rows.push(cancelRow());
-  await wizScreen(st, tr(`Model (${cat.label}):`, `Модель (${cat.label}):`), rows);
+  const currentLine = current
+    ? tr(`Current (display only): ${current}.`, `Текущая (только для справки): ${current}.`)
+    : "";
+  await wizScreen(st, [
+    currentLine,
+    tr(`Choose a live model (${cat.label}):`, `Выбери модель из живого каталога (${cat.label}):`),
+  ].filter(Boolean).join("\n"), rows);
+}
+
+async function showModelValidationError(st, error) {
+  st.step = "model_error";
+  if (error?.code === "auth_rejected" && CATALOG[st.provider]?.keyVar) {
+    st.reenterKey = st.provider;
+  }
+  const reason = error instanceof ModelValidationError
+    ? error.message
+    : tr("provider validation failed", "проверка провайдера не прошла");
+  await wizScreen(st, tr(
+    `Couldn't validate the live model catalog: ${reason}. Your current configuration was not changed.`,
+    `Не удалось проверить живой каталог моделей: ${reason}. Текущая конфигурация не изменена.`,
+  ), retryBackRows());
 }
 
 // Codex device-link login. runDeviceCodeLogin polls up to 15 min — deliberately NOT
@@ -1085,20 +1123,39 @@ async function handleKeyMessage(msg, st) {
     return true;
   }
   st.awaitText = null;
-  await upsertEnv(ENV_PATH, { [cat.keyVar]: key }); // persist immediately — the chat copy is gone
+  st.pendingKey = key;
   if (!wizardIsCurrent(st)) return true;
   await showModelScreen(st);
   return true;
 }
 
-async function saveWizard(st) {
+export async function validateAndSaveWizard(st, {
+  readEnv = () => readEnvValues(ENV_PATH),
+  validate = validateModelSelection,
+  write = (updates) => upsertEnv(ENV_PATH, updates),
+} = {}) {
+  const env = await readEnv();
+  const cat = CATALOG[st.provider];
+  if (!cat || typeof st.model !== "string") {
+    throw new ModelValidationError("invalid_selection", "invalid wizard selection");
+  }
+  const key = cat.keyVar ? (st.pendingKey ?? env[cat.keyVar]) : undefined;
+  await validate({
+    provider: st.provider,
+    model: st.model,
+    key,
+    dataDir: DATA_DIR_ABS,
+  });
   const updates = { THINKING_EFFORT: st.effort }; // null ⇒ drop the line ("не задан")
   if (st.flow === "model") {
     updates.MODEL_PROVIDER = st.provider;
-    updates[CATALOG[st.provider].modelVar] = st.model;
+    updates[cat.modelVar] = st.model;
+    if (cat.keyVar && st.pendingKey) updates[cat.keyVar] = st.pendingKey;
   }
-  await upsertEnv(ENV_PATH, updates);
+  await write(updates);
 }
+
+const saveWizard = (st) => validateAndSaveWizard(st);
 
 async function showSaved(st) {
   const { provider, model, effort } = await currentConfig();
@@ -1142,6 +1199,22 @@ async function handleWizardCallback(cq) {
     if (CATALOG[p]) await pickProvider(st, p);
     return true;
   }
+  if (action === "retry") {
+    if (st.flow === "think") {
+      await handleThinkCmd(st.chatId, st.userId, { msgId: st.msgId });
+      return true;
+    }
+    await showModelScreen(st);
+    return true;
+  }
+  if (action === "back") {
+    if (st.flow === "think") {
+      await endWizard(st, tr("Kept the current configuration.", "Оставил текущую конфигурацию."), menuRow());
+      return true;
+    }
+    await showProviderScreen(st);
+    return true;
+  }
   if (action.startsWith("m:")) {
     const option = selectWizardModel(st, action.slice("m:".length));
     if (!option) return true;
@@ -1151,6 +1224,10 @@ async function handleWizardCallback(cq) {
         await saveWizard(st);
       } catch (e) {
         if (!wizardIsCurrent(st)) return true;
+        if (e instanceof ModelValidationError) {
+          await showModelValidationError(st, e);
+          return true;
+        }
         await endWizard(st, tr("Couldn't save .env: " + e.message, "Не удалось сохранить .env: " + e.message), menuRow());
         return true;
       }
@@ -1171,6 +1248,10 @@ async function handleWizardCallback(cq) {
       await saveWizard(st);
     } catch (e) {
       if (!wizardIsCurrent(st)) return true;
+      if (e instanceof ModelValidationError) {
+        await showModelValidationError(st, e);
+        return true;
+      }
       await endWizard(st, tr("Couldn't save .env: " + e.message, "Не удалось сохранить .env: " + e.message), menuRow());
       return true;
     }

--- a/scripts/telegram-poll.test.mjs
+++ b/scripts/telegram-poll.test.mjs
@@ -12,6 +12,9 @@ const {
   selectWizardModel,
   selectWizardEffort,
   runWizardRequest,
+  resolveThinkCatalogLoad,
+  selectableWizardOptions,
+  validateAndSaveWizard,
 } = await import("./telegram-poll.mjs");
 
 const enc = new TextEncoder();
@@ -96,6 +99,11 @@ test("stale wizard callbacks are rejected by message and screen step", () => {
   assert.equal(wizardActionAllowed(st, "m:0"), true);
   assert.equal(wizardActionAllowed(st, "eff:high"), false);
   assert.equal(wizardActionAllowed(st, "unknown"), false);
+  assert.equal(selectWizardModel({ modelOptions: [{ id: "safe", reasoningLevels: [] }] }, ""), null);
+  assert.equal(selectWizardModel({ modelOptions: [{ id: "safe", reasoningLevels: [] }] }, "00"), null);
+  assert.equal(selectWizardModel({ modelOptions: [{ id: "safe", reasoningLevels: [] }] }, "99"), null);
+  assert.equal(wizardActionAllowed({ step: "model_error" }, "retry"), true);
+  assert.equal(wizardActionAllowed({ step: "model_error" }, "back"), true);
 });
 
 test("model switch carries that model's levels; unknown effort never clears state", () => {
@@ -119,6 +127,21 @@ test("model switch carries that model's levels; unknown effort never clears stat
   assert.equal(st.effort, null);
 });
 
+test("stale current model stays display-only while a live current remains selectable", () => {
+  const live = [
+    { id: "new-a", reasoningLevels: ["low"] },
+    { id: "current", reasoningLevels: ["high"] },
+  ];
+  assert.deepEqual(selectableWizardOptions(live, "retired").map((item) => item.id), [
+    "new-a",
+    "current",
+  ]);
+  assert.deepEqual(selectableWizardOptions(live, "current").map((item) => item.id), [
+    "current",
+    "new-a",
+  ]);
+});
+
 test("Cancel during a rejected model fetch discards the stale error path", async () => {
   const st = { chatId: 1, userId: "2" };
   let active = st;
@@ -132,4 +155,84 @@ test("Cancel during a rejected model fetch discards the stale error path", async
   active = null; // Cancel removed this object from the flow slot while fetch was pending.
   rejectFetch(Object.assign(new Error("key rejected"), { auth: true }));
   assert.deepEqual(await pending, { stale: true });
+});
+
+test("/think catalog failure keeps the wizard and routes to Retry/Back error state", async () => {
+  const st = { step: "loading", removed: false };
+  const failure = Object.assign(new Error("catalog offline"), {
+    code: "catalog_unavailable",
+  });
+
+  const options = await resolveThinkCatalogLoad(
+    st,
+    { ok: false, error: failure },
+    async (current, error) => {
+      assert.equal(current, st);
+      assert.equal(error, failure);
+      current.step = "model_error";
+      current.buttons = ["retry", "back"];
+    },
+  );
+
+  assert.equal(options, null);
+  assert.equal(st.removed, false);
+  assert.equal(st.step, "model_error");
+  assert.deepEqual(st.buttons, ["retry", "back"]);
+});
+
+test("catalog change before save preserves the old env", async () => {
+  const writes = [];
+  await assert.rejects(
+    validateAndSaveWizard(
+      {
+        flow: "model",
+        provider: "ollama",
+        model: "retired",
+        effort: "high",
+        pendingKey: "new-secret",
+      },
+      {
+        readEnv: async () => ({
+          MODEL_PROVIDER: "codex",
+          CODEX_MODEL: "old-model",
+          OLLAMA_API_KEY: "old-secret",
+        }),
+        validate: async () => {
+          throw Object.assign(new Error("retired"), { code: "model_unavailable" });
+        },
+        write: async (updates) => writes.push(updates),
+      },
+    ),
+    /retired/,
+  );
+  assert.deepEqual(writes, []);
+});
+
+test("provider, model, effort and pending key persist in one atomic write", async () => {
+  const validations = [];
+  const writes = [];
+  await validateAndSaveWizard(
+    {
+      flow: "model",
+      provider: "opencode",
+      model: "live-model",
+      effort: "medium",
+      pendingKey: "new-secret",
+    },
+    {
+      readEnv: async () => ({ MODEL_PROVIDER: "ollama" }),
+      validate: async (selection) => {
+        validations.push(selection);
+        return { id: selection.model, reasoningLevels: ["medium"] };
+      },
+      write: async (updates) => writes.push(updates),
+    },
+  );
+  assert.equal(validations[0].key, "new-secret");
+  assert.deepEqual(writes, [{
+    THINKING_EFFORT: "medium",
+    MODEL_PROVIDER: "opencode",
+    OPENCODE_MODEL: "live-model",
+    OPENCODE_API_KEY: "new-secret",
+  }]);
 });


### PR DESCRIPTION
Closes #55

## What changed

- added one shared strict validator used by interactive setup and the Telegram model wizard
- require exact live catalog membership for Ollama Cloud, OpenCode Go and Codex
- validate OpenRouter with a minimal tool/function-call request
- keep stale current models display-only, reject forged callback indices, and revalidate immediately before save
- keep newly entered API keys in wizard memory until provider/model validation succeeds
- persist provider, model, effort and pending key in one atomic `.env` update
- show Retry/Back after network, auth, empty/malformed catalog, or changed-catalog failures

## RED evidence

Before the change, `fetchModelOptions()` restored static fallback models after Codex/network/malformed failures, and `showModelScreen()` explicitly reinserted a stale configured model into selectable Telegram buttons. The new focused test initially failed with `ERR_MODULE_NOT_FOUND` for the absent shared validator; the existing fallback test then failed once strict behavior replaced the fallback.

## GREEN evidence

```text
node --test scripts/lib/model-validation.test.mjs scripts/lib/model-catalog.test.mjs scripts/telegram-poll.test.mjs
20 passed, 0 failed

node --test scripts/lib/*.test.mjs scripts/lib/menu/*.test.mjs scripts/*.test.mjs
336 passed, 0 failed

npm run typecheck
passed

npx eve build
passed

git diff --check
passed
```

## UX before / after

Before: a retired configured model could return as a button, provider outages silently offered static choices, and a newly entered key was written before model validation completed.

After: only current live choices are selectable; the old value remains visible for context; failed validation offers Retry/Back and leaves the complete old configuration untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added strict live validation for model selections across supported providers.
  * Model lists now use successful, non-empty live catalogs; unavailable or malformed catalogs no longer silently fall back.
  * Added provider-specific connectivity checks, including OpenRouter validation.
  * Telegram model and thinking workflows now support retry/back actions and clearer validation errors.
  * API keys and model settings are validated before being saved, with atomic updates preserving existing settings on failure.

* **Tests**
  * Added coverage for catalog failures, invalid selections, provider validation, and wizard save behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->