### PR TITLE
fix(telegram): make offset persistence fail closed

### DIFF
--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -356,7 +356,8 @@
 ## Telegram offset durability (v0.3.11)
 
 - Only ENOENT represents first run. Existing JSON, schema, permission, and I/O failures stop
-  the bridge before `getUpdates(-1)`, preserving Telegram's backlog for the systemd restart.
+  the bridge before `deleteWebhook(drop_pending=true)` or `getUpdates(-1)`, preserving
+  Telegram's backlog for the systemd restart.
 - Offset publication uses a private same-directory tmp file and one rename. Any save failure
   reaches the top-level fatal handler; the bridge never reports an unsaved cursor as durable.
 - The first-run tail lookup also fails closed on Telegram or response-shape errors; falling

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -352,3 +352,13 @@
   `session.reset()`, return with the same continuation token and assert the marker is gone.
   It guards Eve's documented contract ("reset retires a session so its continuation starts
   fresh"), which 0.27.13 honours — the `/new` failure was Iva's token shape, not Eve's reset.
+
+## Telegram offset durability (v0.3.11)
+
+- Only ENOENT represents first run. Existing JSON, schema, permission, and I/O failures stop
+  the bridge before `getUpdates(-1)`, preserving Telegram's backlog for the systemd restart.
+- Offset publication uses a private same-directory tmp file and one rename. Any save failure
+  reaches the top-level fatal handler; the bridge never reports an unsaved cursor as durable.
+- The first-run tail lookup also fails closed on Telegram or response-shape errors; falling
+  back to offset 0 after such an error could replay the installation backlog. An actually empty
+  Telegram result still stores offset 0. Per-call tmp suffixes avoid overlap.

--- a/scripts/lib/offset-store.mjs
+++ b/scripts/lib/offset-store.mjs
@@ -4,15 +4,20 @@
 // Маркер delivered сужает окно двойной доставки до единственного апдейта «в полёте»:
 // свежепереигранное (<= delivered, в пределах окна) пропускается — offset двигаем,
 // в eve не шлём.
-const asInt = (v) => (Number.isSafeInteger(v) ? v : null);
+const asInt = (v) => (Number.isSafeInteger(v) && v >= 0 ? v : null);
 
 export function parseOffsetFile(raw) {
-  try {
-    const j = JSON.parse(raw);
-    return { offset: asInt(j?.offset), delivered: asInt(j?.delivered) };
-  } catch {
-    return { offset: null, delivered: null };
+  const j = JSON.parse(raw);
+  if (
+    typeof j !== "object" ||
+    j === null ||
+    Array.isArray(j) ||
+    asInt(j.offset) === null ||
+    (j.delivered !== undefined && j.delivered !== null && asInt(j.delivered) === null)
+  ) {
+    throw new Error("Telegram offset file has invalid schema");
   }
+  return { offset: j.offset, delivered: j.delivered ?? null };
 }
 
 export function serializeOffsetFile(offset, delivered) {

--- a/scripts/lib/offset-store.test.mjs
+++ b/scripts/lib/offset-store.test.mjs
@@ -7,9 +7,13 @@ test("round-trip offset + delivered", () => {
   assert.deepEqual(parseOffsetFile(raw), { offset: 42, delivered: 41 });
 });
 
-test("легаси-файл без delivered и битый JSON", () => {
+test("легаси-файл без delivered читается, битый JSON отвергается", () => {
   assert.deepEqual(parseOffsetFile('{"offset":7}'), { offset: 7, delivered: null });
-  assert.deepEqual(parseOffsetFile("garbage"), { offset: null, delivered: null });
+  assert.deepEqual(parseOffsetFile('{"offset":7,"delivered":null}'), {
+    offset: 7,
+    delivered: null,
+  });
+  assert.throws(() => parseOffsetFile("garbage"), SyntaxError);
 });
 
 test("alreadyDelivered: пропускаем только то, что уже уходило в eve", () => {
@@ -24,6 +28,14 @@ test("маркер — не вечная граница: далёкое прош
   assert.equal(alreadyDelivered(4_999_999, 5_000_000), true, "в пределах окна — дубль");
 });
 
-test("нецелые и небезопасные значения в файле → null", () => {
-  assert.deepEqual(parseOffsetFile('{"offset":1.5,"delivered":"7"}'), { offset: null, delivered: null });
+test("невалидные значения делают существующий файл невалидным", () => {
+  for (const raw of [
+    '{"offset":1.5}',
+    '{"offset":9007199254740992}',
+    '{"offset":-1}',
+    '{"offset":7,"delivered":"7"}',
+    '{"offset":7,"delivered":-1}',
+  ]) {
+    assert.throws(() => parseOffsetFile(raw), /invalid schema/u);
+  }
 });

--- a/scripts/offset-durability.test.mjs
+++ b/scripts/offset-durability.test.mjs
@@ -1,0 +1,118 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fastForwardOffset, loadOffset, saveOffset } from "./poller/offset.mjs";
+
+test("corrupt JSON fails closed before getUpdates(-1)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "iva-offset-corrupt-test-"));
+  const file = join(dir, "telegram-offset.json");
+  writeFileSync(file, "{broken");
+  let getUpdatesCalls = 0;
+
+  await assert.rejects(async () => {
+    const loaded = await loadOffset({ file });
+    if (loaded.offset === null) {
+      await fastForwardOffset({
+        tgImpl: async () => {
+          getUpdatesCalls++;
+          return { ok: true, result: [] };
+        },
+      });
+    }
+  }, /failed to load Telegram offset/u);
+  assert.equal(getUpdatesCalls, 0);
+  assert.equal(readFileSync(file, "utf8"), "{broken");
+});
+
+test("ENOENT is the only first-run path and fast-forwards to the Telegram tail", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "iva-offset-first-run-test-"));
+  const file = join(dir, "telegram-offset.json");
+  assert.deepEqual(await loadOffset({ file }), { offset: null, delivered: null });
+
+  const calls = [];
+  const offset = await fastForwardOffset({
+    tgImpl: async (method, body) => {
+      calls.push([method, body]);
+      return { ok: true, result: [{ update_id: 40 }, { update_id: 41 }] };
+    },
+  });
+  assert.equal(offset, 42);
+  assert.deepEqual(calls, [["getUpdates", { offset: -1, timeout: 0 }]]);
+});
+
+test("first-run fast-forward propagates Telegram and response-shape failures", async () => {
+  for (const tgImpl of [
+    async () => { throw new Error("network down"); },
+    async () => ({ ok: false, description: "Telegram unavailable" }),
+    async () => ({ ok: true, result: null }),
+    async () => ({ ok: "true", result: [] }),
+    async () => ({ ok: true, result: [{}] }),
+    async () => ({ ok: true, result: [{ update_id: null }] }),
+    async () => ({ ok: true, result: [{ update_id: "41" }] }),
+    async () => ({ ok: true, result: [{ update_id: -1 }] }),
+    async () => ({ ok: true, result: [{ update_id: Number.MAX_SAFE_INTEGER }] }),
+  ]) {
+    const logs = [];
+    await assert.rejects(
+      fastForwardOffset({ tgImpl, logImpl: (...args) => logs.push(args.join(" ")) }),
+      /failed to fast-forward Telegram offset/u,
+    );
+    assert.equal(logs.length, 1);
+  }
+});
+
+test("saveOffset propagates a write error and never renames the cursor", async () => {
+  const dataDir = mkdtempSync(join(tmpdir(), "iva-offset-write-error-test-"));
+  const file = join(dataDir, "telegram-offset-test.json");
+  const calls = [];
+  await assert.rejects(
+    saveOffset(42, 41, {
+      file,
+      dataDir,
+      pid: 123,
+      tmpId: "write-error",
+      mkdirImpl: async () => {},
+      writeFileImpl: async (file, _data, options) => {
+        calls.push(["write", file, options]);
+        throw new Error("injected write failure");
+      },
+      renameImpl: async (...args) => calls.push(["rename", ...args]),
+      rmImpl: async (...args) => calls.push(["rm", ...args]),
+    }),
+    /injected write failure/u,
+  );
+  assert.equal(calls.some(([kind]) => kind === "rename"), false);
+  assert.equal(calls[0][1], `${file}.tmp-123-write-error`);
+  assert.deepEqual(calls[0][2], { encoding: "utf8", mode: 0o600, flag: "wx" });
+});
+
+test("saveOffset publishes a private tmp file with one atomic rename", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "iva-offset-save-test-"));
+  const file = join(dir, "telegram-offset.json");
+  const calls = [];
+  const writeFileImpl = async (path, data, options) => {
+    calls.push(["write", path, options]);
+    const { writeFile } = await import("node:fs/promises");
+    await writeFile(path, data, options);
+  };
+  const renameImpl = async (from, to) => {
+    calls.push(["rename", from, to]);
+    const { rename } = await import("node:fs/promises");
+    await rename(from, to);
+  };
+  await saveOffset(42, 41, {
+    file,
+    dataDir: dir,
+    pid: 456,
+    tmpId: "atomic",
+    writeFileImpl,
+    renameImpl,
+  });
+  assert.deepEqual(calls.map(([kind]) => kind), ["write", "rename"]);
+  assert.equal(calls[0][1], `${file}.tmp-456-atomic`);
+  assert.deepEqual(calls[1], ["rename", `${file}.tmp-456-atomic`, file]);
+  assert.deepEqual(JSON.parse(readFileSync(file, "utf8")), { offset: 42, delivered: 41 });
+  assert.equal(statSync(file).mode & 0o777, 0o600);
+});

--- a/scripts/poller/main.mjs
+++ b/scripts/poller/main.mjs
@@ -1,4 +1,3 @@
-import { existsSync } from "node:fs";
 import {
   COLLECT_QUIET_MS,
   collectorOffer,
@@ -9,7 +8,7 @@ import {
 } from "../lib/telegram-collect.mjs";
 import { alreadyDelivered } from "../lib/offset-store.mjs";
 import { isReplyToBot, migrateQueueFile } from "../lib/telegram-queue.mjs";
-import { ACCEPTANCE_ROUTE, OFFSET_FILE, ROUTE, SECRET, TOKEN, log, sleep } from "./config.mjs";
+import { ACCEPTANCE_ROUTE, ROUTE, SECRET, TOKEN, log, sleep } from "./config.mjs";
 import { tg } from "./transport.mjs";
 import { fastForwardOffset, loadOffset, saveOffset } from "./offset.mjs";
 import { QUEUE_FILE, reapStaleRuns, reconcileScopedResetIntents } from "./queue.mjs";
@@ -42,15 +41,18 @@ export async function main() {
   if (reconciledResets > 0) {
     log(`reconciled ${reconciledResets} durable private Telegram reset intent(s)`);
   }
+  // Читаем offset ДО любого destructive Telegram-вызова: EACCES/EIO/битый JSON
+  // останавливают мост, пока backlog ещё цел. Только подтверждённый ENOENT означает
+  // first run и разрешает drop_pending=true.
+  let { offset, delivered } = await loadOffset();
   // First run (no offset file) — drop the accumulated install backlog (drop_pending=true),
   // so old messages don't replay in a batch → parallel sessions on one chat (HookConflict).
   // On subsequent starts we do NOT drop the backlog (don't lose messages that arrived while the bridge was down).
-  const firstRun = !existsSync(OFFSET_FILE);
+  const firstRun = offset === null;
   const dw = await tg("deleteWebhook", { drop_pending_updates: firstRun });
   log("deleteWebhook:", dw.ok ? `ok (drop_pending=${firstRun})` : dw.description);
   await registerBotCommands();
 
-  let { offset, delivered } = await loadOffset();
   if (offset === null) {
     offset = await fastForwardOffset();
     log("first run — offset past the tail of the queue:", offset);

--- a/scripts/poller/offset.mjs
+++ b/scripts/poller/offset.mjs
@@ -1,28 +1,46 @@
-import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
 import { parseOffsetFile, serializeOffsetFile } from "../lib/offset-store.mjs";
 import { OFFSET_FILE, DATA_DIR, log } from "./config.mjs";
 import { tg } from "./transport.mjs";
 
 // offset: null ⇒ no file (first run) — distinguish from a genuine offset 0.
 // delivered: update_id последнего доставленного в eve апдейта (см. offset-store.mjs).
-async function loadOffset() {
+async function loadOffset({ file = OFFSET_FILE, readFileImpl = readFile } = {}) {
   try {
-    return parseOffsetFile(await readFile(OFFSET_FILE, "utf8"));
-  } catch {
-    return { offset: null, delivered: null };
+    return parseOffsetFile(await readFileImpl(file, "utf8"));
+  } catch (error) {
+    if (error?.code === "ENOENT") return { offset: null, delivered: null };
+    throw new Error(`failed to load Telegram offset ${file}: ${error.message}`, { cause: error });
   }
 }
 
 // First run: jump to the tail of the queue (last update_id + 1) to avoid replaying the
 // install backlog. drop_pending already clears Telegram's queue — this is a belt over suspenders.
-async function fastForwardOffset() {
+async function fastForwardOffset({ tgImpl = tg, logImpl = log } = {}) {
   try {
-    const data = await tg("getUpdates", { offset: -1, timeout: 0 });
-    const list = data.ok ? data.result || [] : [];
-    return list.length ? list[list.length - 1].update_id + 1 : 0;
-  } catch (e) {
-    log("fast-forward offset failed:", e.message);
-    return 0;
+    const data = await tgImpl("getUpdates", { offset: -1, timeout: 0 });
+    if (data?.ok !== true || !Array.isArray(data.result)) {
+      throw new Error(data?.description || "invalid getUpdates response");
+    }
+    const list = data.result;
+    // Текущий first-run контракт: пустой backlog получает числовой курсор 0,
+    // который можно сразу сохранить и передать следующему getUpdates.
+    if (list.length === 0) return 0;
+    const updateId = list[list.length - 1]?.update_id;
+    if (
+      !Number.isSafeInteger(updateId) ||
+      updateId < 0 ||
+      updateId >= Number.MAX_SAFE_INTEGER
+    ) {
+      throw new Error("invalid update_id in getUpdates response");
+    }
+    return updateId + 1;
+  } catch (error) {
+    logImpl("fast-forward offset failed:", error.message);
+    throw new Error(`failed to fast-forward Telegram offset: ${error.message}`, {
+      cause: error,
+    });
   }
 }
 
@@ -35,12 +53,36 @@ function chatKey(update) {
   const threadId = msg?.message_thread_id;
   return `${chatId}:${threadId ?? ""}`;
 }
-async function saveOffset(offset, delivered = null) {
+async function saveOffset(
+  offset,
+  delivered = null,
+  {
+    file = OFFSET_FILE,
+    dataDir = DATA_DIR,
+    pid = process.pid,
+    tmpId = randomUUID(),
+    mkdirImpl = mkdir,
+    writeFileImpl = writeFile,
+    renameImpl = rename,
+    rmImpl = rm,
+  } = {},
+) {
+  const tmp = `${file}.tmp-${pid}-${tmpId}`;
   try {
-    await mkdir(DATA_DIR, { recursive: true });
-    await writeFile(OFFSET_FILE, serializeOffsetFile(offset, delivered), "utf8");
-  } catch (e) {
-    log("offset save failed:", e.message);
+    await mkdirImpl(dataDir, { recursive: true });
+    await writeFileImpl(tmp, serializeOffsetFile(offset, delivered), {
+      encoding: "utf8",
+      mode: 0o600,
+      flag: "wx",
+    });
+    await renameImpl(tmp, file);
+  } catch (error) {
+    try {
+      await rmImpl(tmp, { force: true });
+    } catch {
+      /* исходная ошибка записи важнее ошибки уборки tmp */
+    }
+    throw new Error(`failed to save Telegram offset ${file}: ${error.message}`, { cause: error });
   }
 }
 


### PR DESCRIPTION
## Problem

The Telegram bridge treated every offset read failure as first run, so corrupt JSON or an operational filesystem error could trigger `getUpdates(-1)` and discard the backlog. Offset writes also updated the live file directly and swallowed failures.

## Changes

- treat only ENOENT as first run and surface JSON, schema, permission, and I/O failures
- validate the fast-forward response and fail instead of falling back after Telegram errors
- publish a private 0600 same-directory temporary file through one atomic rename
- propagate write and rename failures to the poller fatal path

## Tests

- `node --test scripts/lib/offset-store.test.mjs scripts/offset-durability.test.mjs` (10 passed)
- `node --test scripts/telegram-poll-queue-durable.test.mjs` (13 passed)
- full test matrix (528 passed)
- `npm run typecheck`
- `npm run build`
- the corrupt-file regression fails against `b464b74a` before any `getUpdates(-1)` call and passes here

## Scope

No queue timeout, direct-delivery path, dependency, version, release, or tag changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Исправления**
  - Повышена надёжность сохранения и загрузки Telegram offset.
  - Повреждённые или некорректные данные теперь отклоняются с ошибкой.
  - Ошибки чтения состояния и обращения к Telegram корректно останавливают обработку.
  - Первый запуск определяется только при отсутствии файла состояния.
  - Сохранение выполняется безопасно: через временный файл и атомарную замену.
  - Пустой результат обновлений корректно сохраняется с offset `0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->