### PR TITLE
Send Telegram working status before turn startup

### DIFF
--- a/agent/channels/telegram.ts
+++ b/agent/channels/telegram.ts
@@ -30,7 +30,13 @@ import {
   TELEGRAM_ACCEPTANCE_ROUTE,
   wrapTelegramQueueOnMessage,
 } from "../../scripts/lib/telegram-acceptance.mjs";
-import { publishTelegramTurnStarted } from "../../scripts/lib/telegram-turn-start.mjs";
+import {
+  abandonTelegramEarlyStatus,
+  emitTelegramTurnLatency,
+  markTelegramFirstOutput,
+  publishTelegramEarlyStatus,
+  publishTelegramTurnStarted,
+} from "../../scripts/lib/telegram-turn-start.mjs";
 import { pathToFileURL } from "node:url";
 
 // Токен (TELEGRAM_BOT_TOKEN) и секрет вебхука (TELEGRAM_WEBHOOK_SECRET_TOKEN)
@@ -272,15 +278,18 @@ function stoppedText(): string {
 // Telegram вернёт 400 на custom_emoji — тогда навсегда падаем на обычные ⏳.
 const WORK_LOADER = { alt: "🔵", customEmojiId: "5258372840389888502", fallback: "⏳" };
 let workLoaderSupported = true;
+const stopReplyMarkup = () => ({
+  inline_keyboard: [[{ text: tr("⏹ Stop", "⏹ Стоп"), callback_data: STOP_CALLBACK }]],
+});
 
 async function sendWorkingStatus(tg: {
   chatId: string;
   messageThreadId?: number;
   request: (m: string, b?: any) => Promise<any>;
-}): Promise<number | null> {
+}, { canStop = true } = {}): Promise<number | null> {
   const base = {
     chat_id: tg.chatId,
-    reply_markup: { inline_keyboard: [[{ text: tr("⏹ Stop", "⏹ Стоп"), callback_data: STOP_CALLBACK }]] },
+    ...(canStop ? { reply_markup: stopReplyMarkup() } : {}),
     ...(tg.messageThreadId !== undefined ? { message_thread_id: tg.messageThreadId } : {}),
   };
   if (workLoaderSupported) {
@@ -341,6 +350,12 @@ async function finishStatus(
         sessionId: null,
         turnId: null,
         statusMessageId: null,
+        ingressId: null,
+        ingressAt: null,
+        statusAt: null,
+        turnAt: null,
+        firstOutputAt: null,
+        latencyLogged: null,
         ...(mode === "cancelled" ? { wasCancelled: true } : {}),
       },
     )
@@ -413,9 +428,15 @@ const telegram = telegramChannel({
         continuationToken: channel.continuationToken,
         sessionId: ctx.session.id,
         turnId: data.turnId,
-        setStatusImpl: setChatStatus,
+        getStatusImpl: getChatStatus,
         setStatusIfImpl: setChatStatusIf,
-        sendWorkingStatusImpl: () => sendWorkingStatus(tg),
+        sendWorkingStatusImpl: (options) => sendWorkingStatus(tg, options),
+        enableWorkingStatusStopImpl: (messageId) =>
+          tg.request("editMessageReplyMarkup", {
+            chat_id: tg.chatId,
+            message_id: messageId,
+            reply_markup: stopReplyMarkup(),
+          }),
         removeWorkingStatusImpl: (messageId) =>
           tg.request("deleteMessage", { chat_id: tg.chatId, message_id: messageId }),
         onWorkingStatusError: (error) =>
@@ -440,8 +461,22 @@ const telegram = telegramChannel({
           status: "idle",
           continuationToken: channel.continuationToken,
           turnId: null,
+          ingressId: null,
+          ingressAt: null,
+          statusAt: null,
+          turnAt: null,
+          firstOutputAt: null,
+          latencyLogged: null,
         },
       );
+    },
+    "message.appended"(_data, channel, ctx) {
+      markTelegramFirstOutput({
+        chatKey: chatKeyOf(channel.telegram.chatId, channel.telegram.messageThreadId),
+        sessionId: ctx.session.id,
+        getStatusImpl: getChatStatus,
+        setStatusIfImpl: setChatStatusIf,
+      });
     },
     // Ответ модели → красивый Telegram-HTML. Переопределяет дефолтную plain-доставку
     // eve. Промежуточный текст перед tool-calls не шлём (зеркалим дефолт). Конвертер
@@ -449,8 +484,17 @@ const telegram = telegramChannel({
     // если случился, НЕ глотаем молча: логируем и шлём один раз plain (теги срезаны,
     // без parse_mode → по сущностям 400 невозможен). Без повторного хода модели — ход
     // уже закрыт, реформат произойдёт на следующем сообщении (ошибка видна в логе/vault).
-    async "message.completed"(data, channel) {
+    async "message.completed"(data, channel, ctx) {
       if (data.finishReason === "tool-calls" || !data.message) return;
+      const recordDelivery = (delivered: boolean) =>
+        emitTelegramTurnLatency({
+          chatKey: chatKeyOf(channel.telegram.chatId, channel.telegram.messageThreadId),
+          sessionId: ctx.session.id,
+          deliveryAt: Date.now(),
+          delivered,
+          getStatusImpl: getChatStatus,
+          setStatusIfImpl: setChatStatusIf,
+        });
       // Outbound security-гейт: редактим утёкшие секреты/эксфил-URL ДО отправки. Fail-open —
       // если гейт что-то нашёл, шлём отредактированное и громко логируем (блокировать ответ
       // целиком хуже редкой утечки для единственного владельца).
@@ -479,7 +523,10 @@ const telegram = telegramChannel({
               ? { message_thread_id: channel.telegram.messageThreadId }
               : {}),
           });
-          if (res.ok) return;
+          if (res.ok) {
+            recordDelivery(true);
+            return;
+          }
           console.error(
             "[telegram] sendRichMessage отвергнут, фолбэк HTML:",
             res.status,
@@ -490,8 +537,12 @@ const telegram = telegramChannel({
         }
       }
 
+      let attemptedDelivery = false;
+      let allChunksDelivered = true;
       for (const html of toTelegramHtmlChunks(guard.text, 4096)) {
         if (!html) continue;
+        attemptedDelivery = true;
+        let chunkDelivered = false;
         try {
           // eve's TelegramMessageBody type omits parse_mode, но рантайм
           // (normalizeTelegramMessageBody) спредит тело прямо в sendMessage —
@@ -500,16 +551,20 @@ const telegram = telegramChannel({
             text: html,
             parse_mode: "HTML",
           } as TelegramMessageBody & { parse_mode: "HTML" });
+          chunkDelivered = true;
         } catch (err) {
           console.error("[telegram] HTML отвергнут, шлю plain:", err, "| HTML:", html.slice(0, 300));
           try {
             // htmlToPlain декодирует сущности (&amp;→&), иначе они утекли бы литералами.
             await channel.telegram.post(htmlToPlain(html));
+            chunkDelivered = true;
           } catch (e2) {
             console.error("[telegram] plain-фолбэк тоже упал:", e2);
           }
         }
+        if (!chunkDelivered) allChunksDelivered = false;
       }
+      if (attemptedDelivery && allChunksDelivered) recordDelivery(true);
     },
     // Ход упал (в т.ч. переполнение контекста / HookConflict) — даём пользователю escape.
     async "turn.failed"(_data, channel, ctx) {
@@ -551,6 +606,83 @@ const telegram = telegramChannel({
       }
       return null; // дропаем апдейт
     }
+
+    const raw = message.raw as Record<string, any>;
+    let media:
+      | { fileId: string; tag: string; transcribe: boolean; mimeType?: string; fileName?: string }
+      | null = null;
+    if (Array.isArray(raw.photo) && raw.photo.length > 0) {
+      const p = raw.photo[raw.photo.length - 1];
+      if (p?.file_id) media = { fileId: p.file_id, tag: "photo", transcribe: false };
+    }
+    if (!media) {
+      for (const m of RAW_MEDIA) {
+        const obj = raw[m.key] as { file_id?: string; mime_type?: string; file_name?: string } | undefined;
+        if (obj && typeof obj.file_id === "string") {
+          media = {
+            fileId: obj.file_id,
+            tag: m.tag,
+            transcribe: m.transcribe,
+            mimeType: obj.mime_type,
+            fileName: obj.file_name,
+          };
+          break;
+        }
+      }
+    }
+    const nonFile = raw.location
+      ? `[location]\t${raw.location.latitude}, ${raw.location.longitude}`
+      : raw.contact
+        ? `[contact]\t${[raw.contact.first_name, raw.contact.last_name, raw.contact.phone_number]
+            .filter(Boolean)
+            .join(" ")}`
+        : raw.poll
+          ? `[poll]\t${raw.poll.question}`
+          : null;
+    if (nonFile) {
+      const [head, body] = nonFile.split("\t");
+      appendDaily(head, body);
+    }
+
+    // The allowlist and dispatch decision are complete. Publish the one working
+    // status before reply sanitization, media I/O, security scans or providers.
+    if (
+      media
+        ? !shouldDispatchMedia(message, ctx.telegram.botUsername)
+        : !shouldDispatch(message, ctx.telegram.botUsername)
+    ) {
+      return null;
+    }
+    const earlyKey = chatKeyOf(message.chat.id, message.messageThreadId);
+    const earlyIngressId = await publishTelegramEarlyStatus({
+      chatKey: earlyKey,
+      setStatusImpl: setChatStatus,
+      setStatusIfImpl: setChatStatusIf,
+      sendWorkingStatusImpl: (options) => sendWorkingStatus(ctx.telegram, options),
+      removeWorkingStatusImpl: (messageId) =>
+        ctx.telegram.request("deleteMessage", {
+          chat_id: ctx.telegram.chatId,
+          message_id: messageId,
+        }),
+      onWorkingStatusError: (error) =>
+        console.error("[telegram] раннее статус-сообщение не отправилось:", error),
+    });
+    const abandonEarly = () =>
+      typeof earlyIngressId === "string"
+        ? abandonTelegramEarlyStatus({
+            chatKey: earlyKey,
+            ingressId: earlyIngressId,
+            getStatusImpl: getChatStatus,
+            setStatusIfImpl: setChatStatusIf,
+            removeWorkingStatusImpl: (messageId) =>
+              ctx.telegram.request("deleteMessage", {
+                chat_id: ctx.telegram.chatId,
+                message_id: messageId,
+              }),
+            onWorkingStatusError: (error) =>
+              console.error("[telegram] раннее статус-сообщение не удалилось:", error),
+          })
+        : Promise.resolve(false);
 
     // 1a-стоп. Пометка о прерванном ходе + совместимость с апдейтом от старого bridge,
     // который приклеивал busy-time строки в message.raw.iva_buffered. Текущий bridge
@@ -652,34 +784,7 @@ const telegram = telegramChannel({
 
     // 2. Любой присланный файл (фото/документ/голос/аудио/видео/кружок/анимация/стикер).
     // uploadPolicy "disabled" → message.attachments пуст; берём ВСЁ из raw сами.
-    const raw = message.raw as Record<string, any>;
-    let media:
-      | { fileId: string; tag: string; transcribe: boolean; mimeType?: string; fileName?: string }
-      | null = null;
-    if (Array.isArray(raw.photo) && raw.photo.length > 0) {
-      // photo — массив размеров по возрастанию; берём самый крупный (последний).
-      const p = raw.photo[raw.photo.length - 1];
-      if (p?.file_id) media = { fileId: p.file_id, tag: "photo", transcribe: false };
-    }
-    if (!media) {
-      for (const m of RAW_MEDIA) {
-        const obj = raw[m.key] as { file_id?: string; mime_type?: string; file_name?: string } | undefined;
-        if (obj && typeof obj.file_id === "string") {
-          media = {
-            fileId: obj.file_id,
-            tag: m.tag,
-            transcribe: m.transcribe,
-            mimeType: obj.mime_type,
-            fileName: obj.file_name,
-          };
-          break;
-        }
-      }
-    }
-
     if (media) {
-      // Гейтим медиа как обычный диспатч (в группе — только обращённое к боту).
-      if (!shouldDispatchMedia(message, ctx.telegram.botUsername)) return null;
       const tag = `[${media.tag}]`;
       const caption = (message.caption || "").trim();
       const capSuffix = caption ? `\n\n${caption}` : "";
@@ -705,6 +810,7 @@ const telegram = telegramChannel({
           } catch {
             /* молча игнорируем сбой ответа */
           }
+          await abandonEarly();
           return null;
         }
         // null = getFile без file_path (не too-big) либо скачивание !ok — общий диагностический фолбэк.
@@ -751,8 +857,10 @@ const telegram = telegramChannel({
           !transcript &&
           !caption &&
           !operationalPreContext.length
-        )
+        ) {
+          await abandonEarly();
           return null;
+        }
 
         const path = `${process.env.ASSISTANT_VAULT_DIR || "vault"}/${rel}`;
         const isImage = media.tag === "photo" || media.tag === "sticker" || media.tag === "animation";
@@ -797,32 +905,12 @@ const telegram = telegramChannel({
         } catch {
           /* молча игнорируем сбой ответа */
         }
+        await abandonEarly();
         return null;
       }
     }
 
-    // 2b. Не-файловые типы (локация/контакт/опрос) — буквально всё фиксируем в логе дня.
-    // Это чистые данные, файла нет; скачивать нечего, отдельный ход без текста не нужен.
-    const nonFile = raw.location
-      ? `[location]\t${raw.location.latitude}, ${raw.location.longitude}`
-      : raw.contact
-        ? `[contact]\t${[raw.contact.first_name, raw.contact.last_name, raw.contact.phone_number]
-            .filter(Boolean)
-            .join(" ")}`
-        : raw.poll
-          ? `[poll]\t${raw.poll.question}`
-          : null;
-    if (nonFile) {
-      const [head, body] = nonFile.split("\t");
-      appendDaily(head, body);
-      // нет текста — только лог, без ответа (если не едет буфер — его терять нельзя)
-      if (!(message.text || "").trim() && !preContext.length) return null;
-    }
-
-    // 3. Штатное гейтирование диспатча (текст; в группе — только обращённое к боту).
-    if (!shouldDispatch(message, ctx.telegram.botUsername)) return null;
-
-    // 4. Текстовая реплика юзера → daily (verbatim) + inbound security-гейт.
+    // 3. Текстовая реплика юзера → daily (verbatim) + inbound security-гейт.
     const userText = (message.text || "").trim();
     if (userText) appendDaily("[text]", userText);
 

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -17,6 +17,28 @@
   Keeping byte-equivalent existing settings skips that rewrite; any changed keep-path
   value validates the configured model first.
 
+## Early Telegram working status and latency phases (IVA-006 / #57)
+
+- A trusted update publishes one provisional `running` status immediately after
+  the allowlist and message/media dispatch decision. Reply sanitization, media
+  download/transcription/vision and provider work all happen after that request.
+- The provisional record has a random ingress ID and no Eve session ID.
+  `turn.started` adopts it with a per-chat compare-and-set, preserving the same
+  Telegram message. A reset that wins the race changes the record first, so the
+  old turn cannot attach its session or revive running state. Its Stop button is
+  added only after that adoption gives cancellation a real session target.
+- Telegram status send and cleanup errors are logged and swallowed. If authored
+  handling intentionally produces no turn, its still-provisional status is
+  compare-and-set back to idle and its message is removed.
+- The status record carries only monotonic lifecycle timestamps. The first
+  `message.appended` event records first output, and final delivery emits one
+  JSON line with ingress-to-status, ingress-to-turn, ingress-to-first-output and
+  ingress-to-delivery milliseconds only after every Telegram chunk succeeds in
+  HTML or plain fallback. The log schema has no identifiers, prompt,
+  user data, tokens or arbitrary error text.
+- Location, contact and poll data is appended to the daily transcript before the
+  no-turn dispatch gate consumes those silent updates.
+
 ## Structured Telegram reply context (IVA-009 / #53)
 
 - Eve keeps quoted text and media only in `raw.reply_to_message`; IVA now adds one

--- a/scripts/lib/telegram-turn-start.d.mts
+++ b/scripts/lib/telegram-turn-start.d.mts
@@ -1,19 +1,80 @@
+type ChatStatus = Record<string, unknown> | null;
+type GetStatus = (chatKey: string) => ChatStatus;
+type SetStatus = (chatKey: string, patch: Record<string, unknown>) => unknown;
+type SetStatusIf = (
+  chatKey: string,
+  expected: Record<string, unknown>,
+  patch: Record<string, unknown>,
+) => unknown;
+
+export interface PublishTelegramEarlyStatusOptions {
+  chatKey: string;
+  ingressId?: string;
+  now?: () => number;
+  setStatusImpl: SetStatus;
+  setStatusIfImpl: SetStatusIf;
+  sendWorkingStatusImpl: (options: { canStop: false }) => Promise<number | null | undefined>;
+  removeWorkingStatusImpl?: (messageId: number) => Promise<unknown>;
+  onWorkingStatusError?: (error: unknown) => void;
+}
+
+export function publishTelegramEarlyStatus(
+  options: PublishTelegramEarlyStatusOptions,
+): Promise<string | null>;
+
 export interface PublishTelegramTurnStartedOptions {
   chatKey: string;
   continuationToken: string;
   sessionId: string;
   turnId: string;
-  setStatusImpl: (chatKey: string, patch: Record<string, unknown>) => unknown;
-  setStatusIfImpl: (
-    chatKey: string,
-    expected: Record<string, unknown>,
-    patch: Record<string, unknown>,
-  ) => unknown;
-  sendWorkingStatusImpl: () => Promise<number | null | undefined>;
+  now?: () => number;
+  getStatusImpl: GetStatus;
+  setStatusIfImpl: SetStatusIf;
+  sendWorkingStatusImpl?: (options: { canStop: true }) => Promise<number | null | undefined>;
+  enableWorkingStatusStopImpl?: (messageId: number) => Promise<unknown>;
   removeWorkingStatusImpl?: (messageId: number) => Promise<unknown>;
   onWorkingStatusError?: (error: unknown) => void;
 }
 
 export function publishTelegramTurnStarted(
   options: PublishTelegramTurnStartedOptions,
-): Promise<void>;
+): Promise<boolean>;
+
+export interface AbandonTelegramEarlyStatusOptions {
+  chatKey: string;
+  ingressId: string;
+  getStatusImpl: GetStatus;
+  setStatusIfImpl: SetStatusIf;
+  removeWorkingStatusImpl?: (messageId: number) => Promise<unknown>;
+  onWorkingStatusError?: (error: unknown) => void;
+}
+
+export function abandonTelegramEarlyStatus(
+  options: AbandonTelegramEarlyStatusOptions,
+): Promise<boolean>;
+
+export interface EmitTelegramTurnLatencyOptions {
+  chatKey: string;
+  sessionId: string;
+  deliveryAt: number;
+  delivered: boolean;
+  getStatusImpl: GetStatus;
+  setStatusIfImpl: SetStatusIf;
+  logImpl?: (line: string) => void;
+}
+
+export function emitTelegramTurnLatency(
+  options: EmitTelegramTurnLatencyOptions,
+): boolean;
+
+export interface MarkTelegramFirstOutputOptions {
+  chatKey: string;
+  sessionId: string;
+  now?: () => number;
+  getStatusImpl: GetStatus;
+  setStatusIfImpl: SetStatusIf;
+}
+
+export function markTelegramFirstOutput(
+  options: MarkTelegramFirstOutputOptions,
+): boolean;

--- a/scripts/lib/telegram-turn-start.mjs
+++ b/scripts/lib/telegram-turn-start.mjs
@@ -1,36 +1,53 @@
-export async function publishTelegramTurnStarted({
+import { randomUUID } from "node:crypto";
+
+const durationFromIngress = (ingressAt, at) =>
+  Number.isFinite(ingressAt) && Number.isFinite(at) && at >= ingressAt
+    ? at - ingressAt
+    : null;
+
+export async function publishTelegramEarlyStatus({
   chatKey,
-  continuationToken,
-  sessionId,
-  turnId,
+  ingressId = randomUUID(),
+  now = Date.now,
   setStatusImpl,
   setStatusIfImpl,
   sendWorkingStatusImpl,
   removeWorkingStatusImpl = async () => {},
   onWorkingStatusError = () => {},
 }) {
-  setStatusImpl(chatKey, {
-    status: "running",
-    continuationToken,
-    sessionId,
-    turnId,
-    statusMessageId: null,
-    wasCancelled: null,
-  });
+  const ingressAt = now();
+  try {
+    setStatusImpl(chatKey, {
+      status: "running",
+      ingressId,
+      ingressAt,
+      statusAt: null,
+      turnAt: null,
+      firstOutputAt: null,
+      sessionId: null,
+      turnId: null,
+      statusMessageId: null,
+      latencyLogged: null,
+      resetAt: null,
+    });
+  } catch (error) {
+    onWorkingStatusError(error);
+    return null;
+  }
 
   let statusMessageId;
   try {
-    statusMessageId = await sendWorkingStatusImpl();
+    statusMessageId = await sendWorkingStatusImpl({ canStop: false });
   } catch (error) {
     onWorkingStatusError(error);
-    return;
+    return ingressId;
   }
-  if (statusMessageId === null || statusMessageId === undefined) return;
+  if (statusMessageId === null || statusMessageId === undefined) return ingressId;
 
   const attached = setStatusIfImpl(
     chatKey,
-    { status: "running", sessionId, turnId },
-    { statusMessageId },
+    { status: "running", ingressId },
+    { statusMessageId, statusAt: now() },
   );
   if (!attached) {
     try {
@@ -39,4 +56,202 @@ export async function publishTelegramTurnStarted({
       onWorkingStatusError(error);
     }
   }
+  return ingressId;
+}
+
+export async function publishTelegramTurnStarted({
+  chatKey,
+  continuationToken,
+  sessionId,
+  turnId,
+  now = Date.now,
+  getStatusImpl,
+  setStatusIfImpl,
+  sendWorkingStatusImpl,
+  enableWorkingStatusStopImpl = async () => {},
+  removeWorkingStatusImpl = async () => {},
+  onWorkingStatusError = () => {},
+}) {
+  const current = getStatusImpl(chatKey);
+  if (
+    current?.status !== "running" ||
+    typeof current.ingressId !== "string" ||
+    current.ingressId.length === 0 ||
+    current.sessionId !== undefined
+  ) {
+    // Callback/HITL and proactive turns do not pass through onMessage. Preserve
+    // their existing status behavior with a generation CAS, while a reset
+    // tombstone always wins over a late old turn.
+    if (current?.resetAt !== undefined) return false;
+    let claimed;
+    try {
+      claimed = setStatusIfImpl(
+        chatKey,
+        { generation: current?.generation },
+        {
+          status: "running",
+          continuationToken,
+          sessionId,
+          turnId,
+          statusMessageId: null,
+          turnAt: now(),
+          latencyLogged: null,
+        },
+      );
+    } catch (error) {
+      onWorkingStatusError(error);
+      return false;
+    }
+    if (!claimed || sendWorkingStatusImpl === undefined) return Boolean(claimed);
+    let statusMessageId;
+    try {
+      statusMessageId = await sendWorkingStatusImpl({ canStop: true });
+    } catch (error) {
+      onWorkingStatusError(error);
+      return true;
+    }
+    if (statusMessageId === null || statusMessageId === undefined) return true;
+    const attached = setStatusIfImpl(
+      chatKey,
+      { status: "running", sessionId, turnId },
+      { statusMessageId },
+    );
+    if (!attached) {
+      try {
+        await removeWorkingStatusImpl(statusMessageId);
+      } catch (error) {
+        onWorkingStatusError(error);
+      }
+    }
+    return true;
+  }
+  try {
+    const adopted = setStatusIfImpl(
+      chatKey,
+      {
+        status: "running",
+        ingressId: current.ingressId,
+        sessionId: undefined,
+      },
+      {
+        continuationToken,
+        sessionId,
+        turnId,
+        turnAt: now(),
+      },
+    );
+    if (!adopted) return false;
+    if (current.statusMessageId !== undefined) {
+      try {
+        await enableWorkingStatusStopImpl(current.statusMessageId);
+      } catch (error) {
+        onWorkingStatusError(error);
+      }
+    }
+    return true;
+  } catch (error) {
+    onWorkingStatusError(error);
+    return false;
+  }
+}
+
+export async function abandonTelegramEarlyStatus({
+  chatKey,
+  ingressId,
+  getStatusImpl,
+  setStatusIfImpl,
+  removeWorkingStatusImpl = async () => {},
+  onWorkingStatusError = () => {},
+}) {
+  const current = getStatusImpl(chatKey);
+  if (
+    current?.status !== "running" ||
+    current.ingressId !== ingressId ||
+    current.sessionId !== undefined
+  ) {
+    return false;
+  }
+  const cleared = setStatusIfImpl(
+    chatKey,
+    { status: "running", ingressId, sessionId: undefined },
+    {
+      status: "idle",
+      ingressId: null,
+      ingressAt: null,
+      statusAt: null,
+      turnAt: null,
+      firstOutputAt: null,
+      statusMessageId: null,
+      latencyLogged: null,
+    },
+  );
+  if (!cleared) return false;
+  if (current.statusMessageId !== undefined) {
+    try {
+      await removeWorkingStatusImpl(current.statusMessageId);
+    } catch (error) {
+      onWorkingStatusError(error);
+    }
+  }
+  return true;
+}
+
+export function markTelegramFirstOutput({
+  chatKey,
+  sessionId,
+  now = Date.now,
+  getStatusImpl,
+  setStatusIfImpl,
+}) {
+  const current = getStatusImpl(chatKey);
+  if (
+    current?.status !== "running" ||
+    current.sessionId !== sessionId ||
+    current.firstOutputAt !== undefined
+  ) {
+    return false;
+  }
+  return Boolean(
+    setStatusIfImpl(
+      chatKey,
+      { status: "running", sessionId, firstOutputAt: undefined },
+      { firstOutputAt: now() },
+    ),
+  );
+}
+
+export function emitTelegramTurnLatency({
+  chatKey,
+  sessionId,
+  deliveryAt,
+  delivered,
+  getStatusImpl,
+  setStatusIfImpl,
+  logImpl = console.log,
+}) {
+  if (delivered !== true) return false;
+  const current = getStatusImpl(chatKey);
+  if (
+    current?.status !== "running" ||
+    current.sessionId !== sessionId ||
+    current.latencyLogged !== undefined
+  ) {
+    return false;
+  }
+  const marked = setStatusIfImpl(
+    chatKey,
+    { status: "running", sessionId, latencyLogged: undefined },
+    { latencyLogged: true },
+  );
+  if (!marked) return false;
+
+  const record = {
+    event: "telegram_turn_latency",
+    ingressToStatusMs: durationFromIngress(current.ingressAt, current.statusAt),
+    ingressToTurnMs: durationFromIngress(current.ingressAt, current.turnAt),
+    ingressToFirstOutputMs: durationFromIngress(current.ingressAt, current.firstOutputAt),
+    ingressToDeliveryMs: durationFromIngress(current.ingressAt, deliveryAt),
+  };
+  logImpl(JSON.stringify(record));
+  return true;
 }

--- a/scripts/lib/telegram-turn-start.test.mjs
+++ b/scripts/lib/telegram-turn-start.test.mjs
@@ -1,7 +1,12 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { publishTelegramTurnStarted } from "./telegram-turn-start.mjs";
+import {
+  emitTelegramTurnLatency,
+  markTelegramFirstOutput,
+  publishTelegramEarlyStatus,
+  publishTelegramTurnStarted,
+} from "./telegram-turn-start.mjs";
 
 function deferred() {
   let resolve;
@@ -11,81 +16,192 @@ function deferred() {
   return { promise, resolve };
 }
 
-test("turn.started publishes running before the working-status request can block", async () => {
-  const working = deferred();
-  const events = [];
-  let status = { status: "idle" };
+function statusStore(initial = {}) {
+  let value = initial;
+  return {
+    get: () => value,
+    set: (_key, patch) => {
+      value = { ...value, ...patch };
+      for (const key of Object.keys(value)) if (value[key] === null) delete value[key];
+      return value;
+    },
+    cas: (_key, expected, patch) => {
+      if (Object.entries(expected).some(([key, expectedValue]) => !Object.is(value[key], expectedValue))) {
+        return null;
+      }
+      value = { ...value, ...patch };
+      for (const key of Object.keys(value)) if (value[key] === null) delete value[key];
+      return value;
+    },
+  };
+}
 
-  const publishing = publishTelegramTurnStarted({
+test("a trusted dispatch creates one status before a fake 20-second pre-turn delay and turn.started adopts it", async () => {
+  const events = [];
+  const store = statusStore({ status: "idle" });
+  let nowMs = 1_000;
+  let sends = 0;
+  const stopEnabled = [];
+
+  await publishTelegramEarlyStatus({
+    chatKey: "1:",
+    ingressId: "ingress-1",
+    now: () => nowMs++,
+    setStatusImpl: store.set,
+    setStatusIfImpl: store.cas,
+    sendWorkingStatusImpl: async (options) => {
+      sends++;
+      stopEnabled.push(options.canStop);
+      events.push("working-status");
+      return 77;
+    },
+  });
+  events.push("provider-work");
+  nowMs += 20_000;
+
+  const adopted = await publishTelegramTurnStarted({
     chatKey: "1:",
     continuationToken: "1::",
     sessionId: "session-1",
     turnId: "turn-1",
-    setStatusImpl: (_key, patch) => {
-      events.push("running");
-      status = { ...status, ...patch };
-      return status;
-    },
-    setStatusIfImpl: (_key, expected, patch) => {
-      assert.equal(status.status, expected.status);
-      assert.equal(status.sessionId, expected.sessionId);
-      assert.equal(status.turnId, expected.turnId);
-      events.push("status-message");
-      status = { ...status, ...patch };
-      return status;
-    },
-    sendWorkingStatusImpl: async () => {
-      events.push("working-request");
-      return working.promise;
+    now: () => nowMs,
+    getStatusImpl: store.get,
+    setStatusIfImpl: store.cas,
+    enableWorkingStatusStopImpl: async (messageId) => {
+      assert.equal(messageId, 77);
+      stopEnabled.push(true);
     },
   });
 
-  await new Promise((resolve) => setImmediate(resolve));
-  assert.equal(status.status, "running");
-  assert.equal(status.statusMessageId, null);
-  assert.deepEqual(events, ["running", "working-request"]);
-
-  working.resolve(77);
-  await publishing;
-  assert.equal(status.statusMessageId, 77);
-  assert.deepEqual(events, ["running", "working-request", "status-message"]);
+  assert.equal(adopted, true);
+  assert.equal(sends, 1);
+  assert.deepEqual(stopEnabled, [false, true]);
+  assert.deepEqual(events, ["working-status", "provider-work"]);
+  assert.equal(store.get().statusMessageId, 77);
+  assert.equal(store.get().sessionId, "session-1");
+  assert.equal(store.get().turnId, "turn-1");
+  assert.equal(store.get().ingressAt, 1_000);
+  assert.equal(store.get().statusAt, 1_001);
+  assert.equal(store.get().turnAt, 21_002);
 });
 
-test("a late working-status response cannot attach to a completed or newer turn", async () => {
-  const working = deferred();
-  let status = { status: "idle" };
-  const removed = [];
+test("working-status failure never blocks turn adoption", async () => {
+  const store = statusStore({ status: "idle" });
+  const errors = [];
 
-  const publishing = publishTelegramTurnStarted({
+  await publishTelegramEarlyStatus({
+    chatKey: "1:",
+    ingressId: "ingress-1",
+    setStatusImpl: store.set,
+    setStatusIfImpl: store.cas,
+    sendWorkingStatusImpl: async () => {
+      throw new Error("Telegram unavailable");
+    },
+    onWorkingStatusError: (error) => errors.push(error.message),
+  });
+  const adopted = await publishTelegramTurnStarted({
     chatKey: "1:",
     continuationToken: "1::",
     sessionId: "session-1",
     turnId: "turn-1",
-    setStatusImpl: (_key, patch) => {
-      status = { ...status, ...patch };
-      return status;
-    },
-    setStatusIfImpl: (_key, expected, patch) => {
-      if (
-        status.status !== expected.status ||
-        status.sessionId !== expected.sessionId ||
-        status.turnId !== expected.turnId
-      ) {
-        return null;
-      }
-      status = { ...status, ...patch };
-      return status;
-    },
+    getStatusImpl: store.get,
+    setStatusIfImpl: store.cas,
+  });
+
+  assert.equal(adopted, true);
+  assert.deepEqual(errors, ["Telegram unavailable"]);
+  assert.equal(store.get().sessionId, "session-1");
+  assert.equal(store.get().statusMessageId, undefined);
+});
+
+test("a reset racing a late early-status response cannot revive the old session", async () => {
+  const working = deferred();
+  const store = statusStore({ status: "idle" });
+  const removed = [];
+
+  const publishing = publishTelegramEarlyStatus({
+    chatKey: "1:",
+    ingressId: "ingress-1",
+    setStatusImpl: store.set,
+    setStatusIfImpl: store.cas,
     sendWorkingStatusImpl: () => working.promise,
     removeWorkingStatusImpl: async (messageId) => {
       removed.push(messageId);
     },
   });
 
-  status = { status: "idle", sessionId: "session-2", turnId: "turn-2" };
+  await new Promise((resolve) => setImmediate(resolve));
+  store.set("1:", {
+    status: "idle",
+    ingressId: null,
+    sessionId: null,
+    turnId: null,
+    resetAt: 2_000,
+  });
   working.resolve(78);
   await publishing;
+  const adopted = await publishTelegramTurnStarted({
+    chatKey: "1:",
+    continuationToken: "1::",
+    sessionId: "session-old",
+    turnId: "turn-old",
+    getStatusImpl: store.get,
+    setStatusIfImpl: store.cas,
+  });
 
+  assert.equal(adopted, false);
   assert.deepEqual(removed, [78]);
-  assert.equal(status.statusMessageId, undefined);
+  assert.equal(store.get().status, "idle");
+  assert.equal(store.get().sessionId, undefined);
+});
+
+test("latency logging emits one allowlisted JSON record with no sensitive fields", () => {
+  const store = statusStore({
+    status: "running",
+    sessionId: "session-secret",
+    ingressAt: 1_000,
+    statusAt: 1_010,
+    turnAt: 1_100,
+    prompt: "private prompt",
+    userId: "123456",
+    token: "bot-token",
+  });
+  const lines = [];
+  assert.equal(markTelegramFirstOutput({
+    chatKey: "1:",
+    sessionId: "session-secret",
+    now: () => 1_500,
+    getStatusImpl: store.get,
+    setStatusIfImpl: store.cas,
+  }), true);
+  assert.equal(markTelegramFirstOutput({
+    chatKey: "1:",
+    sessionId: "session-secret",
+    now: () => 1_600,
+    getStatusImpl: store.get,
+    setStatusIfImpl: store.cas,
+  }), false);
+  const options = {
+    chatKey: "1:",
+    sessionId: "session-secret",
+    deliveryAt: 1_700,
+    delivered: true,
+    getStatusImpl: store.get,
+    setStatusIfImpl: store.cas,
+    logImpl: (line) => lines.push(line),
+  };
+
+  assert.equal(emitTelegramTurnLatency({ ...options, delivered: false }), false);
+  assert.equal(store.get().latencyLogged, undefined);
+  assert.equal(emitTelegramTurnLatency(options), true);
+  assert.equal(emitTelegramTurnLatency(options), false);
+  assert.equal(lines.length, 1);
+  assert.deepEqual(JSON.parse(lines[0]), {
+    event: "telegram_turn_latency",
+    ingressToStatusMs: 10,
+    ingressToTurnMs: 100,
+    ingressToFirstOutputMs: 500,
+    ingressToDeliveryMs: 700,
+  });
+  assert.doesNotMatch(lines[0], /private prompt|123456|bot-token|session-secret|1:/);
 });

--- a/scripts/telegram-poll.mjs
+++ b/scripts/telegram-poll.mjs
@@ -451,6 +451,12 @@ export async function completeScopedResetState(
     sessionId: null,
     turnId: null,
     statusMessageId: null,
+    ingressId: null,
+    ingressAt: null,
+    statusAt: null,
+    turnAt: null,
+    firstOutputAt: null,
+    latencyLogged: null,
     wasCancelled: null,
     resetAt: Date.now(),
   });

--- a/scripts/telegram-reply-context.test.mjs
+++ b/scripts/telegram-reply-context.test.mjs
@@ -1,6 +1,12 @@
 import "./lib/ts-esm-hooks.mjs";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test, { after } from "node:test";
@@ -70,6 +76,32 @@ function replyItem(sendCall) {
     .map((item) => JSON.parse(item))
     .find((item) => item.type === "telegram_reply");
 }
+
+function dailyText() {
+  const dir = join(vault, "daily");
+  if (!existsSync(dir)) return "";
+  return readdirSync(dir)
+    .sort()
+    .map((file) => readFileSync(join(dir, file), "utf8"))
+    .join("\n");
+}
+
+test("location, contact and poll updates append daily data before the no-turn dispatch gate", async () => {
+  const cases = [
+    [message({ text: undefined, location: { latitude: 41.3, longitude: 69.2 } }), /\[location\]\n41\.3, 69\.2/],
+    [message({
+      text: undefined,
+      contact: { first_name: "Ada", last_name: "Lovelace", phone_number: "+99800" },
+    }), /\[contact\]\nAda Lovelace \+99800/],
+    [message({ text: undefined, poll: { question: "Ship it?" } }), /\[poll\]\nShip it\?/],
+  ];
+
+  for (const [raw, pattern] of cases) {
+    const before = dailyText();
+    assert.equal((await dispatch(raw)).length, 0);
+    assert.match(dailyText().slice(before.length), pattern);
+  }
+});
 
 test("private reply reaches Eve as a separate context item", async () => {
   const sends = await dispatch(message({


### PR DESCRIPTION
## What changed

- Publish one Telegram working status immediately after allowlist and dispatch gating, before media, security, or provider latency.
- Adopt the provisional status in `turn.started` with a per-chat CAS, and keep reset races from restoring an old session.
- Record first streamed output and final delivery, then emit one identifier-free JSON latency record.

## Why

Trusted updates could spend 20 to 30 seconds in pre-turn processing with no visible feedback. Status creation also needed clear ownership across turn startup and scoped reset races.

## Validation

- 49 focused Telegram status, reset, acceptance, and reply-context tests
- `npm run typecheck`
- `npm run build`
- `git diff --check`

Closes #57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Telegram now shows a working status earlier while messages are being processed.
  * Improved handling for media, stickers, animations, and early-exit scenarios.
  * Added more accurate delivery and response latency tracking.
  * First generated output is now recorded for improved timing visibility.

* **Bug Fixes**
  * Prevented stale or cancelled activity from reviving older Telegram turns.
  * Ensured working statuses are cleaned up when processing fails or produces no response.
  * Reset additional timing information when a conversation returns to idle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->