### PR TITLE
CI: disposable replica gate — isolated e2e install with a mock provider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Build Eve application
         run: npm run build
 
+      - name: Replica smoke (isolated install + mock provider)
+        run: npm run replica
+
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:

--- a/agent/provider.ts
+++ b/agent/provider.ts
@@ -13,7 +13,9 @@ const PROVIDER = process.env.MODEL_PROVIDER ?? "ollama";
 
 const PROVIDERS = {
   ollama: {
-    baseURL: "https://ollama.com/v1",
+    // OLLAMA_BASE_URL — не пользовательская настройка, а шов для тестов: replica-смоук
+    // подставляет сюда локальный mock-провайдер (scripts/lib/mock-openai-server.mjs).
+    baseURL: process.env.OLLAMA_BASE_URL ?? "https://ollama.com/v1",
     apiKey: process.env.OLLAMA_API_KEY,
     textModel: process.env.OLLAMA_MODEL ?? "deepseek-v4-pro",
     contextWindow: Number(process.env.OLLAMA_CONTEXT_WINDOW ?? 131072),

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "dev": "eve dev",
     "start": "eve start",
     "init-vault": "node scripts/init-vault.mjs",
+    "replica": "node scripts/replica-smoke.mjs",
     "digest": "node scripts/daily-digest.ts",
     "poll": "node --env-file=.env scripts/telegram-poll.mjs",
     "memory": "node --env-file=.env scripts/memory/rollup.ts",

--- a/scripts/lib/mock-openai-server.mjs
+++ b/scripts/lib/mock-openai-server.mjs
@@ -1,0 +1,116 @@
+// Mock OpenAI-совместимый провайдер для replica-смоука (scripts/replica-smoke.mjs).
+// Поднимает локальный http-сервер с единственным эндпоинтом POST /v1/chat/completions
+// и отвечает по сценарию, завязанному на текст последнего user-сообщения, — так смоук
+// проверяет полный путь build → eve → провайдер без сети и настоящей модели.
+// Идея — reference-реализация из stabilization-форка mamysh/iva (PR #7), переписана
+// под upstream с нуля.
+import { createServer } from "node:http";
+
+const MODEL = "iva-replica";
+
+function partText(content) {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((p) => (typeof p === "string" ? p : p?.text ?? ""))
+      .join(" ");
+  }
+  return "";
+}
+
+function transcriptText(messages) {
+  return messages.map((m) => partText(m?.content)).join("\n");
+}
+
+function lastUserText(messages) {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i]?.role === "user") return partText(messages[i].content);
+  }
+  return "";
+}
+
+// Сценарий: маркер CEDAR-#### сеется фразой "Remember this code", а после рестарта
+// eve должен реплеить историю целиком — тогда маркер найдётся в транскрипте и вернётся
+// в ответе. Так restart/resume проверяется без настоящей памяти модели.
+function chooseResponse(body) {
+  const messages = Array.isArray(body?.messages) ? body.messages : [];
+  const last = lastUserText(messages);
+  if (/What code did I ask you to remember/i.test(last)) {
+    const match = transcriptText(messages).match(/CEDAR-\d+/);
+    return match ? match[0] : "MISSING_MARKER";
+  }
+  if (/Remember this code/i.test(last)) return "REMEMBERED";
+  return "REPLICA_OK";
+}
+
+function completionJson(text) {
+  return {
+    id: "chatcmpl-replica",
+    object: "chat.completion",
+    created: 1,
+    model: MODEL,
+    choices: [
+      { index: 0, message: { role: "assistant", content: text }, finish_reason: "stop" },
+    ],
+    usage: { prompt_tokens: 8, completion_tokens: 4, total_tokens: 12 },
+  };
+}
+
+function streamChunks(text) {
+  const base = { id: "chatcmpl-replica", object: "chat.completion.chunk", created: 1, model: MODEL };
+  return [
+    { ...base, choices: [{ index: 0, delta: { role: "assistant", content: text }, finish_reason: null }] },
+    { ...base, choices: [{ index: 0, delta: {}, finish_reason: "stop" }] },
+    { ...base, choices: [], usage: { prompt_tokens: 8, completion_tokens: 4, total_tokens: 12 } },
+  ];
+}
+
+async function readBody(req) {
+  const chunks = [];
+  for await (const chunk of req) chunks.push(chunk);
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+/** Стартует mock-провайдер на 127.0.0.1:0; handle: { baseUrl, requests, close }. */
+export async function startMockOpenAiServer() {
+  const requests = [];
+  const server = createServer(async (req, res) => {
+    if (req.method !== "POST" || req.url !== "/v1/chat/completions") {
+      res.writeHead(404, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: { message: `no route: ${req.method} ${req.url}` } }));
+      return;
+    }
+    let body;
+    try {
+      body = JSON.parse(await readBody(req));
+    } catch {
+      res.writeHead(400, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: { message: "invalid JSON body" } }));
+      return;
+    }
+    requests.push(body);
+    const text = chooseResponse(body);
+    if (body?.stream) {
+      res.writeHead(200, {
+        "content-type": "text/event-stream",
+        "cache-control": "no-cache",
+        connection: "keep-alive",
+      });
+      for (const chunk of streamChunks(text)) res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+      res.end("data: [DONE]\n\n");
+    } else {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(completionJson(text)));
+    }
+  });
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const { port } = server.address();
+  return {
+    baseUrl: `http://127.0.0.1:${port}/v1`,
+    requests,
+    close: () => new Promise((resolve) => server.close(resolve)),
+  };
+}

--- a/scripts/lib/mock-openai-server.test.mjs
+++ b/scripts/lib/mock-openai-server.test.mjs
@@ -1,0 +1,75 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { startMockOpenAiServer } from "./mock-openai-server.mjs";
+
+async function complete(baseUrl, body) {
+  const res = await fetch(`${baseUrl}/chat/completions`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return res;
+}
+
+test("non-streamed completion answers REPLICA_OK by default", async () => {
+  const mock = await startMockOpenAiServer();
+  try {
+    const res = await complete(mock.baseUrl, {
+      model: "iva-replica",
+      messages: [{ role: "user", content: "hello" }],
+    });
+    assert.equal(res.status, 200);
+    const json = await res.json();
+    assert.equal(json.choices[0].message.content, "REPLICA_OK");
+    assert.equal(mock.requests.length, 1);
+  } finally {
+    await mock.close();
+  }
+});
+
+test("streamed completion emits SSE chunks and [DONE]", async () => {
+  const mock = await startMockOpenAiServer();
+  try {
+    const res = await complete(mock.baseUrl, {
+      model: "iva-replica",
+      stream: true,
+      messages: [{ role: "user", content: "Remember this code: CEDAR-4729" }],
+    });
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /text\/event-stream/);
+    const text = await res.text();
+    assert.match(text, /"content":"REMEMBERED"/);
+    assert.match(text, /"finish_reason":"stop"/);
+    assert.match(text, /data: \[DONE\]/);
+  } finally {
+    await mock.close();
+  }
+});
+
+test("marker is echoed back from the replayed transcript", async () => {
+  const mock = await startMockOpenAiServer();
+  try {
+    const res = await complete(mock.baseUrl, {
+      model: "iva-replica",
+      messages: [
+        { role: "user", content: "Remember this code: CEDAR-4729" },
+        { role: "assistant", content: "REMEMBERED" },
+        { role: "user", content: [{ type: "text", text: "What code did I ask you to remember?" }] },
+      ],
+    });
+    const json = await res.json();
+    assert.equal(json.choices[0].message.content, "CEDAR-4729");
+  } finally {
+    await mock.close();
+  }
+});
+
+test("unknown routes return 404", async () => {
+  const mock = await startMockOpenAiServer();
+  try {
+    const res = await fetch(`${mock.baseUrl}/models`);
+    assert.equal(res.status, 404);
+  } finally {
+    await mock.close();
+  }
+});

--- a/scripts/replica-smoke.mjs
+++ b/scripts/replica-smoke.mjs
@@ -124,15 +124,21 @@ async function waitForHealth(port, child) {
 }
 
 async function turn(session, prompt, timeoutMs = TURN_TIMEOUT_MS) {
-  const result = await Promise.race([
-    session.send(prompt).then((r) => {
-      note(`[smoke] send accepted (session ${session.state?.sessionId ?? "new"})`);
-      return r.result();
-    }),
-    new Promise((_, reject) =>
-      setTimeout(reject, timeoutMs, new Error(`turn timed out after ${timeoutMs / 1000}s`)),
-    ),
-  ]);
+  let timer;
+  let result;
+  try {
+    result = await Promise.race([
+      session.send(prompt).then((r) => {
+        note(`[smoke] send accepted (session ${session.state?.sessionId ?? "new"})`);
+        return r.result();
+      }),
+      new Promise((_, reject) => {
+        timer = setTimeout(reject, timeoutMs, new Error(`turn timed out after ${timeoutMs / 1000}s`));
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
   note(`[smoke] turn done: ${JSON.stringify(result?.status)}`);
   if (result.status === "failed" || !result.message) {
     throw new Error(`turn failed: status=${result.status} message=${JSON.stringify(result.message ?? "")}`);

--- a/scripts/replica-smoke.mjs
+++ b/scripts/replica-smoke.mjs
@@ -1,0 +1,240 @@
+// Replica-смоук: одноразовая полностью изолированная установка ивы + mock-провайдер.
+// Проверяет то, что юнит-тесты не видят: прод-билд eve, старт сервера, первый реальный
+// ответ через провайдера и restart/resume сессии. Ни .env, ни Telegram-токена, ни живого
+// vault — только временная директория и закрытый allowlist переменных окружения.
+// Запуск: npm run replica (в CI — шаг после build). По мотивам stabilization-форка
+// mamysh/iva (PR #7), переписано под upstream.
+import { spawn } from "node:child_process";
+import { mkdtemp, mkdir, rm, symlink, writeFile, cp } from "node:fs/promises";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { randomBytes } from "node:crypto";
+import { startMockOpenAiServer } from "./lib/mock-openai-server.mjs";
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const MARKER = "CEDAR-4729";
+const HEALTH_TIMEOUT_MS = 90_000;
+const TURN_TIMEOUT_MS = 120_000;
+
+let phase = "prepare";
+function setPhase(name) {
+  phase = name;
+  note(`[smoke] ${new Date().toISOString()} phase: ${name}`);
+}
+const logs = [];
+
+function note(line) {
+  logs.push(line);
+  if (logs.length > 400) logs.shift();
+}
+
+async function freePort() {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.once("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const { port } = srv.address();
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+function replicaEnv({ sandbox, app, port, mockBaseUrl, bearer }) {
+  // Закрытый allowlist: process.env НЕ спредится — ни секретов хоста, ни его настроек.
+  return {
+    PATH: process.env.PATH,
+    HOME: sandbox,
+    NODE_ENV: "production",
+    PORT: String(port),
+    IVA_PORT: String(port),
+    MODEL_PROVIDER: "ollama",
+    OLLAMA_BASE_URL: mockBaseUrl,
+    OLLAMA_API_KEY: "replica-key",
+    OLLAMA_MODEL: "iva-replica",
+    OLLAMA_CONTEXT_WINDOW: "131072",
+    ASSISTANT_BEARER: bearer,
+    ASSISTANT_DATA_DIR: join(app, "data"),
+    ASSISTANT_VAULT_DIR: join(app, "vault"),
+    ASSISTANT_TIMEZONE: "UTC",
+    MEMORY_SEARCH_MODE: "bm25",
+  };
+}
+
+function run(cmd, args, { cwd, env }) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { cwd, env, stdio: ["ignore", "pipe", "pipe"] });
+    const capture = (buf) => String(buf).split("\n").filter(Boolean).forEach(note);
+    child.stdout.on("data", capture);
+    child.stderr.on("data", capture);
+    child.on("error", reject);
+    child.on("exit", (code) =>
+      code === 0 ? resolve() : reject(new Error(`${cmd} ${args.join(" ")} exited with ${code}`)),
+    );
+  });
+}
+
+function startEve({ app, env, port }) {
+  const child = spawn(
+    process.execPath,
+    [join(app, "node_modules/eve/bin/eve.js"), "start", "--host", "127.0.0.1", "--port", String(port)],
+    { cwd: app, env, detached: true, stdio: ["ignore", "pipe", "pipe"] },
+  );
+  const capture = (buf) => String(buf).split("\n").filter(Boolean).forEach(note);
+  child.stdout.on("data", capture);
+  child.stderr.on("data", capture);
+  return child;
+}
+
+async function stopEve(child) {
+  if (!child || child.exitCode !== null) return;
+  const gone = new Promise((resolve) => child.once("exit", resolve));
+  try {
+    process.kill(-child.pid, "SIGTERM");
+  } catch {
+    return;
+  }
+  // Окно graceful stop у самого eve — 5с; даём заметно больше, чтобы SIGKILL
+  // не обрубал запись состояния .workflow-data на полпути.
+  const timer = new Promise((resolve) => setTimeout(resolve, 15000, "timeout"));
+  if ((await Promise.race([gone, timer])) === "timeout") {
+    try {
+      process.kill(-child.pid, "SIGKILL");
+    } catch {
+      /* уже умер */
+    }
+    await gone;
+  }
+}
+
+async function waitForHealth(port, child) {
+  const deadline = Date.now() + HEALTH_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) throw new Error(`eve exited with ${child.exitCode} before becoming healthy`);
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/`, { signal: AbortSignal.timeout(2000) });
+      if (res.ok) return;
+    } catch {
+      /* ещё не поднялся */
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  throw new Error(`eve did not become healthy within ${HEALTH_TIMEOUT_MS / 1000}s`);
+}
+
+async function turn(session, prompt, timeoutMs = TURN_TIMEOUT_MS) {
+  const result = await Promise.race([
+    session.send(prompt).then((r) => {
+      note(`[smoke] send accepted (session ${session.state?.sessionId ?? "new"})`);
+      return r.result();
+    }),
+    new Promise((_, reject) =>
+      setTimeout(reject, timeoutMs, new Error(`turn timed out after ${timeoutMs / 1000}s`)),
+    ),
+  ]);
+  note(`[smoke] turn done: ${JSON.stringify(result?.status)}`);
+  if (result.status === "failed" || !result.message) {
+    throw new Error(`turn failed: status=${result.status} message=${JSON.stringify(result.message ?? "")}`);
+  }
+  return result.message.trim();
+}
+
+async function prepareReplica(sandbox) {
+  const app = join(sandbox, "app");
+  await mkdir(app, { recursive: true });
+  for (const dir of ["agent", "scripts", "patches", "vault-template"]) {
+    await cp(join(ROOT, dir), join(app, dir), { recursive: true });
+  }
+  for (const file of ["package.json", "package-lock.json", "tsconfig.json"]) {
+    await cp(join(ROOT, file), join(app, file));
+  }
+  // node_modules симлинком: npm ci уже проверяет разрешение зависимостей в соседнем CI-шаге,
+  // а здесь он бы стоил минуты и сотни мегабайт на каждый прогон.
+  await symlink(join(ROOT, "node_modules"), join(app, "node_modules"), "dir");
+  await mkdir(join(app, "data"), { recursive: true });
+  return app;
+}
+
+async function main() {
+  const sandbox = await mkdtemp(join(tmpdir(), "iva-replica-"));
+  const mock = await startMockOpenAiServer();
+  let eve = null;
+  try {
+    const app = await prepareReplica(sandbox);
+    const port = await freePort();
+    const bearer = randomBytes(24).toString("hex");
+    const env = replicaEnv({ sandbox, app, port, mockBaseUrl: mock.baseUrl, bearer });
+    await writeFile(join(app, ".env"), `ASSISTANT_BEARER=${bearer}\n`, { mode: 0o600 });
+
+    setPhase("vault");
+    await run(process.execPath, [join(app, "scripts/init-vault.mjs")], { cwd: app, env });
+
+    setPhase("build");
+    await run(process.execPath, [join(app, "node_modules/eve/bin/eve.js"), "build"], { cwd: app, env });
+
+    setPhase("start");
+    eve = startEve({ app, env, port });
+    await waitForHealth(port, eve);
+
+    // Тот же экземпляр eve, что и у реплики: её node_modules — симлинк на ROOT/node_modules.
+    const { Client } = await import("eve/client");
+    const client = new Client({ host: `http://127.0.0.1:${port}`, auth: { bearer: async () => bearer } });
+
+    setPhase("first-reply");
+    const session = client.session();
+    const first = await turn(session, "Reply with a status word.");
+    if (first !== "REPLICA_OK") throw new Error(`unexpected first reply: ${JSON.stringify(first)}`);
+
+    setPhase("seed-marker");
+    const remembered = await turn(session, `Remember this code: ${MARKER}`);
+    if (remembered !== "REMEMBERED") throw new Error(`unexpected seed reply: ${JSON.stringify(remembered)}`);
+    const savedState = session.state;
+
+    setPhase("restart");
+    await stopEve(eve);
+    eve = startEve({ app, env, port });
+    await waitForHealth(port, eve);
+
+    setPhase("post-restart");
+    const fresh = await turn(client.session(), "Reply with a status word.");
+    if (fresh !== "REPLICA_OK") throw new Error(`unexpected post-restart reply: ${JSON.stringify(fresh)}`);
+
+    // Строгий резюм припаркованной сессии через рестарт: на eve 0.27.13 сервер принимает
+    // continue-POST (200), но молча теряет сообщение — re-enqueued run не просыпается,
+    // в .workflow-data не появляется ни одного нового события (session-resume wedge).
+    // До фикса ассерт мягкий: падение резюма роняет смоук только под
+    // REPLICA_STRICT_RESUME=1 — этим же флагом баг и воспроизводится.
+    setPhase("resume");
+    const strictResume = process.env.REPLICA_STRICT_RESUME === "1";
+    try {
+      const resumed = client.session(savedState);
+      const echo = await turn(
+        resumed,
+        "What code did I ask you to remember? Reply with the code only.",
+        strictResume ? TURN_TIMEOUT_MS : 45_000,
+      );
+      if (echo !== MARKER) throw new Error(`resume lost the marker: got ${JSON.stringify(echo)}`);
+      console.log("replica smoke: session resume across restart OK");
+    } catch (err) {
+      if (strictResume) throw err;
+      console.warn(`replica smoke: KNOWN ISSUE — session resume across restart failed (${err?.message ?? err})`);
+    }
+
+    if (mock.requests.length < 3) throw new Error(`provider was barely exercised: ${mock.requests.length} requests`);
+    console.log(`replica smoke: OK (provider requests: ${mock.requests.length})`);
+  } catch (err) {
+    console.error(`replica smoke FAILED at phase "${phase}": ${err?.message ?? err}`);
+    console.error(`provider requests so far: ${mock.requests.length}`);
+    console.error("--- last child output ---");
+    for (const line of logs.slice(-120)) console.error(line);
+    process.exitCode = 1;
+  } finally {
+    await stopEve(eve);
+    await mock.close();
+    if (process.env.REPLICA_KEEP === "1") console.error(`sandbox kept: ${sandbox}`);
+    else await rm(sandbox, { recursive: true, force: true });
+  }
+}
+
+await main();


### PR DESCRIPTION
Part 1 of #102 (proposed by @mamysh, adapted from the reference implementation in mamysh/iva#7 — thanks!).

Adds an end-to-end smoke that unit tests cannot cover: a fully isolated throwaway install of Iva in a temp directory, talking to a mock OpenAI-compatible provider.

What it does per CI run (after the normal build step):

- copies `agent/ scripts/ patches/ vault-template/` + manifests into a temp dir, symlinks `node_modules` (no extra `npm ci` — dependency resolution is already gated by the previous step);
- closed env allowlist: no host secrets, no Telegram token, no live vault, `HOME` points into the sandbox;
- mock provider (`scripts/lib/mock-openai-server.mjs`): single `POST /v1/chat/completions` endpoint, streamed + non-streamed, scripted replies;
- asserts: prod `eve build` → `eve start` → health → first real reply → server restart → post-restart turn;
- everything torn down in `finally`; on failure prints the last child output with phase markers.

The only production-code change is a one-line env seam in `agent/provider.ts`: `OLLAMA_BASE_URL` override so the mock can be wired in (intentionally undocumented — it is a test seam, not a user setting).

### Known issue caught by this gate

Session resume across a server restart is wedged on eve 0.27.13: the continue-POST returns 200 but the re-enqueued run never wakes up and nothing new is written to `.workflow-data`. On the pre-0.3.6 engine prod resumed parked sessions across restarts fine, so this looks like a regression of the engine bump. The smoke therefore asserts strict resume only under `REPLICA_STRICT_RESUME=1` (which doubles as the repro); tracked in #104.

Run locally: `npm run replica`.
