### PR TITLE
fix(config): apply settings transactionally

### DIFF
--- a/bin/iva.mjs
+++ b/bin/iva.mjs
@@ -5,7 +5,7 @@
 // SINGLE source of truth for systemd units and activation: install.sh delegates here
 // (`iva _install-units` + `_activate-units`), and CLI/doctor reuse the same paths.
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync, writeFileSync, mkdirSync, rmSync, readdirSync, chmodSync, statSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync, mkdirSync, mkdtempSync, rmSync, readdirSync, chmodSync, statSync } from "node:fs";
 import { randomBytes } from "node:crypto";
 import { join, dirname, relative } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -16,9 +16,14 @@ import { createTerminalProgress } from "../scripts/lib/progress.mjs";
 import { quarantinePath, resetStateTargets } from "../scripts/lib/wf-store.mjs";
 import { createTelegramUpdateReporter, loadTelegramJob, removeTelegramJob } from "../scripts/lib/telegram-status.mjs";
 import { generateAssistantBearer, isAssistantBearer } from "../scripts/lib/assistant-auth.mjs";
-import { writeEnvAtomicSync } from "../scripts/lib/env-file.mjs";
+import { parseEnvText, writeEnvAtomicSync } from "../scripts/lib/env-file.mjs";
 import { classifyAgentListeners } from "../scripts/lib/listener-security.mjs";
 import { cleanupSystemdUnits, createSystemdControl } from "../scripts/lib/systemd-control.mjs";
+import {
+  applyConfigTransaction,
+  probeEveHealth,
+  recoverConfigTransaction,
+} from "../scripts/lib/config-transaction.mjs";
 import { userbotSyncArgs } from "../scripts/lib/userbot-deps.mjs";
 import {
   acquireUpdateLock,
@@ -203,9 +208,9 @@ function hardenPerms() {
 }
 
 // Writes iva.service + all deploy/iva-*.{service,timer} with placeholder substitution. daemon-reload.
-function writeUnits() {
+function writeUnits({ ensureBearer = true } = {}) {
   hardenPerms();
-  ensureAssistantBearer({ quiet: true });
+  if (ensureBearer) ensureAssistantBearer({ quiet: true });
   mkdirSync(UNIT_DIR, { recursive: true });
   writeFileSync(join(UNIT_DIR, "iva.service"), ivaServiceBody());
   const written = ["iva.service"];
@@ -567,12 +572,75 @@ async function cmdUpdate(args) {
   }
 }
 
-async function cmdConfig() {
-  const r = run(NODE, ["scripts/setup.mjs"]);
-  if (r.status !== 0) process.exit(r.status ?? 1);
-  if (hasSystemd() && (await confirm("Restart services to apply the settings?", true))) {
-    restartServices(); // setup may have changed IVA_PORT → regenerate the unit, otherwise the server stays on the old port
-    ok("Services restarted");
+async function cmdConfig(args = []) {
+  requireSystemd();
+  const restartConfiguredServices = () => {
+    // Units embed IVA_PORT, so both apply and rollback must regenerate them from
+    // whichever .env is currently live before the checked restart. The candidate
+    // already carries a valid bearer; skipping its migration here also keeps a
+    // rollback snapshot byte-exact for older installations.
+    writeUnits({ ensureBearer: false });
+    systemd.restart(SERVICES);
+  };
+
+  const recovered = await recoverConfigTransaction(
+    { envPath: ENV_PATH, services: SERVICES },
+    { restart: restartConfiguredServices },
+  );
+  if (recovered) ok("Recovered the previous configuration and restarted services");
+  if (args.includes("--recover")) {
+    if (!recovered) ok("No pending configuration recovery");
+    return;
+  }
+
+  const candidateDir = mkdtempSync(join(tmpdir(), "iva-config-"));
+  const candidatePath = join(candidateDir, ".env");
+  try {
+    const r = run(NODE, ["scripts/setup.mjs"], {
+      env: { ...childEnv, IVA_CONFIG_OUTPUT: candidatePath },
+    });
+    if (r.status !== 0) {
+      process.exitCode = r.status ?? 1;
+      return;
+    }
+    if (!(await confirm("Apply settings and restart services now?", true))) {
+      warn("Configuration unchanged");
+      return;
+    }
+
+    const nextText = readFileSync(candidatePath, "utf8");
+    const nextEnv = parseEnvText(nextText);
+    const provider = nextEnv.MODEL_PROVIDER;
+    const selected = {
+      ollama: ["OLLAMA_MODEL", "OLLAMA_API_KEY"],
+      opencode: ["OPENCODE_MODEL", "OPENCODE_API_KEY"],
+      openrouter: ["OPENROUTER_MODEL", "OPENROUTER_API_KEY"],
+      codex: ["CODEX_MODEL", null],
+    }[provider];
+    if (!selected) throw new Error("candidate configuration has an invalid model provider");
+    const port = Number(nextEnv.IVA_PORT || DEFAULT_PORT);
+    if (!Number.isInteger(port) || port < 1 || port > 65535) {
+      throw new Error("candidate configuration has an invalid IVA_PORT");
+    }
+
+    await applyConfigTransaction({
+      envPath: ENV_PATH,
+      nextText,
+      selection: {
+        provider,
+        model: nextEnv[selected[0]],
+        key: selected[1] ? nextEnv[selected[1]] : undefined,
+        dataDir: dataDirAbs(nextEnv),
+      },
+      services: SERVICES,
+      healthUrl: `http://127.0.0.1:${port}/eve/v1/health`,
+    }, {
+      restart: restartConfiguredServices,
+      health: (url) => probeEveHealth(url),
+    });
+    ok("Configuration applied; agent and Telegram bridge are active");
+  } finally {
+    rmSync(candidateDir, { recursive: true, force: true });
   }
 }
 

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -172,6 +172,23 @@
 - Old callbacks are rejected by both Telegram message ID and wizard step, so an earlier screen cannot mutate a later screen in the same edited message.
 - Every wizard-owned network result checks object identity on both success and error; a cancelled/replaced flow cannot resurrect itself with a late response.
 
+## Transactional configuration apply
+
+- `iva config` writes the interactive result to a private temporary candidate. The live
+  `.env` remains untouched until the user confirms apply and the shared live model
+  validator accepts the final provider/model selection again.
+- Apply persists a versioned 0600 rollback snapshot, atomically replaces `.env`,
+  regenerates the port-bearing units, restarts both the agent and Telegram poller through
+  the checked systemd adapter, and waits for local `GET /eve/v1/health`.
+- Any write, restart, health, or commit failure restores the exact previous bytes and
+  restarts the old setup. A failed rollback keeps the durable snapshot and reports
+  `iva config --recover`; the next `iva config` also reconciles it before showing setup.
+- Snapshot and provider errors are redacted using secret-bearing env keys. Temporary
+  candidate data is mode-protected and removed when the config command returns.
+- An occupied unchanged port is no longer attributed to Iva heuristically. The setup
+  requires an explicit negative-default confirmation before reusing it, otherwise it
+  offers the nearest free port.
+
 ## Eve 0.27.8 scoped reset
 
 - Scope: upgrade Eve to 0.27.8, preserve deterministic prompt-error terminal classification,

--- a/scripts/lib/config-transaction.mjs
+++ b/scripts/lib/config-transaction.mjs
@@ -1,0 +1,224 @@
+import { createHash } from "node:crypto";
+import {
+  closeSync,
+  existsSync,
+  fsyncSync,
+  openSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import { dirname } from "node:path";
+import { parseEnvText, writeEnvAtomicSync } from "./env-file.mjs";
+import { validateModelSelection } from "./model-validation.mjs";
+
+const JOURNAL_VERSION = 1;
+const SECRET_KEY_RE = /(KEY|TOKEN|SECRET|BEARER|PASSWORD|HASH)$/;
+
+export const pendingConfigPath = (envPath) => `${envPath}.iva-config-transaction`;
+
+function digest(text) {
+  return createHash("sha256").update(text).digest("hex");
+}
+function secretValues(...texts) {
+  const values = new Set();
+  for (const text of texts) {
+    for (const [key, value] of Object.entries(parseEnvText(text ?? ""))) {
+      if (SECRET_KEY_RE.test(key) && value.length >= 4) values.add(value);
+    }
+  }
+  return [...values].sort((a, b) => b.length - a.length);
+}
+
+function redact(message, secrets) {
+  let safe = String(message || "unknown failure");
+  for (const secret of secrets) safe = safe.split(secret).join("[redacted]");
+  return safe.replace(/\s+/g, " ").slice(0, 500);
+}
+
+function durableRemove(path) {
+  rmSync(path, { force: true });
+  const fd = openSync(dirname(path), "r");
+  try {
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function snapshotOf(envPath) {
+  const existed = existsSync(envPath);
+  const oldText = existed ? readFileSync(envPath, "utf8") : "";
+  return {
+    version: JOURNAL_VERSION,
+    existed,
+    oldText,
+    sha256: digest(oldText),
+  };
+}
+
+function parseSnapshot(raw) {
+  let value;
+  try {
+    value = JSON.parse(raw);
+  } catch (cause) {
+    throw new Error("pending configuration snapshot is invalid JSON", { cause });
+  }
+  if (
+    value?.version !== JOURNAL_VERSION ||
+    typeof value.existed !== "boolean" ||
+    typeof value.oldText !== "string" ||
+    typeof value.sha256 !== "string" ||
+    value.sha256 !== digest(value.oldText)
+  ) {
+    throw new Error("pending configuration snapshot is corrupt");
+  }
+  return value;
+}
+
+function restoreSnapshot(envPath, snapshot, writeEnv) {
+  if (!snapshot.existed) {
+    if (existsSync(envPath)) durableRemove(envPath);
+    return;
+  }
+  const current = existsSync(envPath) ? readFileSync(envPath, "utf8") : null;
+  if (current !== snapshot.oldText) writeEnv(envPath, snapshot.oldText);
+}
+
+async function checkedRestart(restart, services) {
+  const result = await restart(services);
+  if (result === false) throw new Error("systemd restart returned failure");
+}
+
+export class ConfigTransactionError extends Error {
+  constructor(message, { phase, rollbackFailed = false, cause } = {}) {
+    super(message, { cause });
+    this.name = "ConfigTransactionError";
+    this.phase = phase;
+    this.rollbackFailed = rollbackFailed;
+  }
+}
+
+export async function probeEveHealth(
+  url,
+  { fetchFn = fetch, timeoutMs = 15_000, intervalMs = 250, now = Date.now, sleep } = {},
+) {
+  const parsed = new URL(url);
+  if (
+    !["127.0.0.1", "localhost", "::1"].includes(parsed.hostname) ||
+    parsed.pathname !== "/eve/v1/health"
+  ) {
+    throw new Error("health check must use the local /eve/v1/health route");
+  }
+  const wait = sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+  const deadline = now() + timeoutMs;
+  let lastStatus = null;
+  do {
+    try {
+      const remaining = Math.max(1, deadline - now());
+      const response = await fetchFn(parsed, {
+        method: "GET",
+        signal: AbortSignal.timeout(Math.min(2_000, remaining)),
+      });
+      lastStatus = response.status;
+      if (response.ok) return;
+    } catch {}
+    if (now() < deadline) await wait(Math.min(intervalMs, Math.max(1, deadline - now())));
+  } while (now() < deadline);
+  throw Object.assign(
+    new Error(lastStatus === null ? "local Eve health check timed out" : `local Eve health returned ${lastStatus}`),
+    { code: "EHEALTH" },
+  );
+}
+
+export async function recoverConfigTransaction(
+  { envPath, services },
+  {
+    restart,
+    writeEnv = writeEnvAtomicSync,
+    removeJournal = durableRemove,
+  } = {},
+) {
+  const journalPath = pendingConfigPath(envPath);
+  if (!existsSync(journalPath)) return false;
+  if (typeof restart !== "function") throw new TypeError("config recovery requires restart(services)");
+  const snapshot = parseSnapshot(readFileSync(journalPath, "utf8"));
+  const secrets = secretValues(snapshot.oldText);
+  try {
+    restoreSnapshot(envPath, snapshot, writeEnv);
+    await checkedRestart(restart, services);
+    removeJournal(journalPath);
+    return true;
+  } catch (cause) {
+    throw new ConfigTransactionError(
+      `Configuration recovery failed: ${redact(cause?.message, secrets)}. Fix systemd, then run \`iva config --recover\`.`,
+      { phase: "recovery", rollbackFailed: true, cause },
+    );
+  }
+}
+
+export async function applyConfigTransaction(
+  {
+    envPath,
+    nextText,
+    selection,
+    healthUrl,
+    services,
+  },
+  {
+    validate = validateModelSelection,
+    restart,
+    health = probeEveHealth,
+    writeEnv = writeEnvAtomicSync,
+    writeJournal = writeEnvAtomicSync,
+    removeJournal = durableRemove,
+  } = {},
+) {
+  if (typeof restart !== "function") throw new TypeError("config transaction requires restart(services)");
+  if (!Array.isArray(services) || services.length === 0) {
+    throw new TypeError("config transaction requires at least one service");
+  }
+  if (typeof nextText !== "string") throw new TypeError("config transaction requires nextText");
+
+  let phase = "validate";
+  await validate(selection);
+
+  const snapshot = snapshotOf(envPath);
+  const secrets = secretValues(snapshot.oldText, nextText);
+  const journalPath = pendingConfigPath(envPath);
+  phase = "snapshot";
+  writeJournal(journalPath, `${JSON.stringify(snapshot)}\n`);
+
+  try {
+    phase = "write";
+    writeEnv(envPath, nextText);
+    phase = "restart";
+    await checkedRestart(restart, services);
+    phase = "health";
+    await health(healthUrl);
+    phase = "commit";
+    removeJournal(journalPath);
+    return { committed: true };
+  } catch (cause) {
+    let rollbackCause = null;
+    try {
+      restoreSnapshot(envPath, snapshot, writeEnv);
+      await checkedRestart(restart, services);
+      removeJournal(journalPath);
+    } catch (error) {
+      rollbackCause = error;
+    }
+
+    const reason = redact(cause?.message, secrets);
+    if (rollbackCause) {
+      const rollbackReason = redact(rollbackCause?.message, secrets);
+      throw new ConfigTransactionError(
+        `Configuration apply failed during ${phase}: ${reason}. Rollback failed: ${rollbackReason}. The old snapshot is still pending; fix systemd, then run \`iva config --recover\`.`,
+        { phase, rollbackFailed: true, cause },
+      );
+    }
+    throw new ConfigTransactionError(
+      `Configuration apply failed during ${phase}: ${reason}. Previous configuration restored.`,
+      { phase, rollbackFailed: false, cause },
+    );
+  }
+}

--- a/scripts/lib/config-transaction.test.mjs
+++ b/scripts/lib/config-transaction.test.mjs
@@ -1,0 +1,207 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  ConfigTransactionError,
+  applyConfigTransaction,
+  pendingConfigPath,
+  recoverConfigTransaction,
+} from "./config-transaction.mjs";
+
+const OLD = "MODEL_PROVIDER=ollama\nOLLAMA_MODEL=old\nOLLAMA_API_KEY=old-secret\nIVA_PORT=8723\n";
+const NEXT = "MODEL_PROVIDER=ollama\nOLLAMA_MODEL=new\nOLLAMA_API_KEY=new-secret\nIVA_PORT=8724\n";
+const SELECTION = {
+  provider: "ollama",
+  model: "new",
+  key: "new-secret",
+  dataDir: "/tmp/unused",
+};
+const SERVICES = ["iva.service", "iva-telegram-poll.service"];
+
+async function fixture(t) {
+  const dir = await mkdtemp(join(tmpdir(), "iva-config-transaction-"));
+  t.after(() => rm(dir, { recursive: true, force: true }));
+  const envPath = join(dir, ".env");
+  await writeFile(envPath, OLD, { mode: 0o600 });
+  return { dir, envPath };
+}
+
+function healthyDeps(overrides = {}) {
+  const calls = [];
+  return {
+    calls,
+    deps: {
+      validate: async (selection) => calls.push(["validate", selection.model]),
+      restart: async (services) => calls.push(["restart", ...services]),
+      health: async (url) => calls.push(["health", url]),
+      ...overrides,
+    },
+  };
+}
+
+test("env write failure leaves old bytes and never reports success", async (t) => {
+  const { envPath } = await fixture(t);
+  const { calls, deps } = healthyDeps({
+    writeEnv() {
+      throw new Error("disk full");
+    },
+  });
+
+  await assert.rejects(
+    applyConfigTransaction({
+      envPath,
+      nextText: NEXT,
+      selection: SELECTION,
+      healthUrl: "http://127.0.0.1:8724/eve/v1/health",
+      services: SERVICES,
+    }, deps),
+    (error) => error instanceof ConfigTransactionError && error.phase === "write",
+  );
+
+  assert.equal(await readFile(envPath, "utf8"), OLD);
+  assert.deepEqual(calls.map((call) => call[0]), ["validate", "restart"]);
+});
+test("restart failure restores snapshot and restarts old services", async (t) => {
+  const { envPath } = await fixture(t);
+  let restarts = 0;
+  const { deps } = healthyDeps({
+    restart: async () => {
+      restarts++;
+      if (restarts === 1) throw new Error("restart failed");
+    },
+  });
+
+  await assert.rejects(
+    applyConfigTransaction({
+      envPath,
+      nextText: NEXT,
+      selection: SELECTION,
+      healthUrl: "http://127.0.0.1:8724/eve/v1/health",
+      services: SERVICES,
+    }, deps),
+    (error) =>
+      error instanceof ConfigTransactionError &&
+      error.phase === "restart" &&
+      error.rollbackFailed === false,
+  );
+  assert.equal(restarts, 2);
+  assert.equal(await readFile(envPath, "utf8"), OLD);
+  await assert.rejects(readFile(pendingConfigPath(envPath), "utf8"), { code: "ENOENT" });
+});
+
+test("health timeout rolls back the env and restarts old services", async (t) => {
+  const { envPath } = await fixture(t);
+  let restarts = 0;
+  const { deps } = healthyDeps({
+    restart: async () => { restarts++; },
+    health: async () => {
+      throw Object.assign(new Error("health timeout"), { code: "ETIMEDOUT" });
+    },
+  });
+
+  await assert.rejects(
+    applyConfigTransaction({
+      envPath,
+      nextText: NEXT,
+      selection: SELECTION,
+      healthUrl: "http://127.0.0.1:8724/eve/v1/health",
+      services: SERVICES,
+    }, deps),
+    (error) => error instanceof ConfigTransactionError && error.phase === "health",
+  );
+  assert.equal(restarts, 2);
+  assert.equal(await readFile(envPath, "utf8"), OLD);
+});
+
+test("successful apply validates, restarts both units, probes local health and commits", async (t) => {
+  const { envPath } = await fixture(t);
+  const { calls, deps } = healthyDeps();
+  const result = await applyConfigTransaction({
+    envPath,
+    nextText: NEXT,
+    selection: SELECTION,
+    healthUrl: "http://127.0.0.1:8724/eve/v1/health",
+    services: SERVICES,
+  }, deps);
+
+  assert.deepEqual(result, { committed: true });
+  assert.equal(await readFile(envPath, "utf8"), NEXT);
+  assert.deepEqual(calls, [
+    ["validate", "new"],
+    ["restart", ...SERVICES],
+    ["health", "http://127.0.0.1:8724/eve/v1/health"],
+  ]);
+  assert.deepEqual((await readdir(join(envPath, ".."))).filter((name) => name.includes("transaction")), []);
+});
+
+test("failed rollback keeps the snapshot and gives a secret-free recovery instruction", async (t) => {
+  const { envPath } = await fixture(t);
+  let restarts = 0;
+  const { deps } = healthyDeps({
+    restart: async () => {
+      restarts++;
+      throw new Error(restarts === 1 ? "new-secret restart failure" : "old-secret rollback failure");
+    },
+  });
+
+  const error = await applyConfigTransaction({
+    envPath,
+    nextText: NEXT,
+    selection: SELECTION,
+    healthUrl: "http://127.0.0.1:8724/eve/v1/health",
+    services: SERVICES,
+  }, deps).catch((caught) => caught);
+
+  assert.equal(error.rollbackFailed, true);
+  assert.match(error.message, /iva config --recover/);
+  assert.doesNotMatch(error.message, /new-secret|old-secret/);
+  assert.equal(await readFile(envPath, "utf8"), OLD);
+  assert.equal(JSON.parse(await readFile(pendingConfigPath(envPath), "utf8")).version, 1);
+});
+
+test("a crash after env replacement is recovered from the durable snapshot", async (t) => {
+  const { envPath } = await fixture(t);
+  const child = spawnSync(
+    process.execPath,
+    [
+      "--input-type=module",
+      "--eval",
+      `
+        import { applyConfigTransaction } from ${JSON.stringify(new URL("./config-transaction.mjs", import.meta.url).href)};
+        await applyConfigTransaction(
+          ${JSON.stringify({
+            envPath,
+            nextText: NEXT,
+            selection: SELECTION,
+            healthUrl: "http://127.0.0.1:8724/eve/v1/health",
+            services: SERVICES,
+          })},
+          {
+            validate: async () => {},
+            restart: async () => process.exit(73),
+            health: async () => {},
+          },
+        );
+      `,
+    ],
+    { encoding: "utf8" },
+  );
+  assert.equal(child.status, 73, child.stderr);
+  assert.equal(await readFile(envPath, "utf8"), NEXT);
+  assert.equal(JSON.parse(await readFile(pendingConfigPath(envPath), "utf8")).version, 1);
+
+  const restarts = [];
+  assert.equal(
+    await recoverConfigTransaction(
+      { envPath, services: SERVICES },
+      { restart: async (services) => restarts.push(services) },
+    ),
+    true,
+  );
+  assert.equal(await readFile(envPath, "utf8"), OLD);
+  assert.deepEqual(restarts, [SERVICES]);
+  await assert.rejects(readFile(pendingConfigPath(envPath), "utf8"), { code: "ENOENT" });
+});

--- a/scripts/lib/ports.mjs
+++ b/scripts/lib/ports.mjs
@@ -100,6 +100,20 @@ export class PortSelector {
   }
 }
 
+// An unchanged port can be occupied by Iva or by an unrelated process that took
+// the socket while Iva was down. Holder heuristics cannot prove ownership, so
+// reuse is allowed only after an explicit user confirmation.
+export async function confirmOccupiedCurrentPort({
+  port,
+  currentPort,
+  holders = [],
+  confirm,
+}) {
+  if (Number(port) !== Number(currentPort)) return false;
+  if (typeof confirm !== "function") throw new TypeError("occupied port reuse requires confirm(details)");
+  return Boolean(await confirm({ port: Number(port), holders }));
+}
+
 // Готовый чекер со всеми доступными способами детекта.
 export function defaultChecker() {
   return new PortChecker([bindProbe, procProbe, dockerProbe]);

--- a/scripts/lib/ports.test.mjs
+++ b/scripts/lib/ports.test.mjs
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { confirmOccupiedCurrentPort } from "./ports.mjs";
+
+test("an occupied current port is never assumed to belong to Iva", async () => {
+  const prompts = [];
+  assert.equal(
+    await confirmOccupiedCurrentPort({
+      port: 8723,
+      currentPort: 8723,
+      confirm: async (details) => {
+        prompts.push(details);
+        return false;
+      },
+      holders: ["bind: port occupied", "docker:foreign"],
+    }),
+    false,
+  );
+  assert.deepEqual(prompts, [{
+    port: 8723,
+    holders: ["bind: port occupied", "docker:foreign"],
+  }]);
+});
+test("the current occupied port is reused only after explicit confirmation", async () => {
+  assert.equal(
+    await confirmOccupiedCurrentPort({
+      port: 8723,
+      currentPort: 8723,
+      confirm: async () => true,
+    }),
+    true,
+  );
+  assert.equal(
+    await confirmOccupiedCurrentPort({
+      port: 9000,
+      currentPort: 8723,
+      confirm: async () => {
+        throw new Error("must not ask for a different port");
+      },
+    }),
+    false,
+  );
+});

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -8,8 +8,12 @@ import { createReadStream, existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { randomBytes } from "node:crypto";
 import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
-import { defaultChecker, PortSelector } from "./lib/ports.mjs";
+import { dirname, join, resolve } from "node:path";
+import {
+  confirmOccupiedCurrentPort,
+  defaultChecker,
+  PortSelector,
+} from "./lib/ports.mjs";
 import { generateAssistantBearer, isAssistantBearer } from "./lib/assistant-auth.mjs";
 import { writeEnvAtomicSync } from "./lib/env-file.mjs";
 import { authFilePath, readAuth, runDeviceCodeLogin, runBrowserLogin, listCodexModels } from "./lib/codex-oauth.mjs";
@@ -20,7 +24,13 @@ import {
 import { keptSetupWritePlan } from "./lib/setup-keep.mjs";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
-const ENV_PATH = join(ROOT, ".env");
+const SOURCE_ENV_PATH = join(ROOT, ".env");
+// `iva config` stages a complete candidate outside the live .env, then applies it
+// transactionally. Direct setup/install keeps the historical live path.
+const ENV_PATH = process.env.IVA_CONFIG_OUTPUT
+  ? resolve(process.env.IVA_CONFIG_OUTPUT)
+  : SOURCE_ENV_PATH;
+const STAGING_CONFIG = ENV_PATH !== SOURCE_ENV_PATH;
 // Абсолютный каталог data (тот же, что видит агент из cwd=ROOT). Хранит codex-auth.json (OAuth).
 const dataDirAbs = (env) => {
   const d = (env && env.ASSISTANT_DATA_DIR) || "data";
@@ -79,14 +89,26 @@ async function pickPort(def) {
     }
     const { occupied, holders } = await checker.check(port);
     if (!occupied) return String(port);
-    // Reconfiguring a live Iva: the current (unchanged) port reads as "busy" —
-    // it's held by Iva's OWN server. Don't offer to move: that would steer IVA_PORT away from
-    // clients (bridge/cron on ASSISTANT_HOST) → the bot would go mute. Keep the port as is.
-    // ponytail: assume the holder of an unchanged port is our own server (the typical case).
-    if (port === Number(def)) {
-      console.log(`  ${C.y}${t(`Port ${port} is busy — looks like Iva itself (the running server). Keeping it.`, `Порт ${port} занят — похоже, это сам Iva (текущий сервер). Оставляю.`)}${C.x}`);
-      return String(port);
-    }
+    const reuse = await confirmOccupiedCurrentPort({
+      port,
+      currentPort: def,
+      holders,
+      confirm: async ({ port: current, holders: found }) => {
+        const who = found.length ? ` (${found.join("; ")})` : "";
+        console.log(`  ${C.y}${t(
+          `Port ${current} is already occupied${who}. Ownership cannot be verified.`,
+          `Порт ${current} уже занят${who}. Проверить владельца надёжно нельзя.`,
+        )}${C.x}`);
+        return askYesNo(
+          `  ${t(
+            `Keep occupied port ${current}? Only confirm if it is the running Iva`,
+            `Оставить занятый порт ${current}? Подтверди, только если это запущенная Iva`,
+          )}`,
+          false,
+        );
+      },
+    });
+    if (reuse) return String(port);
     const free = await new PortSelector(checker).firstFree(port + 1);
     const who = holders.length ? ` (${holders.join("; ")})` : "";
     console.log(`  ${C.y}${t(`Port ${port} is busy${who}.`, `Порт ${port} занят${who}.`)}${C.x}${free ? ` ${t("Nearest free", "Ближайший свободный")}: ${C.g}${free}${C.x}.` : ""}`);
@@ -132,7 +154,7 @@ function parseEnv(text) {
 }
 async function loadExistingEnv() {
   try {
-    return parseEnv(await readFile(ENV_PATH, "utf8"));
+    return parseEnv(await readFile(SOURCE_ENV_PATH, "utf8"));
   } catch (error) {
     if (error?.code === "ENOENT") return {};
     throw error;
@@ -676,7 +698,9 @@ async function main() {
     { opencode: out.OPENCODE_MODEL, openrouter: out.OPENROUTER_MODEL, codex: out.CODEX_MODEL }[provider] || out.OLLAMA_MODEL;
   console.log();
   hr();
-  console.log(`${C.g}${C.b}  ✓ ${t("Done — everything written to .env", "Готово — всё записано в .env")}${C.x}`);
+  console.log(`${C.g}${C.b}  ✓ ${STAGING_CONFIG
+    ? t("Ready — settings validated for apply", "Готово к применению — настройки проверены")
+    : t("Done — everything written to .env", "Готово — всё записано в .env")}${C.x}`);
   console.log(`  ${t("Provider", "Провайдер")}: ${provider} · ${t("Model", "Модель")}: ${C.g}${chosenModel}${C.x} · Deepgram: ${out.DEEPGRAM_LANGUAGE} · ${t("Bot", "Бот")}: ${C.g}@${out.TELEGRAM_BOT_USERNAME}${C.x}`);
   console.log(`  ${t("Access", "Доступ")}: ${out.TELEGRAM_ALLOWED_USER_IDS} · TZ: ${out.ASSISTANT_TIMEZONE} · vault: ${out.ASSISTANT_VAULT_DIR} · ${t("lang", "язык")}: ${out.AGENT_LANGUAGE}`);
   hr();


### PR DESCRIPTION
Closes #56

## What changed

- stages `iva config` output in a private temporary candidate, leaving the live `.env` untouched until apply
- validates the final provider/model selection with the shared live validator
- persists a versioned 0600 rollback snapshot, atomically writes `.env`, regenerates units, restarts both `iva.service` and `iva-telegram-poll.service` through the checked systemd adapter, then probes local `GET /eve/v1/health`
- restores the exact previous `.env` and restarts the old setup after write, restart, health, or commit failure
- keeps a durable recovery snapshot and reports `iva config --recover` if rollback itself fails; the next `iva config` reconciles a pending snapshot first
- requires explicit negative-default confirmation before reusing an occupied current port

## Root cause and user impact

Setup previously wrote the live `.env` before restart. A failed restart or unhealthy Eve process could leave the assistant on a broken configuration, while an unchanged occupied port was silently assumed to belong to Iva. Apply is now one observable transaction: success means both systemd units are active and Eve answers its local health route; failure restores the working configuration.

## TDD evidence

RED coverage was added for:

- env write failure
- restart failure with successful rollback
- health timeout with successful rollback
- failed rollback with a secret-free recovery instruction
- process crash after `.env` replacement and recovery from the durable snapshot
- successful two-service apply and local health commit
- foreign process on the current port

GREEN after rebase onto `4876cb3`:

- `node --test scripts/lib/config-transaction.test.mjs scripts/lib/ports.test.mjs scripts/lib/env-file.test.mjs scripts/lib/systemd-control.test.mjs scripts/lib/model-validation.test.mjs` - 29/29
- `npm run typecheck` - passed
- `npx eve build` - passed
- `git diff --check origin/main...HEAD` - passed
- `python3 scripts/autograph/tests/test_autograph.py` - 256/256 passed on the stacked head before the dependency-only main rebase
- `python3 services/telegram-userbot/test_guardrails.py` - passed on the stacked head before the dependency-only main rebase

The full Node command reached 342/344. Both failures are in the already-merged `scripts/bash-tool.test.mjs`; the blocked-event-loop failure reproduces on the exact pre-change base `f7e6bda` (24/25), so this PR does not expand into #64. GitHub CI remains the merge gate.

## UX before / after

Before: setup announced that `.env` was written, then offered a restart that could fail after the old working settings were already lost.

After: setup says the candidate is validated, asks once to apply and restart, and prints success only after both services and the Eve health endpoint are ready. Declining apply leaves the live configuration unchanged.