### PR TITLE
fix(memory): preserve configuration integrity

### DIFF
--- a/agent/instrumentation.ts
+++ b/agent/instrumentation.ts
@@ -28,6 +28,7 @@ import { homedir } from "node:os";
 import { defineInstrumentation } from "eve/instrumentation";
 import { probeEveHealth } from "../scripts/lib/config-transaction.mjs";
 import { runScheduleMigration } from "../scripts/lib/schedule-migration.mjs";
+import { validateTimeZone } from "../scripts/lib/timezone.mjs";
 
 const log = (...args: unknown[]) => console.log(new Date().toISOString(), ...args);
 
@@ -37,29 +38,18 @@ export default defineInstrumentation({
   recordInputs: false,
   recordOutputs: false,
   setup() {
-    // Same fallback the poller/rollup scripts use — see scripts/poller/config.mjs — kept
-    // here too because Nitro's schedule runner (unlike those) reads no .env of its own.
-    // Plain `||=` would coerce a genuinely unset ASSISTANT_TIMEZONE into the literal
-    // string "undefined" (process.env assignments always stringify), which then makes
-    // Intl.DateTimeFormat throw — so only assign when there is an actual value to assign.
-    if (!process.env.TZ && process.env.ASSISTANT_TIMEZONE) {
-      process.env.TZ = process.env.ASSISTANT_TIMEZONE;
-    }
+    // Nitro's schedule runner reads the process timezone. Validate before assigning TZ:
+    // process.env stringifies every value, and an unknown zone would make every Intl
+    // consumer throw a RangeError.
     const rawTz =
       process.env.ASSISTANT_TIMEZONE ||
       (process.env.TZ && process.env.TZ !== "undefined" ? process.env.TZ : "UTC");
-    // bin/iva.mjs validates ASSISTANT_TIMEZONE with a regex before ever writing it into a
-    // unit file; this is the other consumer of the same raw env value, so it needs the
-    // same defense — an invalid zone would otherwise reach Intl.DateTimeFormat inside
-    // schedule-migration.mjs's zonedParts(), which throws, which the outer catch below
-    // swallows, silently skipping catch-up on every boot.
-    let tz = "UTC";
-    try {
-      new Intl.DateTimeFormat("en-US", { timeZone: rawTz });
-      tz = rawTz;
-    } catch {
+    const validatedTz = validateTimeZone(rawTz);
+    const tz = validatedTz ?? "UTC";
+    if (validatedTz === null) {
       log(`schedule-migration: invalid timezone ${rawTz} — falling back to UTC`);
     }
+    process.env.TZ = tz;
 
     // Never let this block or fail server startup: wrap synchronously, and treat the
     // whole async chain below as fire-and-forget with its own catch.

--- a/agent/lib/frontmatter.ts
+++ b/agent/lib/frontmatter.ts
@@ -31,11 +31,18 @@ export function parseFrontmatter(content: string): ParsedFrontmatter {
   let multilineKey: string | null = null;
   let multilineMode: "fold" | "literal" | "list" | "pending" | null = null;
   let multilineSep = " ";
+  let multilineBlankLines = 0;
 
   for (const line of rawLines) {
     const stripped = line.trim();
     // ЛЮБОЙ ведущий пробел/таб = continuation: YAML допускает и одиночный пробел.
     const indented = /^[ \t]/.test(line);
+
+    // Пустая строка внутри block scalar разделяет абзацы и не завершает ключ.
+    if (multilineKey && !stripped) {
+      multilineBlankLines++;
+      continue;
+    }
 
     if (multilineKey && indented) {
       if (multilineMode === "pending") {
@@ -53,8 +60,12 @@ export function parseFrontmatter(content: string): ParsedFrontmatter {
         if (item) (fields[multilineKey] as string[]).push(unquote(item));
       } else {
         const prev = (fields[multilineKey] as string) || "";
-        fields[multilineKey] = (prev + multilineSep + stripped).trim();
+        const separator = multilineBlankLines
+          ? "\n".repeat(multilineBlankLines + (multilineMode === "literal" ? 1 : 0))
+          : multilineSep;
+        fields[multilineKey] = (prev + separator + stripped).trim();
       }
+      multilineBlankLines = 0;
       continue;
     }
 
@@ -63,6 +74,7 @@ export function parseFrontmatter(content: string): ParsedFrontmatter {
       multilineKey = null;
       multilineMode = null;
       multilineSep = " ";
+      multilineBlankLines = 0;
     }
 
     if (!stripped || stripped.startsWith("#")) continue;
@@ -185,6 +197,9 @@ export function formatField(key: string, val: FmValue): string {
   if (Array.isArray(val)) return `${key}: [${val.map(formatItem).join(", ")}]`;
   const s = String(val);
   if (s === "") return `${key}:`;
+  if (s.includes("\n")) {
+    return `${key}: |-\n${s.split("\n").map((line) => `  ${line}`).join("\n")}`;
+  }
   return needsQuote(s) ? `${key}: ${JSON.stringify(s)}` : `${key}: ${s}`;
 }
 

--- a/agent/lib/run-status.mjs
+++ b/agent/lib/run-status.mjs
@@ -56,7 +56,9 @@ function readObject(file) {
   try {
     const parsed = JSON.parse(readFileSync(file, "utf8"));
     if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-      throw new Error(`${file} does not contain a JSON object`);
+      const error = new Error(`${file} does not contain a JSON object`);
+      error.code = "ERR_RUN_STATUS_SCHEMA";
+      throw error;
     }
     return parsed;
   } catch (error) {
@@ -65,13 +67,18 @@ function readObject(file) {
   }
 }
 
+function isCorruptStatus(error) {
+  return error instanceof SyntaxError || error?.code === "ERR_RUN_STATUS_SCHEMA";
+}
+
 function readLegacy(chatKey) {
   try {
     return readObject(LEGACY_STATUS_FILE)?.[chatKey] ?? null;
-  } catch {
+  } catch (error) {
     // Старый код считал битый whole-map пустым. Чтение остаётся совместимым,
     // но новый код legacy-файл не переписывает и не рискует остальными чатами.
-    return null;
+    if (isCorruptStatus(error)) return null;
+    throw error;
   }
 }
 
@@ -79,7 +86,8 @@ function readPerChat(chatKey) {
   const file = statusFileOf(chatKey);
   try {
     return readObject(file);
-  } catch {
+  } catch (error) {
+    if (!isCorruptStatus(error)) throw error;
     const backup = `${file}.corrupt-${Date.now()}-${randomUUID()}`;
     try {
       renameSync(file, backup);

--- a/agent/lib/run-status.test.mjs
+++ b/agent/lib/run-status.test.mjs
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import {
+  chmodSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -221,4 +222,24 @@ test("one corrupt per-chat file is quarantined without blocking neighbors", () =
   // Compare after the healthy replacement exists: returning {} and overwriting
   // the damaged file would lose these bytes.
   assert.equal(readFileSync(join(dir, backups[0]), "utf8"), corrupt);
+});
+
+test("an operational read error is rethrown and the status file is not quarantined", () => {
+  const key = "unreadable:";
+  status.setChatStatus(key, { status: "running", sessionId: "keep" });
+  const dir = join(dataDir, "run-status.d");
+  const encoded = Buffer.from(key, "utf8").toString("base64url");
+  const file = join(dir, `${encoded}.json`);
+  chmodSync(file, 0o000);
+
+  try {
+    assert.throws(() => status.getChatStatus(key), (error) => error?.code === "EACCES");
+    assert.equal(existsSync(file), true);
+    assert.equal(
+      readdirSync(dir).some((name) => name.startsWith(`${encoded}.json.corrupt-`)),
+      false,
+    );
+  } finally {
+    chmodSync(file, 0o600);
+  }
 });

--- a/agent/lib/run-status.test.mjs
+++ b/agent/lib/run-status.test.mjs
@@ -224,7 +224,9 @@ test("one corrupt per-chat file is quarantined without blocking neighbors", () =
   assert.equal(readFileSync(join(dir, backups[0]), "utf8"), corrupt);
 });
 
-test("an operational read error is rethrown and the status file is not quarantined", () => {
+test("an operational read error is rethrown and the status file is not quarantined", {
+  skip: process.getuid?.() === 0 ? "root bypasses file permission bits" : false,
+}, () => {
   const key = "unreadable:";
   status.setChatStatus(key, { status: "running", sessionId: "keep" });
   const dir = join(dataDir, "run-status.d");

--- a/bin/iva.mjs
+++ b/bin/iva.mjs
@@ -28,6 +28,7 @@ import {
 } from "../scripts/lib/config-transaction.mjs";
 import { userbotSyncArgs } from "../scripts/lib/userbot-deps.mjs";
 import { probeUserbotHealth } from "../scripts/lib/userbot-health.mjs";
+import { validateTimeZone } from "../scripts/lib/timezone.mjs";
 import {
   acquireUpdateLock,
   commitThenRunPostCommit,
@@ -153,7 +154,12 @@ function ensureAssistantBearer({ quiet = false } = {}) {
 // local time) need — one place so the fallback/validation rule can't drift between them.
 function configuredTimezone() {
   const raw = (readEnv().ASSISTANT_TIMEZONE || "UTC").trim();
-  return /^[A-Za-z0-9_+\/-]+$/.test(raw) ? raw : "UTC";
+  if (/^[A-Za-z0-9_+\/-]+$/.test(raw)) {
+    const timezone = validateTimeZone(raw);
+    if (timezone) return timezone;
+  }
+  warn(`invalid ASSISTANT_TIMEZONE=${JSON.stringify(raw)}; using UTC`);
+  return "UTC";
 }
 
 // ── systemd units: single source of truth ─────────────────────────────────

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -352,3 +352,15 @@
   `session.reset()`, return with the same continuation token and assert the marker is gone.
   It guards Eve's documented contract ("reset retires a session so its continuation starts
   fresh"), which 0.27.13 honours — the `/new` failure was Iva's token shape, not Eve's reset.
+
+## Memory and configuration integrity (v0.3.11)
+
+- TypeScript and Python frontmatter parsers keep blank lines inside block scalars. Strings
+  containing newlines are serialized as literal blocks so parse-write-parse is lossless.
+- One Intl-backed timezone validator is shared by setup, startup instrumentation, and the
+  CLI unit generator. Runtime TZ is always assigned a validated zone or UTC.
+- Per-chat run-status quarantines only JSON/schema corruption. Filesystem failures remain
+  visible to callers and leave the original status path untouched.
+- CORE truncation removes a mutable bullet when fewer than two marker characters survive;
+  a complete `-` plus its following space may still receive the ellipsis. Pointers remain
+  immutable.

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -361,6 +361,8 @@
   CLI unit generator. Runtime TZ is always assigned a validated zone or UTC.
 - Per-chat run-status quarantines only JSON/schema corruption. Filesystem failures remain
   visible to callers and leave the original status path untouched.
+- The real chmod-based EACCES regression is skipped under UID 0 because root bypasses
+  discretionary permission bits; ordinary users and CI still exercise the filesystem path.
 - CORE truncation removes a mutable bullet when fewer than two marker characters survive;
   a complete `-` plus its following space may still receive the ellipsis. Pointers remain
   immutable.

--- a/scripts/autograph/common.py
+++ b/scripts/autograph/common.py
@@ -192,10 +192,16 @@ def parse_frontmatter(content: str) -> tuple[dict, str, list[str]]:
     multiline_key = None
     multiline_mode = None  # fold | literal | list | pending
     multiline_sep = ' '  # >- fold (space), |- literal (newline)
+    multiline_blank_lines = 0
 
     for line in raw_lines:
         stripped = line.strip()
         indented = line.startswith((' ', '\t'))
+
+        # Пустая строка внутри block scalar разделяет абзацы и не завершает ключ.
+        if multiline_key and not stripped:
+            multiline_blank_lines += 1
+            continue
 
         # Multi-line continuation
         if multiline_key and indented:
@@ -214,7 +220,11 @@ def parse_frontmatter(content: str) -> tuple[dict, str, list[str]]:
                     fields[multiline_key].append(item.strip("'\""))
             else:
                 prev = fields.get(multiline_key, '') or ''
-                fields[multiline_key] = (prev + multiline_sep + stripped).strip()
+                sep = multiline_sep
+                if multiline_blank_lines:
+                    sep = '\n' * (multiline_blank_lines + (1 if multiline_mode == 'literal' else 0))
+                fields[multiline_key] = (prev + sep + stripped).strip()
+            multiline_blank_lines = 0
             continue
 
         if multiline_key and not indented:
@@ -223,6 +233,7 @@ def parse_frontmatter(content: str) -> tuple[dict, str, list[str]]:
             multiline_key = None
             multiline_mode = None
             multiline_sep = ' '
+            multiline_blank_lines = 0
 
         if not stripped or stripped.startswith('#'):
             continue
@@ -366,6 +377,9 @@ def format_field(key: str, val) -> str:
     if isinstance(val, (int, float)):
         return f"{key}: {val}"
     s = str(val)
+    if '\n' in s:
+        indented = '\n'.join(f'  {line}' for line in s.split('\n'))
+        return f'{key}: |-\n{indented}'
     if key == 'description' and s and len(s) > 80:
         return f'{key}: >-\n  {s}'
     if YAML_SPECIAL.search(s):

--- a/scripts/autograph/tests/test_autograph.py
+++ b/scripts/autograph/tests/test_autograph.py
@@ -451,6 +451,33 @@ def main():
         test("literal |- rewrite: no leaked continuation lines",
              not continuation_leaked,
              f"got: {rebuilt_lit}")
+        paragraph_folded = ("---\ndescription: >-\n"
+                            "  First paragraph\n\n"
+                            "  Second paragraph\n\n\n"
+                            "  Third paragraph\nstatus: active\n---\n")
+        fm_paragraphs, _, lines_paragraphs = parse_frontmatter(paragraph_folded)
+        expected_folded = "First paragraph\nSecond paragraph\n\nThird paragraph"
+        test("folded paragraphs survive blank lines",
+             fm_paragraphs.get('description') == expected_folded,
+             f"got: {fm_paragraphs.get('description')!r}")
+        folded_written = write_frontmatter(fm_paragraphs, lines_paragraphs)
+        folded_again, _, _ = parse_frontmatter(f"---\n{folded_written}\n---\n")
+        test("folded paragraphs survive parse-write-parse",
+             folded_again.get('description') == expected_folded,
+             f"got: {folded_again.get('description')!r}")
+        paragraph_literal = ("---\nnote: |-\n"
+                             "  Line one\n\n"
+                             "  Line two\nkind: note\n---\n")
+        fm_literal_paragraphs, _, lines_literal_paragraphs = parse_frontmatter(paragraph_literal)
+        expected_literal = "Line one\n\nLine two"
+        test("literal paragraphs survive blank lines",
+             fm_literal_paragraphs.get('note') == expected_literal,
+             f"got: {fm_literal_paragraphs.get('note')!r}")
+        literal_written = write_frontmatter(fm_literal_paragraphs, lines_literal_paragraphs)
+        literal_again, _, _ = parse_frontmatter(f"---\n{literal_written}\n---\n")
+        test("literal paragraphs survive parse-write-parse",
+             literal_again.get('note') == expected_literal,
+             f"got: {literal_again.get('note')!r}")
         # Untouched multiline key preserved as-is
         partial_fields = {'tags': ['ai', 'updated']}  # only update tags, not description
         rebuilt_partial = write_frontmatter(partial_fields, orig_ml)

--- a/scripts/core-clamp.test.mjs
+++ b/scripts/core-clamp.test.mjs
@@ -15,6 +15,17 @@ function pointers(text, heading = "## Указатели") {
   return text.slice(text.indexOf(heading));
 }
 
+function tinyPrefixFixture(prefixLength) {
+  const before = "# CORE — ядро памяти\n\n## Custom\n";
+  const between = "\n## Пользователь\n";
+  const after = "\n\n## Указатели\n- pointer stays exact\n";
+  const bullet = `- ${"x".repeat(78)}`;
+  const fixedWithoutPadding = before.length + between.length + after.length;
+  const protectedPaddingLength = CORE_CAP - prefixLength - 1 - fixedWithoutPadding;
+  assert.ok(protectedPaddingLength > 0);
+  return `${before}${"p".repeat(protectedPaddingLength)}${between}${bullet}${after}`;
+}
+
 test("under-cap input is returned byte-identically", () => {
   const input =
     "# CORE — ядро памяти\r\n\r\n" +
@@ -120,6 +131,22 @@ test("clamp is idempotent", () => {
   );
   const once = clampCore(input);
   assert.equal(clampCore(once), once);
+});
+
+test("prefix 0/1 removes the mutable bullet; prefix 2 keeps a complete bullet marker", () => {
+  for (const prefixLength of [0, 1, 2]) {
+    const input = tinyPrefixFixture(prefixLength);
+    const output = clampCore(input);
+    assert.ok(output.length <= CORE_CAP);
+    assert.equal(pointers(output), pointers(input));
+    if (prefixLength < 2) {
+      assert.doesNotMatch(output, /- x/u);
+      assert.doesNotMatch(output, /…/u);
+    } else {
+      assert.match(output, /## Пользователь\n- …\n/u);
+    }
+    assert.equal(clampCore(output), output);
+  }
 });
 
 test("all H1/H2 headings and their formatting are preserved", () => {

--- a/scripts/frontmatter-edge.test.mjs
+++ b/scripts/frontmatter-edge.test.mjs
@@ -35,3 +35,23 @@ test("пустая строка внутри перезаписываемого 
   assert.match(out, /description: новое/);
   assert.match(out, /status: active/);
 });
+
+test("folded >- сохраняет абзацы через parse → write → parse", () => {
+  const source = "---\ndescription: >-\n  Первый абзац\n\n  Второй абзац\n\n\n  Третий абзац\nstatus: active\n---\nbody";
+  const first = parseFrontmatter(source);
+  assert.equal(first.fields.description, "Первый абзац\nВторой абзац\n\nТретий абзац");
+  const written = writeFrontmatter(first.fields, first.lines);
+  const second = parseFrontmatter(`---\n${written}\n---\nbody`);
+  assert.equal(second.fields.description, first.fields.description);
+  assert.equal(second.fields.status, "active");
+});
+
+test("literal |- сохраняет пустую строку между абзацами через round-trip", () => {
+  const source = "---\nnote: |-\n  Строка один\n\n  Строка два\nkind: note\n---\nbody";
+  const first = parseFrontmatter(source);
+  assert.equal(first.fields.note, "Строка один\n\nСтрока два");
+  const written = writeFrontmatter(first.fields, first.lines);
+  const second = parseFrontmatter(`---\n${written}\n---\nbody`);
+  assert.equal(second.fields.note, first.fields.note);
+  assert.equal(second.fields.kind, "note");
+});

--- a/scripts/lib/timezone.d.mts
+++ b/scripts/lib/timezone.d.mts
@@ -1,0 +1,1 @@
+export function validateTimeZone(value: unknown): string | null;

--- a/scripts/lib/timezone.mjs
+++ b/scripts/lib/timezone.mjs
@@ -1,0 +1,12 @@
+export function validateTimeZone(value) {
+  if (typeof value !== "string") return null;
+  const candidate = value.trim();
+  if (!candidate) return null;
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: candidate });
+    return candidate;
+  } catch (error) {
+    if (error instanceof RangeError) return null;
+    throw error;
+  }
+}

--- a/scripts/lib/timezone.test.mjs
+++ b/scripts/lib/timezone.test.mjs
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { validateTimeZone } from "./timezone.mjs";
+
+test("timezone validation accepts a real IANA zone", () => {
+  assert.equal(validateTimeZone(" Asia/Tashkent "), "Asia/Tashkent");
+});
+
+test("timezone validation rejects a syntactically plausible unknown zone", () => {
+  assert.equal(validateTimeZone("Mars/Olympus"), null);
+});
+
+test("timezone validation rejects an undefined value", () => {
+  assert.equal(validateTimeZone(undefined), null);
+});

--- a/scripts/memory/core-clamp.mjs
+++ b/scripts/memory/core-clamp.mjs
@@ -137,6 +137,10 @@ function truncateToCap(lines) {
   ) {
     prefixLength -= 1;
   }
+  if (prefixLength < 2) {
+    line.removed = true;
+    return render(lines);
+  }
   line.replacement = `${line.content.slice(0, prefixLength)}…${line.ending}`;
   return render(lines);
 }

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -22,6 +22,7 @@ import {
   validateModelSelection,
 } from "./lib/model-validation.mjs";
 import { keptSetupWritePlan } from "./lib/setup-keep.mjs";
+import { validateTimeZone } from "./lib/timezone.mjs";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const SOURCE_ENV_PATH = join(ROOT, ".env");
@@ -662,10 +663,18 @@ async function main() {
   // ── Step 5: timezone, vault, port ─────────────────────────────────
   head(5, t("Timezone and memory storage", "Часовой пояс и хранилище памяти"));
   console.log(`  ${t("The timezone lets Iva use your real local time, not the server's.", "Часовой пояс нужен, чтобы Iva понимала ваше реальное время, а не время сервера.")}`);
-  out.ASSISTANT_TIMEZONE = await ask(
-    `  ${t("Timezone (IANA, e.g. Asia/Almaty, Asia/Tashkent, Europe/Berlin)", "Часовой пояс (IANA, напр. Asia/Almaty, Asia/Tashkent, Europe/Moscow)")}`,
-    out.ASSISTANT_TIMEZONE || "Asia/Almaty",
-  );
+  for (;;) {
+    const candidate = await ask(
+      `  ${t("Timezone (IANA, e.g. Asia/Almaty, Asia/Tashkent, Europe/Berlin)", "Часовой пояс (IANA, напр. Asia/Almaty, Asia/Tashkent, Europe/Moscow)")}`,
+      out.ASSISTANT_TIMEZONE || "Asia/Almaty",
+    );
+    const timezone = validateTimeZone(candidate);
+    if (timezone) {
+      out.ASSISTANT_TIMEZONE = timezone;
+      break;
+    }
+    console.log(`${C.r}  ${t("Unknown IANA timezone. Try again.", "Неизвестный часовой пояс IANA. Введите ещё раз.")}${C.x}`);
+  }
   out.ASSISTANT_VAULT_DIR = await ask(`  ${t("Vault directory (memory + git backup)", "Каталог vault (память + git-бэкап)")}`, out.ASSISTANT_VAULT_DIR || "vault");
   out.ASSISTANT_DATA_DIR = out.ASSISTANT_DATA_DIR || "data";
   // Off-the-beaten-path port: 3000/8000/8080 are often taken on a typical VPS (docker etc.). The server


### PR DESCRIPTION
## Summary
- preserve blank lines in multiline frontmatter across TypeScript and Python parsers
- validate configured timezones before assigning TZ
- quarantine only corrupt run-status data while surfacing operational filesystem errors
- remove unusable CORE bullet fragments at very small clamp prefixes

## Validation
- `node --test`: 530 passed
- `uv run pytest scripts/autograph/`: 265 passed
- `npm run typecheck`
- `npm run build`

## Spec deviations
None.