### PR TITLE
fix: report real userbot health

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,7 @@ jobs:
             --strict \
             services/telegram-userbot/requirements.lock
           .venv-userbot/bin/python services/telegram-userbot/test_guardrails.py
+          .venv-userbot/bin/python services/telegram-userbot/test_health.py
           .venv-userbot/bin/python -m py_compile \
             services/telegram-userbot/guardrails.py \
             services/telegram-userbot/onboarding.py \

--- a/bin/iva.mjs
+++ b/bin/iva.mjs
@@ -25,6 +25,7 @@ import {
   recoverConfigTransaction,
 } from "../scripts/lib/config-transaction.mjs";
 import { userbotSyncArgs } from "../scripts/lib/userbot-deps.mjs";
+import { probeUserbotHealth } from "../scripts/lib/userbot-health.mjs";
 import {
   acquireUpdateLock,
   commitThenRunPostCommit,
@@ -985,7 +986,7 @@ ${C.b}Commands:${C.x}
   ${C.c}iva reset${C.x}          full reset: clear stuck workflows and restart
   ${C.c}iva start${C.x} / ${C.c}stop${C.x}    start / stop
   ${C.c}iva usage${C.x} [win]      token usage (last|today|week|month|by-model|by-source|tail)
-  ${C.c}iva userbot${C.x} [creds|setup|status|off]  personal-account userbot proxy (Telegram, opt-in)
+  ${C.c}iva userbot${C.x} [creds|setup|status|diagnose --json|off]  personal-account userbot proxy
   ${C.c}iva logs${C.x} [poll]     agent logs (or the Telegram bridge) -f
   ${C.c}iva uninstall${C.x}       remove units and the command (--purge — delete code+vault)
   ${C.c}iva version${C.x}         version and git commit
@@ -1087,7 +1088,7 @@ function restartUserbotIfActive({
   if (!quiet) ok("userbot-прокси перезапущен на новом коде");
 }
 
-function cmdUserbot(args) {
+async function cmdUserbot(args) {
   const sub = args[0] || "status";
   if (sub === "creds") {
     // Read api_id + api_hash from STDIN (two lines) — keeps secrets out of argv/ps.
@@ -1137,9 +1138,29 @@ function cmdUserbot(args) {
     ok("Userbot-прокси остановлен и выключен.");
     return;
   }
-  const active = scQ("is-active", SVC_USERBOT).out || "не установлен";
-  const enabled = scQ("is-enabled", SVC_USERBOT).out || "-";
-  console.log(`${SVC_USERBOT}: ${active} (${enabled})`);
+  if (sub === "diagnose") {
+    if (args[1] !== "--json") {
+      bad("Использование: iva userbot diagnose --json");
+      process.exit(1);
+    }
+    const env = readEnv();
+    const health = await probeUserbotHealth({
+      root: ROOT,
+      port: env.TELEGRAM_MCP_PORT || "8724",
+    });
+    console.log(JSON.stringify(health));
+    return;
+  }
+  if (sub !== "status") {
+    bad(`Неизвестная команда userbot: ${sub}`);
+    process.exit(1);
+  }
+  const env = readEnv();
+  const health = await probeUserbotHealth({
+    root: ROOT,
+    port: env.TELEGRAM_MCP_PORT || "8724",
+  });
+  console.log(`${SVC_USERBOT}: ${health.state}`);
   console.log(`venv: ${existsSync(VENV_PY) ? "собран" : "нет — будет собран при setup"}`);
   console.log(`токен: ${existsSync(TOKEN_FILE) ? "есть" : "нет — создастся при setup"}`);
 }

--- a/docs/menu.md
+++ b/docs/menu.md
@@ -71,13 +71,18 @@ The **🔍 Search** screen lists the four providers — Tavily, Brave, Exa, Para
 
 ## Userbot
 
-A status card built from `systemctl --user` plus the presence of your Telegram API credentials, then the next step in context:
+A status card built from the shared CLI/Telegram health probe plus the presence of your Telegram API credentials, then the next step in context:
 
 - **No credentials** → instructions for my.telegram.org and a button to enter `api_id` / `api_hash`.
 - **Credentials, not running** → **Enable**, which launches `iva userbot setup` detached (the venv build is slow, so the screen shows a spinner and refreshes when it's done).
-- **Running** → a hint to connect by QR — just tell the bot "connect my telegram" — plus **Disable** and **Refresh**.
+- **Starting** → a bounded waiting state with **Disable** and **Refresh**.
+- **Unreachable** → the service is active but the bearer-gated proxy health route did not answer.
+- **Login required** → the existing proxy session is reachable but Telethon is not authorized yet.
+- **Ready** → both the proxy and the personal Telegram account are healthy.
 
-The userbot is opt-in beta; the full picture, including the anti-ban guardrail: [userbot.md](userbot.md).
+Setup failures are shown in the menu instead of collapsing back to an inactive card. The
+userbot remains opt-in beta; the full picture, including the anti-ban guardrail:
+[userbot.md](userbot.md).
 
 ## Google Workspace
 

--- a/docs/userbot.md
+++ b/docs/userbot.md
@@ -37,9 +37,16 @@ for you, in chat:
 ```bash
 iva userbot creds    # read api_id + api_hash from stdin → .env (two lines)
 iva userbot setup    # build venv, generate the token, enable + start the proxy (idempotent)
-iva userbot status   # service running? venv built? token present?
+iva userbot status   # shared service, proxy and Telegram-login health
+iva userbot diagnose --json  # read-only machine-readable health
 iva userbot off      # stop and disable the proxy
 ```
+
+The health state is one of `off`, `starting`, `unreachable`, `unauthorized` or
+`ready`. CLI and Telegram use the same 1.5-second probe. It checks the existing
+proxy's `/healthz` route, which reads authorization from the proxy's one live
+Telethon client and never opens another session. Diagnostics expose only fixed
+state/reason values; bearer tokens and transport errors are not returned.
 
 ## Safety knobs
 

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -17,27 +17,18 @@
   Keeping byte-equivalent existing settings skips that rewrite; any changed keep-path
   value validates the configured model first.
 
-## Early Telegram working status and latency phases (IVA-006 / #57)
+## Real userbot health (IVA-010 / #58)
 
-- A trusted update publishes one provisional `running` status immediately after
-  the allowlist and message/media dispatch decision. Reply sanitization, media
-  download/transcription/vision and provider work all happen after that request.
-- The provisional record has a random ingress ID and no Eve session ID.
-  `turn.started` adopts it with a per-chat compare-and-set, preserving the same
-  Telegram message. A reset that wins the race changes the record first, so the
-  old turn cannot attach its session or revive running state. Its Stop button is
-  added only after that adoption gives cancellation a real session target.
-- Telegram status send and cleanup errors are logged and swallowed. If authored
-  handling intentionally produces no turn, its still-provisional status is
-  compare-and-set back to idle and its message is removed.
-- The status record carries only monotonic lifecycle timestamps. The first
-  `message.appended` event records first output, and final delivery emits one
-  JSON line with ingress-to-status, ingress-to-turn, ingress-to-first-output and
-  ingress-to-delivery milliseconds only after every Telegram chunk succeeds in
-  HTML or plain fallback. The log schema has no identifiers, prompt,
-  user data, tokens or arbitrary error text.
-- Location, contact and poll data is appended to the daily transcript before the
-  no-turn dispatch gate consumes those silent updates.
+- The runtime probe will query a read-only health route on the already-running proxy.
+  It must never import or open another Telethon client or session.
+- The public states are limited to `off`, `starting`, `unreachable`, `unauthorized`,
+  and `ready`. A rejected local bearer maps to `unreachable` with a fixed reason,
+  while `unauthorized` is reserved for the Telegram account login state.
+- The whole probe, including systemd and HTTP checks, shares one 1.5-second deadline.
+  Results contain only fixed state and reason values, so command output cannot echo
+  bearer tokens, subprocess output, URLs, or transport exceptions.
+- Telegram setup remains asynchronous to keep the polling loop responsive. A non-zero
+  child exit now becomes a bounded, redacted error and is rendered back into the menu.
 
 ## Structured Telegram reply context (IVA-009 / #53)
 

--- a/scripts/lib/menu/status.mjs
+++ b/scripts/lib/menu/status.mjs
@@ -1,32 +1,16 @@
 // Экран статуса: одна карта — версия, провайдер·модель·размышления, поиск+ключ, язык,
 // userbot, Google, расход за сегодня. Быстрые поля (env/файлы) читаются синхронно в первом
-// рендере; медленная проба (systemctl is-active userbot) НЕ ждётся синхронно — сначала
+// рендере; общая userbot-проба systemd/HTTP/Telethon НЕ ждётся синхронно — сначала
 // заглушка «…», затем async-edit по завершении. Так единственный getUpdates-цикл моста не
-// блокируется дольше ~1.5с. Проба кэшируется на 60с.
+// блокируется дольше ~1.5с.
 import { readFileSync, existsSync } from "node:fs";
-import { execFile } from "node:child_process";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { readEnvValues } from "../env-file.mjs";
 import { CATALOG } from "../model-catalog.mjs";
 import { SEARCH_CATALOG } from "../search-catalog.mjs";
 import { readEntries, summarize } from "../usage.mjs";
-
-const PROBE_TTL_MS = 60_000;
-let probeCache = { at: 0, ubActive: null };
-
-function run(cmd, args, timeout = 1500) {
-  return new Promise((resolve) => {
-    execFile(cmd, args, { timeout, encoding: "utf8" }, (err, stdout = "") =>
-      resolve({ failed: Boolean(err), code: typeof err?.code === "number" ? err.code : err ? 1 : 0, stdout: String(stdout) }),
-    );
-  });
-}
-
-async function probeUserbot() {
-  const r = await run("systemctl", ["--user", "is-active", "iva-telegram-userbot.service"]);
-  return r.code === 0 || r.stdout.trim() === "active";
-}
+import { probeUserbotHealth } from "../userbot-health.mjs";
 
 function version(root) {
   try {
@@ -68,9 +52,16 @@ function fastFields(env, ctx) {
   };
 }
 
-function buildView(d, ubActive, ctx) {
+function buildView(d, health, ctx) {
   const T = ctx.tr;
-  const ub = ubActive === null ? "…" : ubActive ? T("active", "активен") : T("off", "выкл");
+  const labels = {
+    off: T("off", "выкл"),
+    starting: T("starting", "запускается"),
+    unreachable: T("unreachable", "недоступен"),
+    unauthorized: T("login required", "нужен вход"),
+    ready: T("ready", "готов"),
+  };
+  const ub = health === null ? "…" : labels[health.state] || labels.unreachable;
   const lines = [
     T("📊 Status", "📊 Статус"),
     "",
@@ -92,23 +83,19 @@ export default {
   async render(st, ctx) {
     const env = await readEnvValues(ctx.deps.envPath);
     const d = fastFields(env, ctx);
-    const fresh = probeCache.ubActive !== null && Date.now() - probeCache.at < PROBE_TTL_MS;
-    const ubActive = fresh ? probeCache.ubActive : null;
 
-    if (!fresh) {
-      // Медленную пробу гоним ОТДЕЛЬНО и правим сообщение по готовности — только если экран
-      // всё ещё текущий (пользователь не ушёл в другой раздел / не закрыл меню).
-      probeUserbot()
-        .then((active) => {
-          probeCache = { at: Date.now(), ubActive: active };
-          if (ctx.flows.get(st.chatId, st.userId) === st && st.screen === "st") {
-            const v = buildView(d, active, ctx);
-            return ctx.flows.screen(st, v.text, v.rows);
-          }
-        })
-        .catch(() => {});
-    }
-    return buildView(d, ubActive, ctx);
+    // Медленную пробу гоним ОТДЕЛЬНО и правим сообщение по готовности — только если экран
+    // всё ещё текущий (пользователь не ушёл в другой раздел / не закрыл меню).
+    const probe = ctx.deps.probeUserbotHealth || probeUserbotHealth;
+    probe({ root: ctx.deps.root, port: env.TELEGRAM_MCP_PORT || "8724" })
+      .then((result) => {
+        if (ctx.flows.get(st.chatId, st.userId) === st && st.screen === "st") {
+          const v = buildView(d, result, ctx);
+          return ctx.flows.screen(st, v.text, v.rows);
+        }
+      })
+      .catch(() => {});
+    return buildView(d, null, ctx);
   },
   on() {},
 };

--- a/scripts/lib/menu/userbot.mjs
+++ b/scripts/lib/menu/userbot.mjs
@@ -1,6 +1,6 @@
 // Экран «Userbot» меню (/menu → 📡). Статус личного userbot-прокси (Telegram) + подключение.
-// Статус — systemctl --user is-active/is-enabled iva-telegram-userbot.service (execFile,
-// таймаут 1.5с, кэш 60с: единственный getUpdates-цикл моста нельзя блокировать дольше).
+// Общая CLI/Telegram-проба проверяет systemd, health endpoint и авторизацию Telethon.
+// Общий таймаут 1.5с: getUpdates-цикл нельзя блокировать дольше.
 // Наличие creds — булевы TELEGRAM_API_ID/TELEGRAM_API_HASH из .env (значения не показываем).
 //
 // Секреты (api_id/api_hash) принимаются только в личке; сообщение с ними удаляет движок
@@ -10,12 +10,11 @@
 import { execFile } from "node:child_process";
 import { join } from "node:path";
 import { readEnvValues, upsertEnv } from "../env-file.mjs";
+import { probeUserbotHealth } from "../userbot-health.mjs";
 
 const SID = "ub";
 const PARENT = "r";
 const SVC = "iva-telegram-userbot.service";
-const CACHE_TTL_MS = 60_000;
-let cache = { at: 0, data: null };
 
 const isPrivate = (st) => Number(st.chatId) > 0;
 
@@ -27,41 +26,49 @@ function run(cmd, args, timeout = 1500) {
   });
 }
 
-// Статус юнита: {active, enabled}. is-active даёт код 0/«active»; is-enabled печатает
-// enabled/disabled/static… (код != 0 у disabled — берём stdout как метку). Кэш 60с.
-async function probeStatus() {
-  if (cache.data && Date.now() - cache.at < CACHE_TTL_MS) return cache.data;
-  // Параллельно: две последовательные пробы по 1.5с дали бы worst-case 3с блокировки
-  // единственного getUpdates-цикла — параллель возвращает бюджет к 1.5с.
-  const [a, e] = await Promise.all([
-    run("systemctl", ["--user", "is-active", SVC]),
-    run("systemctl", ["--user", "is-enabled", SVC]),
-  ]);
-  const data = {
-    active: a.code === 0 || a.stdout.trim() === "active",
-    enabled: e.stdout.trim() || (e.code === 0 ? "enabled" : "—"),
-  };
-  cache = { at: Date.now(), data };
-  return data;
+export function runSetupCommand(bin, { exec = execFile, timeoutMs = 180_000 } = {}) {
+  return new Promise((resolve, reject) => {
+    exec(process.execPath, [bin, "userbot", "setup"], { timeout: timeoutMs, encoding: "utf8" }, (error) => {
+      if (error) {
+        const code = typeof error.code === "number" ? error.code : 1;
+        reject(new Error(`userbot setup failed (exit ${code})`));
+        return;
+      }
+      resolve();
+    });
+  });
 }
 
-const invalidate = () => (cache = { at: 0, data: null });
+async function probeStatus(ctx, env) {
+  const probe = ctx.deps.probeUserbotHealth || probeUserbotHealth;
+  return probe({ root: ctx.deps.root, port: env.TELEGRAM_MCP_PORT || "8724" });
+}
 
 // Единая сборка карты — используется и render(), и async-перерисовкой после setup.
 async function buildScreen(st, ctx) {
   const T = ctx.tr;
   const env = await readEnvValues(ctx.deps.envPath);
   const hasCreds = Boolean(env.TELEGRAM_API_ID && env.TELEGRAM_API_HASH);
-  const status = await probeStatus();
+  const status = await probeStatus(ctx, env);
   const head = T("📡 Telegram userbot", "📡 Telegram-userbot");
-  const statusLine = T(
-    `Service: ${status.active ? "active" : "inactive"} (${status.enabled})`,
-    `Сервис: ${status.active ? "активен" : "неактивен"} (${status.enabled})`,
+  const beta = T(
+    "🧪 Beta: personal-account automation can misbehave and carries account-ban risk.",
+    "🧪 Бета: автоматизация личного аккаунта может сбоить и несёт риск блокировки.",
   );
+  const stateLabel = {
+    off: T("off", "выкл"),
+    starting: T("starting", "запускается"),
+    unreachable: T("unreachable", "недоступен"),
+    unauthorized: T("login required", "нужен вход"),
+    ready: T("ready", "готов"),
+  }[status.state] || T("unreachable", "недоступен");
+  const statusLine = `${T("Status", "Статус")}: ${stateLabel}`;
 
   if (!hasCreds) {
     const text = [
       head,
+      "",
+      beta,
       "",
       statusLine,
       "",
@@ -73,9 +80,11 @@ async function buildScreen(st, ctx) {
     return { text, rows: [[ctx.btn(T("Enter credentials", "Ввести ключи"), `iva_menu:${SID}:do:creds`)], ctx.backRow(PARENT)] };
   }
 
-  if (!status.active) {
+  if (status.state === "off") {
     const text = [
       head,
+      "",
+      beta,
       "",
       statusLine,
       "",
@@ -91,16 +100,62 @@ async function buildScreen(st, ctx) {
     };
   }
 
-  // Активен: подключение аккаунта — через QR у бота (флоу на стороне агента, не моста).
+  if (status.state === "starting") {
+    return {
+      text: [
+        head,
+        "",
+        beta,
+        "",
+        statusLine,
+        "",
+        T("The proxy service is still starting. Refresh in a moment.", "Прокси ещё запускается. Обнови через несколько секунд."),
+      ].join("\n"),
+      rows: [
+        [ctx.btn(T("Turn off", "Выключить"), `iva_menu:${SID}:do:off`), ctx.btn(T("🔄 Refresh", "🔄 Обновить"), `iva_menu:${SID}:rf`)],
+        ctx.backRow(PARENT),
+      ],
+    };
+  }
+
+  if (status.state === "unreachable") {
+    return {
+      text: [
+        head,
+        "",
+        beta,
+        "",
+        statusLine,
+        "",
+        T(
+          "The service is active, but its health endpoint did not answer. Run `iva userbot diagnose --json` for the fixed diagnostic.",
+          "Сервис активен, но health endpoint не ответил. Запусти `iva userbot diagnose --json` для точной диагностики.",
+        ),
+      ].join("\n"),
+      rows: [
+        [ctx.btn(T("Turn off", "Выключить"), `iva_menu:${SID}:do:off`), ctx.btn(T("🔄 Refresh", "🔄 Обновить"), `iva_menu:${SID}:rf`)],
+        ctx.backRow(PARENT),
+      ],
+    };
+  }
+
+  const accountHint = status.state === "unauthorized"
+    ? T(
+      "Proxy is on, but the Telegram account is not connected. Message the bot: «connect my telegram» to scan a QR.",
+      "Прокси включён, но аккаунт Telegram не подключён. Напиши боту: «подключи мой телеграм», чтобы отсканировать QR.",
+    )
+    : T(
+      "Proxy and Telegram account are ready.",
+      "Прокси и аккаунт Telegram готовы.",
+    );
   const text = [
     head,
     "",
+    beta,
+    "",
     statusLine,
     "",
-    T(
-      "Proxy is on. To connect your account, message the bot: «connect my telegram» — it replies with a QR to scan.",
-      "Прокси включён. Чтобы подключить аккаунт — напиши боту: «подключи мой телеграм», он пришлёт QR для входа.",
-    ),
+    accountHint,
   ].join("\n");
   return {
     text,
@@ -148,25 +203,42 @@ export default {
       const bin = join(ctx.deps.root, "bin/iva.mjs");
       // Отсоединённо: НЕ ждём (venv-сборка до 3 мин заблокировала бы poll-цикл). Перерисуем
       // экран по завершении — только если пользователь всё ещё на нём.
-      run(process.execPath, [bin, "userbot", "setup"], 180_000)
+      const setup = ctx.deps.runUserbotSetup || (() => runSetupCommand(bin));
+      setup()
         .then(async () => {
-          invalidate();
           if (ctx.flows.get(st.chatId, st.userId) === st && st.screen === SID) {
             const v = await buildScreen(st, ctx);
             await ctx.flows.screen(st, v.text, v.rows);
           }
         })
-        .catch((e) => ctx.deps.log?.("userbot setup error:", e.message));
+        .catch(async () => {
+          ctx.deps.log?.("userbot setup failed");
+          if (ctx.flows.get(st.chatId, st.userId) === st && st.screen === SID) {
+            await ctx.flows.screen(
+              st,
+              ctx.tr(
+                "🧪 Beta\n\nSetup failed. Check the service logs, then try again.",
+                "🧪 Бета\n\nНастройка завершилась с ошибкой. Проверь логи сервиса и повтори.",
+              ),
+              [
+                [ctx.btn(ctx.tr("Try again", "Повторить"), `iva_menu:${SID}:do:setup`)],
+                ctx.backRow(PARENT),
+              ],
+            );
+          }
+        });
       return ctx.flows.screen(
         st,
-        ctx.tr("◇ Setting up the userbot proxy…", "◇ Собираю userbot-прокси…"),
+        ctx.tr(
+          "🧪 Beta\n\n◇ Setting up the userbot proxy…",
+          "🧪 Бета\n\n◇ Собираю userbot-прокси…",
+        ),
         [ctx.backRow(PARENT)],
       );
     }
 
     if (step === "off") {
       await run("systemctl", ["--user", "disable", "--now", SVC]);
-      invalidate();
       return ctx.show(st, SID);
     }
     return ctx.show(st, SID);
@@ -208,7 +280,6 @@ export default {
           [ctx.backRow(PARENT)],
         );
       }
-      invalidate();
       // Ключи есть — экран покажет [Включить].
       return ctx.show(st, SID);
     },

--- a/scripts/lib/menu/userbot.test.mjs
+++ b/scripts/lib/menu/userbot.test.mjs
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { runSetupCommand } from "./userbot.mjs";
+import userbot from "./userbot.mjs";
+
+test("userbot menu setup rejects exit 1 with a redacted error", async () => {
+  const secret = "setup-stderr-secret";
+  const exec = (_cmd, _args, _opts, callback) => {
+    const error = Object.assign(new Error(secret), { code: 1 });
+    callback(error, "", secret);
+  };
+
+  await assert.rejects(
+    runSetupCommand("/iva/bin/iva.mjs", { exec }),
+    (error) => {
+      assert.equal(error.message, "userbot setup failed (exit 1)");
+      assert.doesNotMatch(error.message, new RegExp(secret));
+      return true;
+    },
+  );
+});
+
+test("userbot menu renders the shared Telethon authorization state", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "iva-userbot-health-menu-"));
+  const envPath = join(dir, ".env");
+  await writeFile(envPath, "TELEGRAM_API_ID=12345\nTELEGRAM_API_HASH=abcdef123456\n");
+  let calls = 0;
+  const ctx = {
+    deps: {
+      root: dir,
+      envPath,
+      probeUserbotHealth: async ({ root, port }) => {
+        calls += 1;
+        assert.equal(root, dir);
+        assert.equal(port, "8724");
+        return { state: "unauthorized", reason: "telegram_login_required" };
+      },
+    },
+    tr: (en) => en,
+    btn: (text, callback_data) => ({ text, callback_data }),
+    backRow: () => [{ text: "Back", callback_data: "iva_menu:r:o" }],
+  };
+
+  const view = await userbot.render({ chatId: 1, userId: "2", data: {} }, ctx);
+
+  assert.equal(calls, 1);
+  assert.match(view.text, /Status: login required/);
+  assert.match(view.text, /Beta/);
+});
+
+test("userbot menu surfaces setup exit 1 and keeps the beta warning", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "iva-userbot-menu-"));
+  const envPath = join(dir, ".env");
+  await writeFile(envPath, "TELEGRAM_API_ID=12345\nTELEGRAM_API_HASH=abcdef123456\n");
+  const rendered = [];
+  const state = {
+    chatId: 1,
+    userId: "2",
+    screen: "ub",
+    data: {},
+  };
+  const flows = {
+    get: () => state,
+    screen: async (_state, text, rows) => {
+      state._last = { text, rows };
+      rendered.push(state._last);
+    },
+  };
+  const ctx = {
+    deps: {
+      root: dir,
+      envPath,
+      probeUserbotHealth: async () => ({ state: "off", reason: "service_off" }),
+      runUserbotSetup: async () => {
+        throw new Error("must stay redacted");
+      },
+      log: () => {},
+    },
+    flows,
+    tr: (en) => en,
+    btn: (text, callback_data) => ({ text, callback_data }),
+    backRow: () => [{ text: "Back", callback_data: "iva_menu:r:o" }],
+    show: async () => {},
+  };
+
+  await userbot.on("do", ["setup"], state, ctx);
+  for (let i = 0; i < 20 && !rendered.some((view) => /Setup failed/.test(view.text)); i += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+
+  assert.match(state._last.text, /Beta/);
+  assert.match(state._last.text, /Setup failed/);
+  assert.doesNotMatch(state._last.text, /must stay redacted/);
+});

--- a/scripts/lib/userbot-health-cli.test.mjs
+++ b/scripts/lib/userbot-health-cli.test.mjs
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createServer } from "node:http";
+import test from "node:test";
+import {
+  chmod,
+  copyFile,
+  mkdir,
+  mkdtemp,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
+
+function run(command, args, options) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, options);
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.once("error", reject);
+    child.once("close", (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+test("iva userbot diagnose --json returns the shared ready state without secrets", async (t) => {
+  const dir = await mkdtemp(join(tmpdir(), "iva-userbot-cli-"));
+  t.after(() => rm(dir, { recursive: true, force: true }));
+  const project = join(dir, "iva");
+  const fakeBin = join(dir, "bin");
+  const token = "diagnose-secret-token";
+  await mkdir(join(project, "bin"), { recursive: true });
+  await mkdir(join(project, "data"), { recursive: true });
+  await mkdir(fakeBin, { recursive: true });
+  await copyFile(join(ROOT, "bin/iva.mjs"), join(project, "bin/iva.mjs"));
+  await symlink(join(ROOT, "scripts"), join(project, "scripts"), "dir");
+  await writeFile(join(project, "data/telegram-userbot.token"), token);
+
+  const systemctl = join(fakeBin, "systemctl");
+  await writeFile(
+    systemctl,
+    [
+      "#!/bin/sh",
+      'if [ "$2" = "is-active" ]; then echo active; exit 0; fi',
+      'if [ "$2" = "is-enabled" ]; then echo enabled; exit 0; fi',
+      "exit 1",
+      "",
+    ].join("\n"),
+  );
+  await chmod(systemctl, 0o755);
+
+  const server = createServer((request, response) => {
+    assert.equal(request.url, "/healthz");
+    assert.equal(request.headers.authorization, `Bearer ${token}`);
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end('{"state":"ready"}');
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  t.after(() => server.close());
+  const port = server.address().port;
+  await writeFile(join(project, ".env"), `TELEGRAM_MCP_PORT=${port}\n`);
+
+  const result = await run(
+    process.execPath,
+    [join(project, "bin/iva.mjs"), "userbot", "diagnose", "--json"],
+    {
+      cwd: project,
+      env: {
+        ...process.env,
+        HOME: join(dir, "home"),
+        NO_COLOR: "1",
+        PATH: `${fakeBin}:/usr/bin:/bin`,
+      },
+      encoding: "utf8",
+    },
+  );
+
+  assert.equal(result.code, 0, result.stderr || result.stdout);
+  assert.deepEqual(JSON.parse(result.stdout), { state: "ready", reason: "ok" });
+  assert.doesNotMatch(`${result.stdout}\n${result.stderr}`, new RegExp(token));
+});

--- a/scripts/lib/userbot-health.mjs
+++ b/scripts/lib/userbot-health.mjs
@@ -1,0 +1,110 @@
+import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+export const USERBOT_HEALTH_TIMEOUT_MS = 1500;
+export const USERBOT_SERVICE = "iva-telegram-userbot.service";
+
+function fixed(state, reason) {
+  return { state, reason };
+}
+
+function defaultRunSystemctl(args, { signal } = {}) {
+  return new Promise((resolve) => {
+    execFile(
+      "systemctl",
+      ["--user", ...args],
+      { encoding: "utf8", signal },
+      (error, stdout = "") => {
+        resolve({
+          code: typeof error?.code === "number" ? error.code : error ? 1 : 0,
+          out: String(stdout).trim(),
+        });
+      },
+    );
+  });
+}
+
+async function defaultReadToken(root) {
+  try {
+    return (await readFile(join(root, "data", "telegram-userbot.token"), "utf8")).trim();
+  } catch {
+    return "";
+  }
+}
+
+async function runProbe({
+  root,
+  port,
+  signal,
+  runSystemctl,
+  readToken,
+  fetchImpl,
+}) {
+  const [active, enabled] = await Promise.all([
+    runSystemctl(["is-active", USERBOT_SERVICE], { signal }),
+    runSystemctl(["is-enabled", USERBOT_SERVICE], { signal }),
+  ]);
+  const activeLabel = String(active?.out || "").trim();
+  const enabledLabel = String(enabled?.out || "").trim();
+  const isActive = active?.code === 0 && activeLabel === "active";
+  const isEnabled = enabled?.code === 0 && enabledLabel === "enabled";
+
+  if (!isActive) {
+    if (activeLabel === "activating" || isEnabled) return fixed("starting", "service_starting");
+    return fixed("off", "service_off");
+  }
+
+  const token = String(await readToken(root)).trim();
+  if (!token) return fixed("unreachable", "proxy_token_missing");
+
+  const safePort = /^\d{1,5}$/.test(String(port)) ? String(port) : "8724";
+  const response = await fetchImpl(`http://127.0.0.1:${safePort}/healthz`, {
+    method: "GET",
+    headers: { authorization: `Bearer ${token}` },
+    signal,
+  });
+  if (response.status === 401) return fixed("unreachable", "proxy_auth_rejected");
+  if (!response.ok) return fixed("unreachable", "proxy_unreachable");
+
+  const payload = await response.json();
+  if (payload?.state === "ready") return fixed("ready", "ok");
+  if (payload?.state === "unauthorized") return fixed("unauthorized", "telegram_login_required");
+  return fixed("unreachable", "invalid_proxy_response");
+}
+
+export async function probeUserbotHealth({
+  root = process.cwd(),
+  port = process.env.TELEGRAM_MCP_PORT || "8724",
+  timeoutMs = USERBOT_HEALTH_TIMEOUT_MS,
+  runSystemctl = defaultRunSystemctl,
+  readToken = defaultReadToken,
+  fetchImpl = globalThis.fetch,
+} = {}) {
+  const controller = new AbortController();
+  let timer;
+  const timeout = new Promise((resolve) => {
+    timer = setTimeout(() => {
+      controller.abort();
+      resolve(fixed("unreachable", "probe_timeout"));
+    }, timeoutMs);
+  });
+  const probe = runProbe({
+    root,
+    port,
+    signal: controller.signal,
+    runSystemctl,
+    readToken,
+    fetchImpl,
+  }).catch(() =>
+    controller.signal.aborted
+      ? fixed("unreachable", "probe_timeout")
+      : fixed("unreachable", "proxy_unreachable"),
+  );
+
+  try {
+    return await Promise.race([probe, timeout]);
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/scripts/lib/userbot-health.test.mjs
+++ b/scripts/lib/userbot-health.test.mjs
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { probeUserbotHealth, USERBOT_HEALTH_TIMEOUT_MS } from "./userbot-health.mjs";
+
+const activeSystemd = async (args) => {
+  if (args[0] === "is-active") return { code: 0, out: "active" };
+  return { code: 0, out: "enabled" };
+};
+
+const response = (status, body) => ({
+  status,
+  ok: status >= 200 && status < 300,
+  json: async () => body,
+});
+
+test("userbot health uses the required 1.5 second production budget", () => {
+  assert.equal(USERBOT_HEALTH_TIMEOUT_MS, 1500);
+});
+
+test("userbot health reports off and does not contact the proxy", async () => {
+  let fetched = false;
+  const health = await probeUserbotHealth({
+    runSystemctl: async (args) =>
+      args[0] === "is-active" ? { code: 3, out: "inactive" } : { code: 1, out: "disabled" },
+    readToken: async () => "unused",
+    fetchImpl: async () => {
+      fetched = true;
+      throw new Error("must not fetch");
+    },
+  });
+
+  assert.equal(health.state, "off");
+  assert.equal(fetched, false);
+});
+
+test("userbot health reports starting for an enabled inactive service", async () => {
+  let fetched = false;
+  const health = await probeUserbotHealth({
+    runSystemctl: async (args) =>
+      args[0] === "is-active" ? { code: 3, out: "activating" } : { code: 0, out: "enabled" },
+    readToken: async () => "unused",
+    fetchImpl: async () => {
+      fetched = true;
+      throw new Error("must not fetch");
+    },
+  });
+
+  assert.equal(health.state, "starting");
+  assert.equal(fetched, false);
+});
+
+test("userbot health reports unreachable when the proxy is down", async () => {
+  const health = await probeUserbotHealth({
+    runSystemctl: activeSystemd,
+    readToken: async () => "local-token",
+    fetchImpl: async () => {
+      throw new Error("connect ECONNREFUSED secret-local-token");
+    },
+  });
+
+  assert.deepEqual(health, { state: "unreachable", reason: "proxy_unreachable" });
+  assert.doesNotMatch(JSON.stringify(health), /local-token|ECONNREFUSED/);
+});
+
+test("userbot health reports unreachable on bearer mismatch and redacts the token", async () => {
+  const token = "bearer-mismatch-secret";
+  let authorization = "";
+  const health = await probeUserbotHealth({
+    runSystemctl: activeSystemd,
+    readToken: async () => token,
+    fetchImpl: async (_url, init) => {
+      authorization = init.headers.authorization;
+      return response(401, { error: "unauthorized", reflected: token });
+    },
+  });
+
+  assert.equal(authorization, `Bearer ${token}`);
+  assert.deepEqual(health, { state: "unreachable", reason: "proxy_auth_rejected" });
+  assert.doesNotMatch(JSON.stringify(health), new RegExp(token));
+});
+
+test("userbot health bounds a hanging proxy probe to its timeout", async () => {
+  const started = Date.now();
+  const health = await probeUserbotHealth({
+    timeoutMs: 25,
+    runSystemctl: activeSystemd,
+    readToken: async () => "local-token",
+    fetchImpl: async (_url, { signal }) =>
+      new Promise((_resolve, reject) => {
+        signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+      }),
+  });
+
+  assert.deepEqual(health, { state: "unreachable", reason: "probe_timeout" });
+  assert.ok(Date.now() - started < 250, "probe exceeded the bounded test budget");
+});
+
+test("userbot health distinguishes an unauthorized Telethon session", async () => {
+  const health = await probeUserbotHealth({
+    runSystemctl: activeSystemd,
+    readToken: async () => "local-token",
+    fetchImpl: async () => response(200, { state: "unauthorized" }),
+  });
+
+  assert.deepEqual(health, { state: "unauthorized", reason: "telegram_login_required" });
+});
+
+test("userbot health reports ready from the existing proxy session", async () => {
+  const health = await probeUserbotHealth({
+    runSystemctl: activeSystemd,
+    readToken: async () => "local-token",
+    fetchImpl: async () => response(200, { state: "ready" }),
+  });
+
+  assert.deepEqual(health, { state: "ready", reason: "ok" });
+});

--- a/services/telegram-userbot/serve.py
+++ b/services/telegram-userbot/serve.py
@@ -31,6 +31,11 @@ import sys
 from pathlib import Path
 
 
+async def _health_payload(client) -> dict[str, str]:
+    """Report authorization from the proxy's existing Telethon client."""
+    return {"state": "ready" if await client.is_user_authorized() else "unauthorized"}
+
+
 def _fail(msg: str) -> None:
     print(f"telegram-userbot: {msg}", file=sys.stderr)
     sys.exit(1)
@@ -145,6 +150,9 @@ def main() -> None:
                 print(f"telegram-userbot: reconnect failed: {exc}", file=sys.stderr)
             return await call_next(request)
 
+    async def health(_request):
+        return JSONResponse(await _health_payload(client))
+
     async def amain() -> None:
         await client.connect()  # NOT .start() — that would prompt for interactive login
         authorized = await client.is_user_authorized()
@@ -165,6 +173,7 @@ def main() -> None:
         )
 
         app = mcp.streamable_http_app()
+        app.add_route("/healthz", health, methods=["GET"])
         # add_middleware stacks outermost-last: BearerAuth runs first (reject before
         # we bother reconnecting), then EnsureConnected.
         app.add_middleware(EnsureConnectedMiddleware)

--- a/services/telegram-userbot/test_health.py
+++ b/services/telegram-userbot/test_health.py
@@ -1,0 +1,36 @@
+import asyncio
+import unittest
+
+from serve import _health_payload
+
+
+class FakeClient:
+    def __init__(self, authorized):
+        self.authorized = authorized
+        self.calls = 0
+
+    async def is_user_authorized(self):
+        self.calls += 1
+        return self.authorized
+
+
+class HealthPayloadTest(unittest.TestCase):
+    def test_uses_the_existing_client_for_unauthorized_health(self):
+        client = FakeClient(False)
+
+        payload = asyncio.run(_health_payload(client))
+
+        self.assertEqual(payload, {"state": "unauthorized"})
+        self.assertEqual(client.calls, 1)
+
+    def test_uses_the_existing_client_for_ready_health(self):
+        client = FakeClient(True)
+
+        payload = asyncio.run(_health_payload(client))
+
+        self.assertEqual(payload, {"state": "ready"})
+        self.assertEqual(client.calls, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add one 1.5-second read-only `probeUserbotHealth()` shared by the CLI and Telegram menus, with `off`, `starting`, `unreachable`, `unauthorized`, and `ready` states
- expose bearer-gated `/healthz` from the existing proxy client, so health checks never open a second Telethon session
- add `iva userbot diagnose --json`, surface redacted menu setup failures, retain the beta warning, and document the state contract

## Testing

- `node --test scripts/lib/userbot-health.test.mjs scripts/lib/userbot-health-cli.test.mjs scripts/lib/menu/userbot.test.mjs`
- `uv run python services/telegram-userbot/test_health.py`
- `npm run typecheck`
- `npm run build`
- autograph self-tests: 256/256
- security defense tests: 45/45
- full Node suite passes except two reproducible failures in untouched `scripts/bash-tool.test.mjs`: `minimum deadline is enforced while the Node event loop is blocked` and `timeout leaves no TERM-resistant child PID behind`

Closes #58