### PR TITLE
fix: align memory graph health with vault contract

### DIFF
--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -468,3 +468,9 @@
   affects scoring, not whether an exact pending parent is considered broken.
 - Doctor supplies its timezone-aware local day through `--as-of`, avoiding midnight
   disagreements between the Node orchestrator and Python graph process.
+- A not-yet-materialized exact parent supplies a virtual incoming signal only for
+  orphan scoring; persisted graph edges still contain resolved files exclusively.
+- Wiki targets resolve before the audio-embed exemption, so a real `voice.ogg.md`
+  note remains linkable while a missing `voice.ogg` attachment stays ignored.
+- The full Node matrix initially hit the existing deadline-probe timing test once;
+  its isolated rerun and the complete 568-test rerun both passed.

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -450,3 +450,15 @@
   with stock Node runtimes that do not load TypeScript.
 - Preserved the agent import contract through a thin TypeScript re-export.
 - Reminder persistence across reboot remains tracked separately in issue #117.
+
+## fix/memory-health-contract
+
+- Health quality is scoped by the existing `node_types` and `path_type_hints`; raw
+  transcripts remain append-only graph nodes and require no schema migration.
+- Existing structural totals remain visible. Managed-card counters drive the score,
+  while the general description ratio is exposed separately as `all_desc_coverage`.
+- Future parents are recognized only for exact daily-to-weekly, weekly-to-monthly,
+  and monthly-to-yearly relationships, including their scheduled creation day.
+- An absent parent becomes broken the day after its rollup was scheduled to run.
+- Audio embeds accepted by Telegram (`.ogg`, `.opus`, `.m4a`, `.wav`) are excluded
+  from broken-link checks; similarly named Markdown files remain graph targets.

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -462,3 +462,9 @@
 - An absent parent becomes broken the day after its rollup was scheduled to run.
 - Audio embeds accepted by Telegram (`.ogg`, `.opus`, `.m4a`, `.wav`) are excluded
   from broken-link checks; similarly named Markdown files remain graph targets.
+- `graph.py` discovers `<vault>/schema.json` for legacy CLI calls and falls back to
+  all-node health only when no schema exists.
+- Future rollup classification is structural even under legacy schemas; managed scope
+  affects scoring, not whether an exact pending parent is considered broken.
+- Doctor supplies its timezone-aware local day through `--as-of`, avoiding midnight
+  disagreements between the Node orchestrator and Python graph process.

--- a/scripts/autograph/graph.py
+++ b/scripts/autograph/graph.py
@@ -15,7 +15,7 @@ import json
 import re
 import sys
 from pathlib import Path
-from datetime import datetime
+from datetime import date, datetime, timedelta
 from collections import defaultdict
 
 from common import (
@@ -24,10 +24,81 @@ from common import (
     build_link_index, normalize_link_target, resolve_link_target, is_hub_path
 )
 
-EMBED_EXTS = {'.jpg', '.jpeg', '.png', '.gif', '.svg', '.pdf', '.mp3', '.mp4', '.webp'}
+EMBED_EXTS = {'.jpg', '.jpeg', '.png', '.gif', '.svg', '.pdf', '.mp3', '.mp4', '.webp',
+              '.ogg', '.opus', '.m4a', '.wav'}
 
 
-def build_graph(vault_dir: Path, schema: dict) -> dict:
+def _matches_path_hint(file_rel_path: str, pattern: str) -> bool:
+    """Match a schema path hint on directory boundaries."""
+    path = file_rel_path.lower().strip('/')
+    hint = str(pattern).lower().strip('/')
+    if not hint:
+        return False
+    return path == hint or path.startswith(f'{hint}/') or f'/{hint}/' in f'/{path}'
+
+
+def is_managed_card(file_rel_path: str, frontmatter: dict, schema: dict) -> bool:
+    """Return whether a Markdown node belongs to the schema-managed card set."""
+    valid_types = set((schema.get('node_types') or {}).keys())
+    if frontmatter.get('type') in valid_types:
+        return True
+    for pattern, hinted_type in (schema.get('path_type_hints') or {}).items():
+        if pattern == '_comment' or hinted_type not in valid_types:
+            continue
+        if _matches_path_hint(file_rel_path, pattern):
+            return True
+    return False
+
+
+def _next_month(year: int, month: int) -> date:
+    if month == 12:
+        return date(year + 1, 1, 1)
+    return date(year, month + 1, 1)
+
+
+def expected_future_link(source: str, target: str, today: date | None = None) -> bool:
+    """Classify an absent, exact Iva rollup parent that is not overdue yet.
+
+    The scheduled creation day is included. Starting the next calendar day an
+    absent parent is a real broken link.
+    """
+    today = today or date.today()
+
+    daily_match = re.fullmatch(r'summaries/daily/(\d{4})-(\d{2})-(\d{2})', source)
+    if daily_match:
+        try:
+            child_date = date(*(int(value) for value in daily_match.groups()))
+        except ValueError:
+            return False
+        iso_year, iso_week, _ = child_date.isocalendar()
+        expected = f'weekly/{iso_year:04d}-W{iso_week:02d}'
+        creation_day = date.fromisocalendar(iso_year, iso_week, 1) + timedelta(days=7)
+        return target == expected and today <= creation_day
+
+    weekly_match = re.fullmatch(r'weekly/(\d{4})-W(\d{2})', source)
+    if weekly_match:
+        iso_year, iso_week = (int(value) for value in weekly_match.groups())
+        try:
+            thursday = date.fromisocalendar(iso_year, iso_week, 4)
+        except ValueError:
+            return False
+        expected = f'monthly/{thursday.year:04d}-{thursday.month:02d}'
+        return target == expected and today <= _next_month(thursday.year, thursday.month)
+
+    monthly_match = re.fullmatch(r'monthly/(\d{4})-(\d{2})', source)
+    if monthly_match:
+        year, month = (int(value) for value in monthly_match.groups())
+        try:
+            date(year, month, 1)
+        except ValueError:
+            return False
+        expected = f'yearly/{year:04d}'
+        return target == expected and today <= date(year + 1, 1, 1)
+
+    return False
+
+
+def build_graph(vault_dir: Path, schema: dict, today: date | None = None) -> dict:
     """Scan vault, build full graph structure."""
     vault_dir = Path(vault_dir)
     files = walk_vault(vault_dir)
@@ -37,6 +108,7 @@ def build_graph(vault_dir: Path, schema: dict) -> dict:
     nodes = {}
     all_links = []      # (source, raw_target, resolved_target)
     broken_links = []   # (source, raw_target)
+    future_links = []   # (source, raw_target)
 
     for md in files:
         rp = rel_path(md, vault_dir)
@@ -53,6 +125,7 @@ def build_graph(vault_dir: Path, schema: dict) -> dict:
         domain = infer_domain(rp, schema)
         has_desc = bool(fm.get('description', ''))
         card_type = fm.get('type', 'unknown')
+        managed = is_managed_card(rp, fm, schema)
 
         outgoing = []
         links = extract_wikilinks(body if body else content)
@@ -65,6 +138,8 @@ def build_graph(vault_dir: Path, schema: dict) -> dict:
             if resolved:
                 outgoing.append(resolved)
                 all_links.append((rp_noext, target_clean, resolved))
+            elif managed and expected_future_link(rp_noext, target_clean, today=today):
+                future_links.append((rp_noext, target_clean))
             else:
                 broken_links.append((rp_noext, target_clean))
 
@@ -75,6 +150,7 @@ def build_graph(vault_dir: Path, schema: dict) -> dict:
             'outgoing': outgoing,
             'incoming': [],  # filled below
             'link_count': len(outgoing),
+            'managed': managed,
         }
 
     # Build incoming links
@@ -90,15 +166,27 @@ def build_graph(vault_dir: Path, schema: dict) -> dict:
     orphans = [p for p, n in nodes.items() if not n['incoming'] and not is_hub_path(p)]
     dead_ends = [p for p, n in nodes.items() if not n['outgoing'] and n['incoming']]
     desc_count = sum(1 for n in nodes.values() if n['has_description'])
-    desc_ratio = desc_count / max(total, 1)
+    all_desc_ratio = desc_count / max(total, 1)
 
-    orphan_ratio = len(orphans) / max(total, 1)
-    broken_ratio = len(broken_links) / max(total, 1)
+    managed_nodes = {path: node for path, node in nodes.items() if node['managed']}
+    managed_total = len(managed_nodes)
+    managed_orphans = [path for path, node in managed_nodes.items()
+                       if not node['incoming'] and not is_hub_path(path)]
+    managed_broken_links = [(source, target) for source, target in broken_links
+                            if nodes.get(source, {}).get('managed')]
+    managed_resolved_links = sum(node['link_count'] for node in managed_nodes.values())
+    managed_link_count = managed_resolved_links + len(future_links)
+    managed_avg_links = managed_link_count / max(managed_total, 1)
+    managed_desc_count = sum(1 for node in managed_nodes.values() if node['has_description'])
+    desc_ratio = managed_desc_count / max(managed_total, 1)
+
+    orphan_ratio = len(managed_orphans) / max(managed_total, 1)
+    broken_ratio = len(managed_broken_links) / max(managed_total, 1)
 
     health = 100.0
     health -= orphan_ratio * 30
     health -= broken_ratio * 30
-    health -= max(0, (3 - avg_links) * 15)
+    health -= max(0, (3 - managed_avg_links) * 15)
     health -= (1 - desc_ratio) * 10
     health = max(0, round(health, 1))
 
@@ -117,8 +205,12 @@ def build_graph(vault_dir: Path, schema: dict) -> dict:
             domain_stats[nodes[o]['domain']]['orphans'] += 1
 
     nonstandard_count = sum(len(v) for v in nonstandard_domains.values())
-    nonstandard_ratio = nonstandard_count / max(total, 1)
-    health -= nonstandard_ratio * 5  # small penalty for domain inconsistency
+    managed_nonstandard_count = sum(
+        1 for node in managed_nodes.values()
+        if valid_domains and node['domain'] not in valid_domains
+    )
+    managed_nonstandard_ratio = managed_nonstandard_count / max(managed_total, 1)
+    health -= managed_nonstandard_ratio * 5  # small penalty for domain inconsistency
     health = max(0, round(health, 1))
 
     return {
@@ -131,7 +223,15 @@ def build_graph(vault_dir: Path, schema: dict) -> dict:
             'dead_ends': len(dead_ends),
             'broken_links': len(broken_links),
             'desc_coverage': round(desc_ratio * 100, 1),
+            'all_desc_coverage': round(all_desc_ratio * 100, 1),
             'nonstandard_domains': nonstandard_count,
+            'managed_files': managed_total,
+            'managed_links': managed_link_count,
+            'managed_avg_links': round(managed_avg_links, 2),
+            'managed_orphans': len(managed_orphans),
+            'managed_broken_links': len(managed_broken_links),
+            'managed_nonstandard_domains': managed_nonstandard_count,
+            'future_links': len(future_links),
             'health_score': health,
         },
         'domains': dict(domain_stats),
@@ -139,8 +239,9 @@ def build_graph(vault_dir: Path, schema: dict) -> dict:
         'orphan_list': sorted(orphans),
         'dead_end_list': sorted(dead_ends),
         'broken_link_list': [{'source': s, 'target': t} for s, t in broken_links],
+        'future_link_list': [{'source': s, 'target': t} for s, t in future_links],
         'nodes': {k: {'domain': v['domain'], 'type': v['type'], 'has_description': v['has_description'],
-                       'outgoing': v['outgoing'], 'incoming': v['incoming']}
+                       'managed': v['managed'], 'outgoing': v['outgoing'], 'incoming': v['incoming']}
                   for k, v in nodes.items()},
     }
 
@@ -175,9 +276,14 @@ def generate_report(stats: dict, domains: dict) -> str:
         f"| Total files | {s['total_files']} |",
         f"| Total links | {s['total_links']} |",
         f"| Avg links/file | {s['avg_links']} |",
+        f"| Managed files | {s['managed_files']} |",
+        f"| Managed avg links/file | {s['managed_avg_links']} |",
         f"| Orphans | {s['orphans']} |",
+        f"| Managed orphans | {s['managed_orphans']} |",
         f"| Dead-ends | {s['dead_ends']} |",
         f"| Broken links | {s['broken_links']} |",
+        f"| Managed broken links | {s['managed_broken_links']} |",
+        f"| Expected future links | {s['future_links']} |",
         f"| Desc coverage | {s['desc_coverage']}% |",
         f"",
         f"## Domains",
@@ -351,9 +457,14 @@ def main():
         print(f"Total files:      {stats['total_files']}")
         print(f"Total links:      {stats['total_links']}")
         print(f"Avg links/file:   {stats['avg_links']}")
+        print(f"Managed files:    {stats['managed_files']}")
+        print(f"Managed avg links:{stats['managed_avg_links']:>7}")
         print(f"Orphan files:     {stats['orphans']}")
+        print(f"Managed orphans:  {stats['managed_orphans']}")
         print(f"Dead-ends:        {stats['dead_ends']}")
         print(f"Broken links:     {stats['broken_links']}")
+        print(f"Managed broken:   {stats['managed_broken_links']}")
+        print(f"Future links:     {stats['future_links']}")
         print(f"Desc coverage:    {stats['desc_coverage']}%")
         ns_count = stats.get('nonstandard_domains', 0)
         if ns_count > 0:

--- a/scripts/autograph/graph.py
+++ b/scripts/autograph/graph.py
@@ -144,14 +144,15 @@ def build_graph(vault_dir: Path, schema: dict, today: date | None = None) -> dic
         outgoing = []
         links = extract_wikilinks(body if body else content)
         for target, display in links:
-            # Skip embeds
-            if any(target.lower().endswith(ext) for ext in EMBED_EXTS):
-                continue
             target_clean = normalize_link_target(target)
             resolved, _ = resolve_link_target(target_clean, link_index)
             if resolved:
                 outgoing.append(resolved)
                 all_links.append((rp_noext, target_clean, resolved))
+            elif any(target.lower().endswith(ext) for ext in EMBED_EXTS):
+                # A Markdown note may legitimately end in an attachment-like suffix
+                # (voice.ogg.md). Resolution must win before the embed exemption.
+                continue
             elif expected_future_link(rp_noext, target_clean, today=today):
                 future_links.append((rp_noext, target_clean))
             else:
@@ -184,8 +185,10 @@ def build_graph(vault_dir: Path, schema: dict, today: date | None = None) -> dic
 
     managed_nodes = {path: node for path, node in nodes.items() if node['managed']}
     managed_total = len(managed_nodes)
+    future_sources = {source for source, _ in future_links}
     managed_orphans = [path for path, node in managed_nodes.items()
-                       if not node['incoming'] and not is_hub_path(path)]
+                       if not node['incoming'] and path not in future_sources
+                       and not is_hub_path(path)]
     managed_broken_links = [(source, target) for source, target in broken_links
                             if nodes.get(source, {}).get('managed')]
     managed_resolved_links = sum(node['link_count'] for node in managed_nodes.values())

--- a/scripts/autograph/graph.py
+++ b/scripts/autograph/graph.py
@@ -3,8 +3,8 @@
 autograph graph — vault graph analysis, link repair, backlinks, orphans.
 
 Commands:
-  graph.py health <vault-dir> [schema.json]        — health score + report
-  graph.py fix <vault-dir> [schema.json] [--apply]  — fix broken links
+  graph.py health <vault-dir> [schema.json] [--as-of YYYY-MM-DD] — health score + report
+  graph.py fix <vault-dir> [schema.json] [--apply] [--as-of YYYY-MM-DD] — fix broken links
   graph.py backlinks <vault-dir> <target>           — incoming links
   graph.py orphans <vault-dir>                      — files with no incoming links
 
@@ -12,10 +12,12 @@ All domain/type logic from schema.json. No hardcoded values.
 """
 
 import json
+import os
 import re
 import sys
 from pathlib import Path
 from datetime import date, datetime, timedelta
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from collections import defaultdict
 
 from common import (
@@ -40,6 +42,8 @@ def _matches_path_hint(file_rel_path: str, pattern: str) -> bool:
 def is_managed_card(file_rel_path: str, frontmatter: dict, schema: dict) -> bool:
     """Return whether a Markdown node belongs to the schema-managed card set."""
     valid_types = set((schema.get('node_types') or {}).keys())
+    if not valid_types:
+        return True  # backward-compatible all-node health when no schema exists
     if frontmatter.get('type') in valid_types:
         return True
     for pattern, hinted_type in (schema.get('path_type_hints') or {}).items():
@@ -56,13 +60,23 @@ def _next_month(year: int, month: int) -> date:
     return date(year, month + 1, 1)
 
 
+def _local_today() -> date:
+    timezone = os.environ.get('ASSISTANT_TIMEZONE') or os.environ.get('TZ')
+    if not timezone:
+        return date.today()
+    try:
+        return datetime.now(ZoneInfo(timezone)).date()
+    except (ZoneInfoNotFoundError, ValueError):
+        return date.today()
+
+
 def expected_future_link(source: str, target: str, today: date | None = None) -> bool:
     """Classify an absent, exact Iva rollup parent that is not overdue yet.
 
     The scheduled creation day is included. Starting the next calendar day an
     absent parent is a real broken link.
     """
-    today = today or date.today()
+    today = today or _local_today()
 
     daily_match = re.fullmatch(r'summaries/daily/(\d{4})-(\d{2})-(\d{2})', source)
     if daily_match:
@@ -138,7 +152,7 @@ def build_graph(vault_dir: Path, schema: dict, today: date | None = None) -> dic
             if resolved:
                 outgoing.append(resolved)
                 all_links.append((rp_noext, target_clean, resolved))
-            elif managed and expected_future_link(rp_noext, target_clean, today=today):
+            elif expected_future_link(rp_noext, target_clean, today=today):
                 future_links.append((rp_noext, target_clean))
             else:
                 broken_links.append((rp_noext, target_clean))
@@ -175,7 +189,10 @@ def build_graph(vault_dir: Path, schema: dict, today: date | None = None) -> dic
     managed_broken_links = [(source, target) for source, target in broken_links
                             if nodes.get(source, {}).get('managed')]
     managed_resolved_links = sum(node['link_count'] for node in managed_nodes.values())
-    managed_link_count = managed_resolved_links + len(future_links)
+    managed_future_links = sum(
+        1 for source, _ in future_links if nodes.get(source, {}).get('managed')
+    )
+    managed_link_count = managed_resolved_links + managed_future_links
     managed_avg_links = managed_link_count / max(managed_total, 1)
     managed_desc_count = sum(1 for node in managed_nodes.values() if node['has_description'])
     desc_ratio = managed_desc_count / max(managed_total, 1)
@@ -412,15 +429,30 @@ def find_backlinks(graph: dict, target: str, vault_dir: Path = None) -> tuple[li
 
 
 # ─── CLI ───────────────────────────────────────────────────
-def find_schema(args: list) -> Path | None:
+def find_schema(args: list, vault_dir: Path) -> Path | None:
     """Find schema.json in args or default location."""
     for a in args:
         if a.endswith('.json') and Path(a).exists():
             return Path(a)
+    vault_schema = vault_dir / 'schema.json'
+    if vault_schema.exists():
+        return vault_schema
     default = Path(__file__).parent.parent / 'schema.json'
     if default.exists():
         return default
     return None
+
+
+def find_as_of(args: list) -> date | None:
+    if '--as-of' not in args:
+        return None
+    index = args.index('--as-of')
+    if index + 1 >= len(args):
+        raise ValueError('--as-of requires YYYY-MM-DD')
+    try:
+        return date.fromisoformat(args[index + 1])
+    except ValueError as error:
+        raise ValueError('--as-of requires a valid YYYY-MM-DD') from error
 
 
 def main():
@@ -436,11 +468,16 @@ def main():
         print(f"Error: vault directory required", file=sys.stderr)
         sys.exit(1)
 
-    schema_path = find_schema(args)
+    schema_path = find_schema(args, vault_dir)
     schema = load_schema(schema_path) if schema_path else {}
+    try:
+        as_of = find_as_of(args)
+    except ValueError as error:
+        print(f"Error: {error}", file=sys.stderr)
+        sys.exit(1)
 
     if cmd == 'health':
-        graph = build_graph(vault_dir, schema)
+        graph = build_graph(vault_dir, schema, today=as_of)
         stats = graph['stats']
 
         # Save outputs
@@ -479,7 +516,7 @@ def main():
                 print(f"    '{domain}' ({len(files)} files): {', '.join(files[:5])}")
 
     elif cmd == 'fix':
-        graph = build_graph(vault_dir, schema)
+        graph = build_graph(vault_dir, schema, today=as_of)
         apply = '--apply' in args
         fixes, applied = fix_broken_links(vault_dir, graph, apply=apply)
         mode = 'APPLIED' if apply else 'DRY RUN'
@@ -495,7 +532,7 @@ def main():
         if not target:
             print("Usage: graph.py backlinks <vault> <target>", file=sys.stderr)
             sys.exit(1)
-        graph = build_graph(vault_dir, schema)
+        graph = build_graph(vault_dir, schema, today=as_of)
         wikilinks, mentions = find_backlinks(graph, target, vault_dir)
         print(f"Backlinks to '{target}': {len(wikilinks)} wikilinks, {len(mentions)} text mentions")
         if wikilinks:
@@ -508,7 +545,7 @@ def main():
                 print(f"    ~ {m}")
 
     elif cmd == 'orphans':
-        graph = build_graph(vault_dir, schema)
+        graph = build_graph(vault_dir, schema, today=as_of)
         orphans = graph['orphan_list']
         print(f"Orphans: {len(orphans)}")
         for o in orphans:

--- a/scripts/autograph/tests/test_autograph.py
+++ b/scripts/autograph/tests/test_autograph.py
@@ -812,7 +812,8 @@ def main():
         future_graph = build_graph(rollup_vault, health_schema, today=date(2021, 1, 4))
         test("exact absent parent is reported separately as future",
              future_graph['stats']['future_links'] == 1
-             and future_graph['stats']['broken_links'] == 0,
+             and future_graph['stats']['broken_links'] == 0
+             and future_graph['stats']['managed_orphans'] == 0,
              str(future_graph['stats']))
         fixes, applied = fix_broken_links(rollup_vault, future_graph, apply=False)
         test("graph fix ignores an expected future parent", fixes == [] and applied == 0)
@@ -846,7 +847,8 @@ def main():
         overdue_graph = build_graph(rollup_vault, health_schema, today=date(2021, 1, 5))
         test("overdue parent becomes managed broken link",
              overdue_graph['stats']['future_links'] == 0
-             and overdue_graph['stats']['managed_broken_links'] == 1,
+             and overdue_graph['stats']['managed_broken_links'] == 1
+             and overdue_graph['stats']['managed_orphans'] == 1,
              str(overdue_graph['stats']))
         daily_summary.write_text(
             "---\ntype: daily-summary\ndescription: Boundary day\n---\n"
@@ -871,18 +873,25 @@ def main():
 
         audio_vault = tmp / 'audio-embed-vault'
         (audio_vault / 'cards/notes').mkdir(parents=True)
+        (audio_vault / 'cards/notes/voice.ogg.md').write_text(
+            "---\ntype: note\ndescription: Real Markdown note\n---\n# Voice note\n"
+        )
         (audio_vault / 'cards/notes/audio.md').write_text(
             "---\ntype: note\ndescription: Audio embeds\n---\n# Audio\n"
-            "![[voice.ogg]] ![[voice.OPUS]] ![[voice.m4a]] ![[voice.WAV]] "
-            "[[voice.ogg.md]]\n"
+            "![[missing.ogg]] ![[missing.OPUS]] ![[missing.m4a]] ![[missing.WAV]] "
+            "[[cards/notes/voice.ogg]] [[missing-note.ogg.md]]\n"
         )
         audio_graph = build_graph(audio_vault, health_schema, today=date(2026, 8, 5))
         test("audio attachment extensions are not broken wiki-links",
              audio_graph['stats']['broken_links'] == 1,
              str(audio_graph['broken_link_list']))
-        test("Markdown filename ending in .ogg.md is still checked",
+        test("existing Markdown filename ending in .ogg.md resolves before embed skip",
+             audio_graph['stats']['total_links'] == 1
+             and audio_graph['nodes']['cards/notes/voice.ogg']['incoming']
+             == ['cards/notes/audio'], str(audio_graph['nodes']))
+        test("missing Markdown filename ending in .ogg.md is still checked",
              audio_graph['broken_link_list'] == [
-                 {'source': 'cards/notes/audio', 'target': 'voice.ogg'}
+                 {'source': 'cards/notes/audio', 'target': 'missing-note.ogg'}
              ], str(audio_graph['broken_link_list']))
 
         # graph orphans

--- a/scripts/autograph/tests/test_autograph.py
+++ b/scripts/autograph/tests/test_autograph.py
@@ -753,6 +753,31 @@ def main():
         test("raw transcripts and CORE/MOC are outside managed health",
              with_raw['stats']['managed_files'] == 1)
 
+        auto_schema_vault = tmp / 'auto-schema-health-vault'
+        (auto_schema_vault / 'cards/notes').mkdir(parents=True)
+        (auto_schema_vault / 'schema.json').write_text(json.dumps(health_schema))
+        (auto_schema_vault / 'cards/notes/hinted.md').write_text(
+            "# Managed through the discovered path hint\n"
+        )
+        code, _, err = run([py, str(SCRIPTS_DIR / 'graph.py'), 'health',
+                            str(auto_schema_vault), '--as-of', '2026-08-05'])
+        auto_stats = json.loads(
+            (auto_schema_vault / '.graph/vault-graph.json').read_text()
+        )['stats']
+        test("CLI auto-discovers vault/schema.json",
+             code == 0 and auto_stats['managed_files'] == 1, err[:200])
+
+        no_schema_vault = tmp / 'no-schema-health-vault'
+        no_schema_vault.mkdir()
+        (no_schema_vault / 'plain.md').write_text('# Plain node\n')
+        code, _, err = run([py, str(SCRIPTS_DIR / 'graph.py'), 'health',
+                            str(no_schema_vault), '--as-of', '2026-08-05'])
+        no_schema_stats = json.loads(
+            (no_schema_vault / '.graph/vault-graph.json').read_text()
+        )['stats']
+        test("CLI without any schema keeps all-node health fallback",
+             code == 0 and no_schema_stats['managed_files'] == 1, err[:200])
+
         (health_vault / 'cards/notes/no-description.md').write_text(
             "# Missing description but managed through path_type_hints\n"
         )
@@ -791,6 +816,33 @@ def main():
              str(future_graph['stats']))
         fixes, applied = fix_broken_links(rollup_vault, future_graph, apply=False)
         test("graph fix ignores an expected future parent", fixes == [] and applied == 0)
+        legacy_graph = build_graph(
+            rollup_vault,
+            {"node_types": {"note": {}}, "path_type_hints": {}},
+            today=date(2021, 1, 4),
+        )
+        test("future parent classification does not depend on managed schema types",
+             legacy_graph['stats']['future_links'] == 1
+             and legacy_graph['stats']['broken_links'] == 0
+             and legacy_graph['stats']['managed_files'] == 0,
+             str(legacy_graph['stats']))
+
+        (rollup_vault / 'schema.json').write_text(json.dumps(health_schema))
+        code, _, err = run([py, str(SCRIPTS_DIR / 'graph.py'), 'health',
+                            str(rollup_vault), '--as-of', '2021-01-04'])
+        cli_future = json.loads(
+            (rollup_vault / '.graph/vault-graph.json').read_text()
+        )['stats']
+        test("CLI --as-of keeps parent future on scheduled creation day",
+             code == 0 and cli_future['future_links'] == 1, err[:200])
+        code, _, err = run([py, str(SCRIPTS_DIR / 'graph.py'), 'health',
+                            str(rollup_vault), '--as-of', '2021-01-05'])
+        cli_overdue = json.loads(
+            (rollup_vault / '.graph/vault-graph.json').read_text()
+        )['stats']
+        test("CLI --as-of makes parent broken the following day",
+             code == 0 and cli_overdue['future_links'] == 0
+             and cli_overdue['managed_broken_links'] == 1, err[:200])
         overdue_graph = build_graph(rollup_vault, health_schema, today=date(2021, 1, 5))
         test("overdue parent becomes managed broken link",
              overdue_graph['stats']['future_links'] == 0

--- a/scripts/autograph/tests/test_autograph.py
+++ b/scripts/autograph/tests/test_autograph.py
@@ -702,6 +702,137 @@ def main():
              f"expected {len(VAULT_FILES)}, got '{file_count_str}'")
         test("graph health shows Health Score", 'Health Score' in out)
 
+        # Health is defined over schema-managed cards. Raw transcripts and roots remain
+        # graph nodes, but adding them cannot decay card-quality metrics.
+        from graph import build_graph, expected_future_link, fix_broken_links
+        health_schema = {
+            "node_types": {
+                "note": {},
+                "daily-summary": {},
+                "weekly-summary": {},
+                "monthly-summary": {},
+                "yearly-summary": {},
+            },
+            "path_type_hints": {
+                "cards/notes/": "note",
+                "summaries/daily/": "daily-summary",
+                "weekly/": "weekly-summary",
+                "monthly/": "monthly-summary",
+                "yearly/": "yearly-summary",
+            },
+            "domain_inference": {
+                "cards/": "knowledge",
+                "daily/": "personal",
+                "summaries/": "personal",
+                "weekly/": "personal",
+                "monthly/": "personal",
+                "yearly/": "personal",
+            },
+        }
+        health_vault = tmp / 'managed-health-vault'
+        (health_vault / 'cards/notes').mkdir(parents=True)
+        (health_vault / 'cards/notes/alpha.md').write_text(
+            "---\ntype: note\ndescription: Alpha\n---\n# Alpha\n"
+            "[[cards/notes/alpha]] [[cards/notes/alpha]] [[cards/notes/alpha]]\n"
+        )
+        baseline = build_graph(health_vault, health_schema, today=date(2026, 8, 5))
+        (health_vault / 'daily').mkdir()
+        for day in range(100):
+            (health_vault / 'daily' / f'raw-{day:03d}.md').write_text(
+                f"# Raw {day}\nNo frontmatter or description.\n"
+            )
+        (health_vault / 'CORE.md').write_text('# Core\n')
+        (health_vault / 'MOC.md').write_text('# MOC\n')
+        with_raw = build_graph(health_vault, health_schema, today=date(2026, 8, 5))
+        for metric in ('health_score', 'desc_coverage', 'managed_avg_links'):
+            test(f"100 raw transcripts leave {metric} unchanged",
+                 with_raw['stats'][metric] == baseline['stats'][metric],
+                 f"baseline={baseline['stats'][metric]} raw={with_raw['stats'][metric]}")
+        test("raw transcripts and CORE/MOC remain graph nodes",
+             with_raw['stats']['total_files'] == 103)
+        test("raw transcripts and CORE/MOC are outside managed health",
+             with_raw['stats']['managed_files'] == 1)
+
+        (health_vault / 'cards/notes/no-description.md').write_text(
+            "# Missing description but managed through path_type_hints\n"
+        )
+        missing_desc = build_graph(health_vault, health_schema, today=date(2026, 8, 5))
+        test("managed path without description lowers coverage",
+             missing_desc['stats']['desc_coverage'] < with_raw['stats']['desc_coverage'])
+
+        # Exact rollup parents stay future only through their scheduled creation day.
+        test("ISO-year daily parent accepts W53 on creation day",
+             expected_future_link('summaries/daily/2021-01-01', 'weekly/2020-W53',
+                                  date(2021, 1, 4)))
+        test("ISO-year daily parent becomes broken after creation day",
+             not expected_future_link('summaries/daily/2021-01-01', 'weekly/2020-W53',
+                                      date(2021, 1, 5)))
+        test("W53 belongs to month containing its Thursday",
+             expected_future_link('weekly/2020-W53', 'monthly/2020-12', date(2021, 1, 1)))
+        test("leap-day Thursday selects February",
+             expected_future_link('weekly/2024-W09', 'monthly/2024-02', date(2024, 3, 1)))
+        test("monthly parent year expires after Jan 1",
+             expected_future_link('monthly/2024-12', 'yearly/2024', date(2025, 1, 1))
+             and not expected_future_link('monthly/2024-12', 'yearly/2024', date(2025, 1, 2)))
+        test("wrong rollup period is never future",
+             not expected_future_link('weekly/2024-W09', 'monthly/2024-03', date(2024, 3, 1)))
+
+        rollup_vault = tmp / 'rollup-health-vault'
+        (rollup_vault / 'summaries/daily').mkdir(parents=True)
+        daily_summary = rollup_vault / 'summaries/daily/2021-01-01.md'
+        daily_summary.write_text(
+            "---\ntype: daily-summary\ndescription: Boundary day\n---\n"
+            "# Boundary\nUp: [[weekly/2020-W53]]\n"
+        )
+        future_graph = build_graph(rollup_vault, health_schema, today=date(2021, 1, 4))
+        test("exact absent parent is reported separately as future",
+             future_graph['stats']['future_links'] == 1
+             and future_graph['stats']['broken_links'] == 0,
+             str(future_graph['stats']))
+        fixes, applied = fix_broken_links(rollup_vault, future_graph, apply=False)
+        test("graph fix ignores an expected future parent", fixes == [] and applied == 0)
+        overdue_graph = build_graph(rollup_vault, health_schema, today=date(2021, 1, 5))
+        test("overdue parent becomes managed broken link",
+             overdue_graph['stats']['future_links'] == 0
+             and overdue_graph['stats']['managed_broken_links'] == 1,
+             str(overdue_graph['stats']))
+        daily_summary.write_text(
+            "---\ntype: daily-summary\ndescription: Boundary day\n---\n"
+            "# Boundary\nUp: [[weekly/2021-W01]]\n"
+        )
+        wrong_graph = build_graph(rollup_vault, health_schema, today=date(2021, 1, 1))
+        test("wrong missing parent is immediately broken",
+             wrong_graph['stats']['future_links'] == 0
+             and wrong_graph['stats']['managed_broken_links'] == 1)
+        (rollup_vault / 'weekly').mkdir()
+        (rollup_vault / 'weekly/2020-W53.md').write_text(
+            "---\ntype: weekly-summary\ndescription: Week 53\n---\n# Week 53\n"
+        )
+        daily_summary.write_text(
+            "---\ntype: daily-summary\ndescription: Boundary day\n---\n"
+            "# Boundary\nUp: [[weekly/2020-W53]]\n"
+        )
+        resolved_graph = build_graph(rollup_vault, health_schema, today=date(2021, 1, 5))
+        test("existing parent is an ordinary resolved link",
+             resolved_graph['stats']['future_links'] == 0
+             and resolved_graph['stats']['broken_links'] == 0)
+
+        audio_vault = tmp / 'audio-embed-vault'
+        (audio_vault / 'cards/notes').mkdir(parents=True)
+        (audio_vault / 'cards/notes/audio.md').write_text(
+            "---\ntype: note\ndescription: Audio embeds\n---\n# Audio\n"
+            "![[voice.ogg]] ![[voice.OPUS]] ![[voice.m4a]] ![[voice.WAV]] "
+            "[[voice.ogg.md]]\n"
+        )
+        audio_graph = build_graph(audio_vault, health_schema, today=date(2026, 8, 5))
+        test("audio attachment extensions are not broken wiki-links",
+             audio_graph['stats']['broken_links'] == 1,
+             str(audio_graph['broken_link_list']))
+        test("Markdown filename ending in .ogg.md is still checked",
+             audio_graph['broken_link_list'] == [
+                 {'source': 'cards/notes/audio', 'target': 'voice.ogg'}
+             ], str(audio_graph['broken_link_list']))
+
         # graph orphans
         code, out, _ = run([py, str(SCRIPTS_DIR / 'graph.py'), 'orphans',
                             str(vault_dir), str(schema_path)])

--- a/scripts/memory/doctor.ts
+++ b/scripts/memory/doctor.ts
@@ -114,7 +114,7 @@ maint("cleanup", [`${SCRIPTS}/cleanup.py`, ".", "--apply"]);
 // This is the deterministic guarantee that cards written outside write_card stay in-schema.
 maint("enforce", [`${SCRIPTS}/enforce.py`, ".", SCHEMA, "--apply"]);
 // graph.health rebuilds the graph and writes health-history.json (for drop detection).
-maint("graph.health", [`${SCRIPTS}/graph.py`, "health", ".", SCHEMA]);
+maint("graph.health", [`${SCRIPTS}/graph.py`, "health", ".", SCHEMA, "--as-of", today]);
 // engine.decay updates card relevance/tiers.
 maint("engine.decay", [`${SCRIPTS}/engine.py`, "decay", "."]);
 // moc.generate rebuilds the MOC indexes.

--- a/scripts/memory/doctor.ts
+++ b/scripts/memory/doctor.ts
@@ -114,7 +114,7 @@ maint("cleanup", [`${SCRIPTS}/cleanup.py`, ".", "--apply"]);
 // This is the deterministic guarantee that cards written outside write_card stay in-schema.
 maint("enforce", [`${SCRIPTS}/enforce.py`, ".", SCHEMA, "--apply"]);
 // graph.health rebuilds the graph and writes health-history.json (for drop detection).
-maint("graph.health", [`${SCRIPTS}/graph.py`, "health", "."]);
+maint("graph.health", [`${SCRIPTS}/graph.py`, "health", ".", SCHEMA]);
 // engine.decay updates card relevance/tiers.
 maint("engine.decay", [`${SCRIPTS}/engine.py`, "decay", "."]);
 // moc.generate rebuilds the MOC indexes.

--- a/scripts/memory/instructions/dbrain-processor/SKILL.md
+++ b/scripts/memory/instructions/dbrain-processor/SKILL.md
@@ -69,11 +69,11 @@ of the vault, and take the vault directory as an argument (`vault` = `$ASSISTANT
 ```bash
 # dry-run first, then --apply
 uv run scripts/autograph/enforce.py vault vault/schema.json --apply   # schema compliance + autofix
-uv run scripts/autograph/graph.py fix vault --apply                   # repair broken wiki-links
+uv run scripts/autograph/graph.py fix vault vault/schema.json --apply # repair broken wiki-links
 uv run scripts/autograph/engine.py touch vault/summaries/daily/YYYY-MM-DD.md
 uv run scripts/autograph/moc.py generate vault vault/schema.json      # regenerate domain MOCs
 uv run scripts/autograph/engine.py decay vault                        # recompute relevance/tiers
-uv run scripts/autograph/graph.py health vault                        # confirm score
+uv run scripts/autograph/graph.py health vault vault/schema.json      # confirm score
 ```
 
 If `uv` / Python is unavailable, still produce the cards and summary (they are plain

--- a/scripts/memory/instructions/dbrain-processor/phases/link.md
+++ b/scripts/memory/instructions/dbrain-processor/phases/link.md
@@ -25,7 +25,7 @@ Wire every card created/updated in Phase 2 into the graph. No orphans.
    Find siblings with:
    ```bash
    grep -rl "type: <type>" vault/cards/<kind>/
-   uv run scripts/autograph/graph.py backlinks vault cards/<kind>/<hub>
+   uv run scripts/autograph/graph.py backlinks vault cards/<kind>/<hub> vault/schema.json
    ```
 3. **Back-reference.** When a card relates strongly to another, add the reciprocal link
    on the neighbor too (keep the graph undirected where it makes sense).

--- a/scripts/memory/instructions/dbrain-processor/phases/summarize.md
+++ b/scripts/memory/instructions/dbrain-processor/phases/summarize.md
@@ -71,11 +71,11 @@ From the project root, with the vault as an argument (dry-run, then `--apply`):
 
 ```bash
 uv run scripts/autograph/enforce.py vault vault/schema.json --apply
-uv run scripts/autograph/graph.py fix vault --apply
+uv run scripts/autograph/graph.py fix vault vault/schema.json --apply
 uv run scripts/autograph/engine.py touch vault/summaries/daily/YYYY-MM-DD.md
 uv run scripts/autograph/moc.py generate vault vault/schema.json
 uv run scripts/autograph/engine.py decay vault
-uv run scripts/autograph/graph.py health vault
+uv run scripts/autograph/graph.py health vault vault/schema.json
 ```
 
 ## 4. Hand back

--- a/scripts/memory/instructions/dbrain-processor/references/linking.md
+++ b/scripts/memory/instructions/dbrain-processor/references/linking.md
@@ -25,7 +25,7 @@ Find siblings of the same type+domain:
 
 ```bash
 grep -rl "type: <type>" vault/cards/<kind>/
-uv run scripts/autograph/graph.py backlinks vault cards/<kind>/_index
+uv run scripts/autograph/graph.py backlinks vault cards/<kind>/_index vault/schema.json
 ```
 
 Link the 2–3 most relevant, each with a context phrase explaining the relationship:
@@ -46,7 +46,7 @@ both directions.
 
 ```bash
 uv run scripts/autograph/engine.py touch vault/cards/<kind>/<file>.md
-uv run scripts/autograph/graph.py health vault   # broken links should be 0
+uv run scripts/autograph/graph.py health vault vault/schema.json   # broken links should be 0
 ```
 
 ## Wiki-link form (Obsidian)


### PR DESCRIPTION
## Summary
- calculate health from schema-managed cards while retaining raw transcripts and roots as graph nodes
- classify only exact, not-yet-overdue rollup parents as future links
- pass the active vault schema and timezone-safe date through doctor and dbrain graph commands
- recognize Telegram audio embeds without hiding Markdown links

Closes #131
Closes #132

## Validation
- `uv run scripts/autograph/tests/test_autograph.py` (290 passed)
- `node --test agent/lib/*.test.mjs scripts/lib/*.test.mjs scripts/lib/menu/*.test.mjs scripts/*.test.mjs` (568 passed)
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- staged secret-pattern scan clean

CodeRabbit review was skipped after the organization quota was exhausted.