### PR TITLE
fix(schedules): harden migration and reservations

### DIFF
--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -352,3 +352,14 @@
   `session.reset()`, return with the same continuation token and assert the marker is gone.
   It guards Eve's documented contract ("reset retires a session so its continuation starts
   fresh"), which 0.27.13 honours — the `/new` failure was Iva's token shape, not Eve's reset.
+
+## Schedule migration durability (v0.3.11)
+
+- Memory catch-up baselines are seeded per key under the shared status lock. Existing
+  digest state can no longer disable first-run storm protection for memory schedules.
+- The seed transaction commits before legacy timer teardown; a failed seed leaves the
+  retired persistent units available for another boot.
+- Reservations record the owner process. A confirmed-dead owner is recovered immediately,
+  while old ownerless markers keep the time-based compatibility rule.
+- Completion and cleanup mutate status only while holding the status lock and keep a
+  reservation marked locally until its removal write succeeds.

--- a/scripts/lib/schedule-migration.mjs
+++ b/scripts/lib/schedule-migration.mjs
@@ -198,24 +198,7 @@ export async function runScheduleMigration({
   runJob,
 } = {}) {
   try {
-    // Legacy-unit teardown genuinely needs systemd — catch-up does not. These used to
-    // share one early-return, which meant ANY environment without a user systemd
-    // (containers, this repo's own `npm run replica` sandbox, CI) silently never caught
-    // up a missed rollup either, contradicting the "runs on every start" contract
-    // documented in docs/deploy.md and TECH_DEBT.md.
-    if (homedir && existsSync(join(homedir, ".config/systemd/user"))) {
-      let probe;
-      try {
-        probe = execImpl(["--version"]);
-      } catch (error) {
-        probe = { code: 127, error };
-      }
-      if (probe?.error?.code !== "ENOENT") {
-        removeLegacyUnits({ homedir, execImpl, log });
-      }
-    }
-
-    if (!statusPath) return; // nowhere to read/write catch-up state — nothing more to do
+    if (!statusPath) return;
 
     const runPeriod =
       runJob ??
@@ -230,7 +213,7 @@ export async function runScheduleMigration({
           log,
         }));
 
-    // First-boot detection, the seed write, AND the due-check all happen inside the
+    // Per-key seed, the seed write, AND the due-check all happen inside the
     // SAME single lock acquisition runScheduledJob's own admission check uses — never
     // decided from a status snapshot read outside any critical section. Two things this
     // closes: (1) a real run's own read-modify-write (recording inProgressSince/
@@ -246,46 +229,62 @@ export async function runScheduleMigration({
         return { action: "defer" };
       }
       const current = readStatus(statusPath);
-      const isFirstBoot = Object.keys(current).length === 0;
-      if (isFirstBoot) {
-        const nowMs = now();
-        const seeded = { ...current };
-        // seededAt, deliberately NOT lastSuccessAt: this is a storm-protection baseline,
-        // not a real run — /menu → crons and formatLastSuccess() must keep showing
-        // "never" for a period that has only ever been seeded, never actually executed.
-        // It still suppresses first-boot catch-up below exactly the way
-        // lastSuccessAt-as-seed used to (see the effective-baseline comparison), just
-        // under its own field name.
-        for (const period of PERIODS) {
-          seeded[statusKey(period)] = { ...seeded[statusKey(period)], seededAt: nowMs };
-        }
-        writeStatusAtomic(statusPath, seeded);
-        return { action: "seeded" };
-      }
-
       const nowMs = now();
+      const seeded = { ...current };
+      const freshlySeeded = new Set();
+      for (const period of PERIODS) {
+        const key = statusKey(period);
+        const entry = current[key];
+        if (
+          typeof entry?.lastSuccessAt !== "number" &&
+          typeof entry?.seededAt !== "number"
+        ) {
+          seeded[key] = { ...entry, seededAt: nowMs };
+          freshlySeeded.add(period);
+        }
+      }
+      if (freshlySeeded.size > 0) writeStatusAtomic(statusPath, seeded);
+
       const due = [];
       for (const period of PERIODS) {
+        if (freshlySeeded.has(period)) continue;
         const { graceMs } = PERIOD_SCHEDULE[period];
         const dueAt = lastDueMs(period, nowMs, tz);
-        const entry = current[statusKey(period)];
+        const entry = seeded[statusKey(period)];
         // A real success always wins; otherwise fall back to the seeded baseline (if
         // any) so a freshly-seeded period doesn't immediately look "due" the moment
         // it's due relative to real time — same suppression the old
         // lastSuccessAt-as-seed did.
         const recorded = typeof entry?.lastSuccessAt === "number" ? entry.lastSuccessAt : entry?.seededAt;
-        const effectiveBaseline = typeof recorded === "number" ? recorded : -Infinity;
+        const effectiveBaseline = recorded;
         const alreadyCaughtUp = effectiveBaseline >= dueAt;
         const withinGrace = nowMs - dueAt <= graceMs;
         if (!alreadyCaughtUp && withinGrace) due.push({ period, dueAt, effectiveBaseline });
       }
-      return { action: "run", due };
+      return { action: "run", due, freshlySeeded: [...freshlySeeded] };
     });
 
     if (decision.action === "defer") return;
-    if (decision.action === "seeded") {
-      log("schedule-migration: first boot — seeded catch-up baseline, running nothing (storm protection)");
-      return;
+
+    // The seed transaction must commit before the retired units are disabled. A crash
+    // before this point leaves the old persistent timers able to cover the night; a
+    // crash after it has a durable in-process catch-up baseline.
+    if (homedir && existsSync(join(homedir, ".config/systemd/user"))) {
+      let probe;
+      try {
+        probe = execImpl(["--version"]);
+      } catch (error) {
+        probe = { code: 127, error };
+      }
+      if (probe?.error?.code !== "ENOENT") {
+        removeLegacyUnits({ homedir, execImpl, log });
+      }
+    }
+
+    if (decision.freshlySeeded.length > 0) {
+      log(
+        `schedule-migration: seeded catch-up baseline for ${decision.freshlySeeded.join(", ")} (storm protection)`,
+      );
     }
 
     // The actual catch-up run (and ITS OWN reservation, under its own fresh lock

--- a/scripts/lib/schedule-migration.test.mjs
+++ b/scripts/lib/schedule-migration.test.mjs
@@ -131,6 +131,54 @@ test("first boot (no status file): seeds a baseline (seededAt, NOT lastSuccessAt
   }
 });
 
+test("a digest-only status seeds every missing memory key and causes no catch-up burst", async () => {
+  const homedir = await scaffoldHome();
+  const statusPath = join(homedir, "..", "data", "rollup-status.json");
+  await mkdir(join(homedir, "..", "data"), { recursive: true });
+  await writeFile(statusPath, JSON.stringify({ digest: { lastSuccessAt: 123 } }));
+  const fixedNow = Date.UTC(2026, 7, 4, 10, 0, 0);
+  const ranPeriods = [];
+
+  await runScheduleMigration({
+    homedir,
+    statusPath,
+    tz: "UTC",
+    log: () => {},
+    now: () => fixedNow,
+    execImpl: fakeExecImpl().execImpl,
+    runJob: async (period) => { ranPeriods.push(period); },
+  });
+
+  assert.deepEqual(ranPeriods, []);
+  const status = JSON.parse(await readFile(statusPath, "utf8"));
+  assert.deepEqual(status.digest, { lastSuccessAt: 123 });
+  for (const period of ["daily", "weekly", "monthly", "yearly"]) {
+    assert.equal(status[`memory-${period}`]?.seededAt, fixedNow);
+  }
+});
+
+test("legacy teardown is not attempted when the seed transaction cannot be committed", async () => {
+  const homedir = await scaffoldHome();
+  const unitDir = join(homedir, UNIT_DIR_REL);
+  const unit = join(unitDir, "iva-memory-daily.timer");
+  await writeFile(unit, "[Unit]\n");
+  const { execImpl, calls } = fakeExecImpl();
+  const logs = [];
+
+  // A directory cannot be atomically replaced by the JSON status tmp file. This makes
+  // the seed write fail after the status lock is acquired, before teardown is allowed.
+  await runScheduleMigration({
+    homedir,
+    statusPath: unitDir,
+    execImpl,
+    log: (...args) => logs.push(args.join(" ")),
+  });
+
+  assert.deepEqual(calls, []);
+  assert.equal(existsSync(unit), true);
+  assert.ok(logs.some((line) => line.includes("unexpected failure")));
+});
+
 test("legacy units: disabled and deleted by exact name; unrelated xfeed-daily.timer is left alone", async () => {
   const homedir = await scaffoldHome();
   const unitDir = join(homedir, UNIT_DIR_REL);

--- a/scripts/lib/schedule-runner.mjs
+++ b/scripts/lib/schedule-runner.mjs
@@ -24,6 +24,31 @@ const TAIL_MAX = 4000;
 const LOCK_STALE_MS = 30_000;
 const LOCK_RETRY_ATTEMPTS = 25;
 const LOCK_RETRY_DELAY_MS = 20;
+const OWNER_STARTED_AT = Math.round(Date.now() - process.uptime() * 1000);
+
+function reservationOwnerIsDead(entry) {
+  if (
+    !Number.isSafeInteger(entry?.ownerPid) ||
+    entry.ownerPid <= 0 ||
+    typeof entry?.ownerStartedAt !== "number"
+  ) {
+    return false;
+  }
+  try {
+    process.kill(entry.ownerPid, 0);
+    return false;
+  } catch (error) {
+    return error?.code === "ESRCH";
+  }
+}
+
+function ownsReservation(entry, startedAt) {
+  return (
+    entry?.inProgressSince === startedAt &&
+    entry?.ownerPid === process.pid &&
+    entry?.ownerStartedAt === OWNER_STARTED_AT
+  );
+}
 
 // Shared with schedule-migration.mjs — one status file, one implementation of how it's
 // safely read/written/locked, rather than two copies that could drift.
@@ -142,7 +167,11 @@ export async function runScheduledJob({
         // see it. Without this, a Nitro tick and a migration catch-up landing on the
         // same period at nearly the same instant would both read the same stale
         // lastSuccessAt and both pass that guard.
-        if (typeof prior?.inProgressSince === "number" && now() - prior.inProgressSince < timeoutMs) {
+        if (
+          typeof prior?.inProgressSince === "number" &&
+          now() - prior.inProgressSince < timeoutMs &&
+          !reservationOwnerIsDead(prior)
+        ) {
           const ageS = Math.round((now() - prior.inProgressSince) / 1000);
           log(`schedule-runner: ${name} skipped — already in progress (started ${ageS}s ago)`);
           return false;
@@ -156,7 +185,13 @@ export async function runScheduledJob({
         startedAt = now();
         writeStatusAtomic(statusPath, {
           ...existing,
-          [name]: { ...prior, lastStartedAt: startedAt, inProgressSince: startedAt },
+          [name]: {
+            ...prior,
+            lastStartedAt: startedAt,
+            inProgressSince: startedAt,
+            ownerPid: process.pid,
+            ownerStartedAt: OWNER_STARTED_AT,
+          },
         });
         reserved = true;
         return true;
@@ -258,9 +293,22 @@ export async function runScheduledJob({
     if (outcome.error) log(`schedule-runner: ${name} spawn error: ${outcome.error.message}`);
 
     if (statusPath) {
-      await withStatusLock(statusPath, () => {
+      const completed = await withStatusLock(statusPath, (acquired) => {
+        if (!acquired) {
+          log(`schedule-runner: ${name} could not acquire the status lock to record completion`);
+          return false;
+        }
         const current = readStatus(statusPath);
-        const { inProgressSince: _drop, ...rest } = current[name] ?? {};
+        if (!ownsReservation(current[name], startedAt)) {
+          log(`schedule-runner: ${name} completion ignored because its reservation changed owner`);
+          return false;
+        }
+        const {
+          inProgressSince: _drop,
+          ownerPid: _ownerPid,
+          ownerStartedAt: _ownerStartedAt,
+          ...rest
+        } = current[name] ?? {};
         writeStatusAtomic(statusPath, {
           ...current,
           [name]: {
@@ -271,8 +319,9 @@ export async function runScheduledJob({
             ...(ok ? { lastSuccessAt: finishedAt } : {}),
           },
         });
+        return true;
       });
-      reserved = false;
+      if (completed) reserved = false;
     }
 
     return { skipped: false, ok, code: outcome.code, signal: outcome.signal };
@@ -289,13 +338,27 @@ export async function runScheduledJob({
     // don't leave the reservation stuck for the rest of timeoutMs for no reason.
     if (reserved && statusPath) {
       try {
-        await withStatusLock(statusPath, () => {
-          const current = readStatus(statusPath);
-          if (typeof current[name]?.inProgressSince === "number") {
-            const { inProgressSince: _drop, ...rest } = current[name];
-            writeStatusAtomic(statusPath, { ...current, [name]: rest });
+        const cleaned = await withStatusLock(statusPath, (acquired) => {
+          if (!acquired) {
+            log(`schedule-runner: ${name} could not acquire the status lock to clear its reservation`);
+            return false;
           }
+          const current = readStatus(statusPath);
+          if (ownsReservation(current[name], startedAt)) {
+            const {
+              inProgressSince: _drop,
+              ownerPid: _ownerPid,
+              ownerStartedAt: _ownerStartedAt,
+              ...rest
+            } = current[name];
+            writeStatusAtomic(statusPath, { ...current, [name]: rest });
+          } else {
+            log(`schedule-runner: ${name} cleanup ignored because its reservation changed owner`);
+            return false;
+          }
+          return true;
         });
+        if (cleaned) reserved = false;
       } catch {
         // best-effort cleanup only — a stuck reservation still self-heals via the
         // inProgressSince/timeoutMs staleness check above on the next attempt.

--- a/scripts/lib/schedule-runner.test.mjs
+++ b/scripts/lib/schedule-runner.test.mjs
@@ -410,6 +410,94 @@ test("a stale inProgressSince (older than timeoutMs — a presumed crash) does n
   assert.equal(result.ok, true);
 });
 
+test("a fresh reservation owned by a dead process is recovered immediately", async () => {
+  const root = await scaffold();
+  await writeFile(join(root, "ok.mjs"), "process.exit(0);\n");
+  const statusPath = join(root, "data/rollup-status.json");
+  await mkdir(join(root, "data"), { recursive: true });
+  await writeFile(statusPath, JSON.stringify({
+    "memory-daily": {
+      inProgressSince: Date.now(),
+      ownerPid: 2_147_483_647,
+      ownerStartedAt: Date.now(),
+    },
+  }));
+
+  const result = await runScheduledJob({
+    name: "memory-daily",
+    argv: ["ok.mjs"],
+    root,
+    nodeBin: process.execPath,
+    statusPath,
+    log: () => {},
+  });
+
+  assert.equal(result.skipped, false);
+  assert.equal(result.ok, true);
+});
+
+test("a fresh reservation owned by a live process still blocks duplicate entry", async () => {
+  const root = await scaffold();
+  await writeFile(join(root, "boom.mjs"), "process.exit(1);\n");
+  const statusPath = join(root, "data/rollup-status.json");
+  await mkdir(join(root, "data"), { recursive: true });
+  await writeFile(statusPath, JSON.stringify({
+    "memory-daily": {
+      inProgressSince: Date.now(),
+      ownerPid: process.pid,
+      ownerStartedAt: Date.now(),
+    },
+  }));
+  let spawned = false;
+
+  const result = await runScheduledJob({
+    name: "memory-daily",
+    argv: ["boom.mjs"],
+    root,
+    nodeBin: process.execPath,
+    statusPath,
+    log: () => {},
+    spawnImpl: (...args) => {
+      spawned = true;
+      return realSpawn(...args);
+    },
+  });
+
+  assert.equal(result.skipped, true);
+  assert.equal(spawned, false);
+});
+
+test("completion and finally do not modify status when their lock acquisition fails", async () => {
+  const root = await scaffold();
+  const statusPath = join(root, "data/rollup-status.json");
+  await mkdir(join(root, "data"), { recursive: true });
+  await writeFile(
+    join(root, "hold-status-lock.mjs"),
+    [
+      "import { writeFileSync } from 'node:fs';",
+      `writeFileSync(${JSON.stringify(`${statusPath}.lock`)}, 'held');`,
+      "process.exit(0);",
+    ].join("\n"),
+  );
+  const { log, lines } = collectLogs();
+
+  const result = await runScheduledJob({
+    name: "memory-daily",
+    argv: ["hold-status-lock.mjs"],
+    root,
+    nodeBin: process.execPath,
+    statusPath,
+    log,
+  });
+
+  assert.equal(result.ok, true, "the child outcome remains successful");
+  const status = JSON.parse(await readFile(statusPath, "utf8"));
+  assert.equal(typeof status["memory-daily"].inProgressSince, "number");
+  assert.equal(status["memory-daily"].lastFinishedAt, undefined);
+  assert.ok(lines.some((line) => line.includes("record completion")));
+  assert.ok(lines.some((line) => line.includes("clear its reservation")));
+});
+
 test("no lockPath: a clean exit right after SIGTERM cancels the pending hard-kill (no stale SIGKILL later)", async () => {
   // The direct-spawn case (digest has no lockPath): "child" IS the actual target, so its
   // exit really does mean the process is gone, and any still-pending hard-kill timer must


### PR DESCRIPTION
## Problem

Schedule migration used whole-file first-boot detection, tore down legacy timers before committing catch-up state, and could keep fresh reservations from dead processes. Completion callbacks also modified status after a failed lock acquisition.

## Changes

- seed every missing memory period under the existing status lock and exclude freshly seeded periods from the current catch-up
- commit the seed transaction before legacy systemd teardown
- add process ownership to reservations and recover a reservation whose owner PID is gone
- require an acquired status lock for completion and cleanup writes, and clear only the matching reservation

## Tests

- `node --test scripts/lib/schedule-migration.test.mjs scripts/lib/schedule-runner.test.mjs` (28 passed)
- full test matrix (528 passed)
- `npm run typecheck`
- `npm run build`
- the four new regression scenarios fail against `b464b74a` and pass on this branch

## Scope

No scheduler replacement, new lock framework, merge, release, tag, or version change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые возможности**
  * Повышена надежность миграции расписаний и восстановления прерванных задач.
  * Зависшие резервирования автоматически восстанавливаются после завершения процесса-владельца.
  * Catch-up-задачи запускаются безопаснее, с сохранением базового состояния.

* **Исправления**
  * Предотвращено удаление legacy-таймеров при невозможности сохранить статус миграции.
  * Исключены изменения статуса и очистка резервирования без подтвержденной блокировки.
  * Повторный запуск корректно блокируется, если текущая задача еще выполняется.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->