### PR TITLE
fix: enforce rollup card structure

### DIFF
--- a/agent/lib/card-store.ts
+++ b/agent/lib/card-store.ts
@@ -1,9 +1,9 @@
 // Хранилище карточек: поиск существующего файла по идентичности, слияние (merge)
 // нового содержимого со старым, лок + атомарная запись.
 //
-// Инвариант: write_card НИКОГДА не заменяет карточку целиком. Файл читается, известные
-// поля frontmatter обновляются, неизвестные (tier/relevance/last_accessed/phone/…)
-// сохраняются, created не трогается, старый body остаётся на месте.
+// Инвариант: write_card сохраняет неизвестные поля frontmatter и created. UPDATE
+// дополняет один ## Log, SUPERSEDE заменяет Compiled Truth и переносит прежний факт
+// в ## History, а NOOP не пишет файл.
 
 import {
   closeSync,
@@ -50,7 +50,10 @@ export function baseName(s: string): string {
 const hasQualifier = (s: string) => /\(/.test(s);
 
 export function extractH1(body: string): string | null {
-  const m = /^#\s+(.+)$/m.exec(body);
+  const lines = body.split("\n");
+  const outside = outsideFences(lines);
+  const line = lines.find((candidate, index) => outside[index] && /^ {0,3}#\s+/.test(candidate));
+  const m = line ? /^ {0,3}#\s+(.+)$/.exec(line) : null;
   return m ? m[1].trim() : null;
 }
 
@@ -132,33 +135,195 @@ export function bodyContains(existingBody: string, incoming: string): boolean {
   return b.length === 0 || a.includes(b);
 }
 
-function relatedTargets(body: string): Set<string> {
-  const out = new Set<string>();
-  for (const m of body.matchAll(/\[\[([^\]]+)\]\]/g)) out.add(m[1].trim().toLowerCase());
-  return out;
+interface H2Section {
+  start: number;
+  end: number;
 }
 
-/** Дописать недостающие [[ссылки]] в секцию `## Related` (создать, если её нет). */
-export function mergeRelated(body: string, related: string[]): string {
-  const missing = related.filter((r) => !relatedTargets(body).has(r.trim().toLowerCase()));
-  if (!missing.length) return body;
-  const bullets = missing.map((r) => `- [[${r}]]`).join("\n");
+function outsideFences(lines: string[]): boolean[] {
+  const outside = Array(lines.length).fill(true) as boolean[];
+  let fence: { marker: "`" | "~"; length: number } | null = null;
+  for (let index = 0; index < lines.length; index++) {
+    const line = lines[index];
+    if (fence) {
+      outside[index] = false;
+      const close = /^ {0,3}(`{3,}|~{3,})\s*$/.exec(line);
+      if (close && close[1][0] === fence.marker && close[1].length >= fence.length) fence = null;
+      continue;
+    }
+    const open = /^ {0,3}(`{3,}|~{3,})(.*)$/.exec(line);
+    if (!open || (open[1][0] === "`" && open[2].includes("`"))) continue;
+    outside[index] = false;
+    fence = { marker: open[1][0] as "`" | "~", length: open[1].length };
+  }
+  return outside;
+}
 
+function h2Sections(lines: string[], heading: string): H2Section[] {
+  const escaped = heading.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const wanted = new RegExp(`^ {0,3}##\\s+${escaped}\\s*$`, "i");
+  const outside = outsideFences(lines);
+  const starts = lines.flatMap((line, index) => (outside[index] && wanted.test(line) ? [index] : []));
+  return starts.map((start) => {
+    let end = lines.length;
+    for (let index = start + 1; index < lines.length; index++) {
+      if (outside[index] && /^ {0,3}#{1,2}\s+/.test(lines[index])) {
+        end = index;
+        break;
+      }
+    }
+    return { start, end };
+  });
+}
+
+function normalizeRelatedTarget(raw: string): string {
+  return raw
+    .trim()
+    .replace(/^\[\[|\]\]$/g, "")
+    .split("|", 1)[0]
+    .split("#", 1)[0]
+    .trim()
+    .toLowerCase();
+}
+
+function replaceH2Sections(body: string, heading: string, content: string[]): string {
   const lines = body.split("\n");
-  const idx = lines.findIndex((l) => /^##\s+Related\s*$/i.test(l.trim()));
-  if (idx === -1) return `${body.replace(/\s+$/, "")}\n\n## Related\n${bullets}\n`;
+  const sections = h2Sections(lines, heading);
+  const canonical = [`## ${heading}`, ...content];
+  if (!sections.length) {
+    return `${body.replace(/\s+$/, "")}\n\n${canonical.join("\n")}\n`;
+  }
 
-  let end = lines.length;
-  for (let i = idx + 1; i < lines.length; i++) {
-    if (/^#{1,2}\s+/.test(lines[i])) {
-      end = i;
-      break;
+  const first = sections[0].start;
+  const byStart = new Map(sections.map((section) => [section.start, section.end]));
+  const output: string[] = [];
+  for (let index = 0; index < lines.length;) {
+    const end = byStart.get(index);
+    if (end !== undefined) {
+      if (index === first) output.push(...canonical);
+      index = end;
+      continue;
+    }
+    output.push(lines[index]);
+    index++;
+  }
+  return output.join("\n").replace(/\s+$/, "") + "\n";
+}
+
+/** Keep exactly one Related section and deduplicate targets ignoring alias/anchor. */
+export function mergeRelated(body: string, related: string[]): string {
+  const lines = body.split("\n");
+  const sections = h2Sections(lines, "Related");
+  const seen = new Set<string>();
+  const links: string[] = [];
+  const prose: string[] = [];
+
+  for (const section of sections) {
+    for (const line of lines.slice(section.start + 1, section.end)) {
+      if (!line.trim()) continue;
+      const matches = [...line.matchAll(/\[\[([^\]]+)\]\]/g)];
+      const remainder = line
+        .replace(/\[\[[^\]]+\]\]/g, "")
+        .replace(/[-*·,;:\s]/g, "");
+      if (matches.length && !remainder) {
+        for (const match of matches) {
+          const target = normalizeRelatedTarget(match[1]);
+          if (!target || seen.has(target)) continue;
+          seen.add(target);
+          links.push(match[1].trim());
+        }
+      } else {
+        prose.push(line);
+        for (const match of matches) seen.add(normalizeRelatedTarget(match[1]));
+      }
     }
   }
-  while (end > idx + 1 && lines[end - 1].trim() === "") end--;
-  lines.splice(end, 0, bullets);
-  return lines.join("\n");
+
+  for (const raw of related) {
+    const display = raw.trim().replace(/^\[\[|\]\]$/g, "");
+    const target = normalizeRelatedTarget(display);
+    if (!target || seen.has(target)) continue;
+    seen.add(target);
+    links.push(display);
+  }
+
+  if (!sections.length && !prose.length && !links.length) return body;
+  const content = [...prose, ...links.map((link) => `- [[${link}]]`)];
+  return replaceH2Sections(body, "Related", content);
 }
+
+function sectionContent(body: string, heading: string): string[] {
+  const lines = body.split("\n");
+  return h2Sections(lines, heading).flatMap((section) =>
+    lines.slice(section.start + 1, section.end).filter((line) => line.trim()),
+  );
+}
+
+function removeH2Sections(body: string, heading: string): string {
+  const lines = body.split("\n");
+  const sections = h2Sections(lines, heading);
+  if (!sections.length) return body;
+  const byStart = new Map(sections.map((section) => [section.start, section.end]));
+  const output: string[] = [];
+  for (let index = 0; index < lines.length;) {
+    const end = byStart.get(index);
+    if (end !== undefined) {
+      index = end;
+      continue;
+    }
+    output.push(lines[index]);
+    index++;
+  }
+  return output.join("\n").replace(/\s+$/, "") + "\n";
+}
+
+function appendLog(body: string, incoming: string, date: string): string {
+  const oldEntries = sectionContent(body, "Log");
+  const withoutLogs = removeH2Sections(body, "Log");
+  const incomingLines = incoming.trim().split("\n");
+  const entry = incomingLines.length === 1
+    ? `- ${date}: ${incomingLines[0]}`
+    : [`- ${date}:`, ...incomingLines.map((line) => `  ${line}`)].join("\n");
+  return replaceH2Sections(withoutLogs, "Log", [...oldEntries, entry]);
+}
+
+function collapseLogSections(body: string): string {
+  const lines = body.split("\n");
+  if (h2Sections(lines, "Log").length <= 1) return body;
+  return replaceH2Sections(body, "Log", sectionContent(body, "Log"));
+}
+
+function replaceCompiledTruth(
+  oldBody: string,
+  replacement: string,
+  historyEntry: string | undefined,
+  date: string,
+): string {
+  const history = [...sectionContent(oldBody, "History"), ...sectionContent(replacement, "History")];
+  const log = [...sectionContent(oldBody, "Log"), ...sectionContent(replacement, "Log")];
+  const related = [...sectionContent(oldBody, "Related"), ...sectionContent(replacement, "Related")];
+  if (historyEntry?.trim()) {
+    const entry = historyEntry.trim();
+    history.push(/^[-*]\s+/.test(entry) ? entry : `- ${date}: ${entry}`);
+  }
+  const deduped: string[] = [];
+  const seen = new Set<string>();
+  for (const line of history) {
+    const key = norm(line);
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(line);
+  }
+  let truth = removeH2Sections(replacement, "History");
+  truth = removeH2Sections(truth, "Log");
+  truth = removeH2Sections(truth, "Related");
+  if (log.length) truth = replaceH2Sections(truth, "Log", log);
+  if (deduped.length) truth = replaceH2Sections(truth, "History", deduped);
+  if (related.length) truth = replaceH2Sections(truth, "Related", related);
+  return truth;
+}
+
+export type CardOperation = "ADD" | "UPDATE" | "SUPERSEDE" | "NOOP";
 
 export interface MergeInput {
   /** Содержимое существующего файла (undefined — карточки ещё нет). */
@@ -173,16 +338,37 @@ export interface MergeInput {
   date: string;
   /** SUPERSEDE: заменить body целиком (frontmatter всё равно сливается). */
   replaceBody?: boolean;
+  /** Explicit operation; omitted callers retain legacy auto-detection. */
+  operation?: CardOperation;
+  /** One dated fact moved out of Compiled Truth during SUPERSEDE. */
+  historyEntry?: string;
 }
 
 export interface MergeResult {
   content: string;
-  action: "created" | "updated" | "merged" | "replaced";
+  action: "created" | "updated" | "merged" | "replaced" | "noop";
 }
 
 export function mergeCard(input: MergeInput): MergeResult {
-  const { existing, title, fields, initialFields, body, related, date, replaceBody } = input;
+  const { existing, title, fields, initialFields, body, related, date, replaceBody, historyEntry } = input;
   const trimmedBody = body.trim();
+  const operation = input.operation ?? (replaceBody ? "SUPERSEDE" : existing === undefined ? "ADD" : "UPDATE");
+
+  if (h2Sections(trimmedBody.split("\n"), "Related").length) {
+    throw new Error("body must not contain ## Related; pass links through related");
+  }
+  if (replaceBody && operation !== "SUPERSEDE") {
+    throw new Error("replaceBody is valid only for SUPERSEDE");
+  }
+  if (operation === "NOOP") {
+    return { content: existing ?? "", action: "noop" };
+  }
+  if (operation === "ADD" && existing !== undefined) {
+    throw new Error("ADD refuses to overwrite an existing card");
+  }
+  if ((operation === "UPDATE" || operation === "SUPERSEDE") && existing === undefined) {
+    throw new Error(`${operation} requires an existing card`);
+  }
 
   if (existing === undefined) {
     const all: FmFields = { ...fields, ...(initialFields || {}) };
@@ -219,26 +405,21 @@ export function mergeCard(input: MergeInput): MergeResult {
     ? writeFrontmatter(updates, parsed.lines)
     : writeFrontmatter(updates, []);
 
-  let newBody = oldBody;
+  let newBody = operation === "UPDATE" ? collapseLogSections(oldBody) : oldBody;
   let appended = false;
-  if (replaceBody) {
-    // SUPERSEDE: вызывающий сознательно переписывает текущую истину (и обязан сам
-    // перенести старое значение в ## History — см. правила rollup). Merge здесь
-    // невозможен по определению: противоречащие факты нельзя «дописать».
-    newBody = `\n${trimmedBody}\n`;
+  if (operation === "SUPERSEDE") {
+    newBody = `\n${replaceCompiledTruth(oldBody, trimmedBody, historyEntry, date).trim()}\n`;
   } else if (!bodyContains(oldBody, trimmedBody)) {
-    newBody = `${newBody.replace(/\s+$/, "")}\n\n## Обновление ${date}\n\n${trimmedBody}\n`;
+    newBody = appendLog(newBody, trimmedBody, date);
     appended = true;
   }
   if (!extractH1(newBody)) newBody = `# ${title}\n\n${newBody.replace(/^\s+/, "")}`;
-  if (related && related.length) {
-    const before = newBody;
-    newBody = mergeRelated(newBody, related);
-    if (before !== newBody) appended = true;
-  }
+  const beforeRelated = newBody;
+  newBody = mergeRelated(newBody, related ?? []);
+  if (beforeRelated !== newBody) appended = true;
 
   const content = `---\n${fmText}\n---\n${newBody.replace(/\s*$/, "")}\n`;
-  return { content, action: replaceBody ? "replaced" : appended ? "merged" : "updated" };
+  return { content, action: operation === "SUPERSEDE" ? "replaced" : appended ? "merged" : "updated" };
 }
 
 // ─── lock + атомарная запись ───────────────────────────────────────────────

--- a/agent/lib/card-store.ts
+++ b/agent/lib/card-store.ts
@@ -140,6 +140,11 @@ interface H2Section {
   end: number;
 }
 
+interface NamedH2Section extends H2Section {
+  heading: string;
+  key: string;
+}
+
 function outsideFences(lines: string[]): boolean[] {
   const outside = Array(lines.length).fill(true) as boolean[];
   let fence: { marker: "`" | "~"; length: number } | null = null;
@@ -173,6 +178,29 @@ function h2Sections(lines: string[], heading: string): H2Section[] {
       }
     }
     return { start, end };
+  });
+}
+
+export function hasH2Section(body: string, heading: string): boolean {
+  return h2Sections(body.split("\n"), heading).length > 0;
+}
+
+function namedH2Sections(lines: string[]): NamedH2Section[] {
+  const outside = outsideFences(lines);
+  const starts = lines.flatMap((line, index) => {
+    if (!outside[index]) return [];
+    const match = /^ {0,3}##\s+(.+?)\s*$/.exec(line);
+    return match ? [{ start: index, heading: match[1].trim(), key: norm(match[1]) }] : [];
+  });
+  return starts.map(({ start, heading, key }) => {
+    let end = lines.length;
+    for (let index = start + 1; index < lines.length; index++) {
+      if (outside[index] && /^ {0,3}#{1,2}\s+/.test(lines[index])) {
+        end = index;
+        break;
+      }
+    }
+    return { start, end, heading, key };
   });
 }
 
@@ -299,28 +327,72 @@ function replaceCompiledTruth(
   historyEntry: string | undefined,
   date: string,
 ): string {
-  const history = [...sectionContent(oldBody, "History"), ...sectionContent(replacement, "History")];
-  const log = [...sectionContent(oldBody, "Log"), ...sectionContent(replacement, "Log")];
-  const related = [...sectionContent(oldBody, "Related"), ...sectionContent(replacement, "Related")];
+  const structural = new Set(["log", "history", "related"]);
+  const oldLines = oldBody.split("\n");
+  const replacementLines = replacement.split("\n");
+  const oldSections = namedH2Sections(oldLines);
+  const replacementSections = namedH2Sections(replacementLines);
+  const replacementKeys = new Set(replacementSections.map((section) => section.key));
+
+  // The replacement owns Compiled Truth. Structural archives remain append-only,
+  // and an old custom H2 survives unless the replacement explicitly names it.
+  const replacementStructuralStarts = new Map(
+    replacementSections
+      .filter((section) => structural.has(section.key))
+      .map((section) => [section.start, section.end]),
+  );
+  const truthLines: string[] = [];
+  for (let index = 0; index < replacementLines.length;) {
+    const end = replacementStructuralStarts.get(index);
+    if (end !== undefined) {
+      index = end;
+      continue;
+    }
+    truthLines.push(replacementLines[index]);
+    index++;
+  }
+
+  const blocks = oldSections
+    .filter((section) => structural.has(section.key) || !replacementKeys.has(section.key))
+    .map((section) => ({
+      key: section.key,
+      heading: section.heading,
+      lines: oldLines.slice(section.start, section.end),
+    }));
+
+  const additions = new Map<string, string[]>();
+  for (const section of replacementSections.filter((candidate) => structural.has(candidate.key))) {
+    const content = replacementLines.slice(section.start + 1, section.end);
+    if (content.some((line) => line.length)) {
+      additions.set(section.key, [...(additions.get(section.key) ?? []), ...content]);
+    }
+  }
   if (historyEntry?.trim()) {
     const entry = historyEntry.trim();
-    history.push(/^[-*]\s+/.test(entry) ? entry : `- ${date}: ${entry}`);
+    const dated = /^[-*]\s+\d{4}-\d{2}-\d{2}:/.test(entry)
+      ? entry
+      : `- ${date}: ${entry.replace(/^[-*]\s+/, "")}`;
+    additions.set("history", [...(additions.get("history") ?? []), dated]);
   }
-  const deduped: string[] = [];
-  const seen = new Set<string>();
-  for (const line of history) {
-    const key = norm(line);
-    if (!key || seen.has(key)) continue;
-    seen.add(key);
-    deduped.push(line);
+
+  for (const [key, lines] of additions) {
+    let block = [...blocks].reverse().find((candidate) => candidate.key === key);
+    if (!block) {
+      const heading = key === "history" ? "History" : key === "log" ? "Log" : "Related";
+      block = { key, heading, lines: [`## ${heading}`] };
+      blocks.push(block);
+    }
+    if (block.lines.at(-1)?.trim()) block.lines.push("");
+    block.lines.push(...lines);
   }
-  let truth = removeH2Sections(replacement, "History");
-  truth = removeH2Sections(truth, "Log");
-  truth = removeH2Sections(truth, "Related");
-  if (log.length) truth = replaceH2Sections(truth, "Log", log);
-  if (deduped.length) truth = replaceH2Sections(truth, "History", deduped);
-  if (related.length) truth = replaceH2Sections(truth, "Related", related);
-  return truth;
+
+  const output = [...truthLines];
+  while (output.length && !output.at(-1)?.trim()) output.pop();
+  for (const block of blocks) {
+    if (output.length && output.at(-1)?.trim()) output.push("");
+    output.push(...block.lines);
+  }
+  return output.join("\n").replace(/\s+$/, "") + "\n";
 }
 
 export type CardOperation = "ADD" | "UPDATE" | "SUPERSEDE" | "NOOP";

--- a/agent/lib/card-store.ts
+++ b/agent/lib/card-store.ts
@@ -362,7 +362,30 @@ function replaceCompiledTruth(
 
   const additions = new Map<string, string[]>();
   for (const section of replacementSections.filter((candidate) => structural.has(candidate.key))) {
-    const content = replacementLines.slice(section.start + 1, section.end);
+    let content = replacementLines.slice(section.start + 1, section.end);
+    while (content.length && !content.at(-1)?.trim()) content.pop();
+    if (section.key === "history") {
+      const oldHistory = oldSections.filter((candidate) => candidate.key === "history");
+      const newHistory = replacementSections.filter((candidate) => candidate.key === "history");
+      if (oldHistory.length > 1 || newHistory.length > 1) {
+        throw new Error("SUPERSEDE requires exactly one unambiguous ## History section");
+      }
+      if (!content.some((line) => line.trim())) {
+        throw new Error("SUPERSEDE replacement ## History must contain the displaced fact");
+      }
+      if (oldHistory.length === 1) {
+        const oldContent = oldLines.slice(oldHistory[0].start + 1, oldHistory[0].end);
+        while (oldContent.length && !oldContent.at(-1)?.trim()) oldContent.pop();
+        const prefixMatches = oldContent.every((line, index) => content[index] === line);
+        if (!prefixMatches) {
+          throw new Error("SUPERSEDE replacement ## History must preserve existing History as an exact prefix");
+        }
+        content = content.slice(oldContent.length);
+        if (!content.some((line) => line.trim()) && !historyEntry?.trim()) {
+          throw new Error("SUPERSEDE replacement ## History must append the displaced fact");
+        }
+      }
+    }
     if (content.some((line) => line.length)) {
       additions.set(section.key, [...(additions.get(section.key) ?? []), ...content]);
     }

--- a/agent/lib/card-store.ts
+++ b/agent/lib/card-store.ts
@@ -185,6 +185,12 @@ export function hasH2Section(body: string, heading: string): boolean {
   return h2Sections(body.split("\n"), heading).length > 0;
 }
 
+function hasOutsideHeading(body: string, pattern: RegExp): boolean {
+  const lines = body.split("\n");
+  const outside = outsideFences(lines);
+  return lines.some((line, index) => outside[index] && pattern.test(line));
+}
+
 function namedH2Sections(lines: string[]): NamedH2Section[] {
   const outside = outsideFences(lines);
   const starts = lines.flatMap((line, index) => {
@@ -455,6 +461,12 @@ export function mergeCard(input: MergeInput): MergeResult {
   if (replaceBody && operation !== "SUPERSEDE") {
     throw new Error("replaceBody is valid only for SUPERSEDE");
   }
+  if (historyEntry && /[\r\n]/.test(historyEntry)) {
+    throw new Error("historyEntry must be a single line");
+  }
+  if (operation === "UPDATE" && hasOutsideHeading(trimmedBody, /^ {0,3}#{1,2}\s+/)) {
+    throw new Error("UPDATE body must be a fact without H1/H2 headings");
+  }
   if (operation === "NOOP") {
     return { content: existing ?? "", action: "noop" };
   }
@@ -475,6 +487,12 @@ export function mergeCard(input: MergeInput): MergeResult {
 
   const parsed = parseFrontmatter(existing);
   const oldBody = parsed.body;
+  if (
+    operation === "UPDATE" &&
+    hasOutsideHeading(oldBody, /^ {0,3}##\s+(?:Обновление|Update)\s+\d{4}-\d{2}-\d{2}\s*$/i)
+  ) {
+    throw new Error("existing card has legacy dated update headings; run semantic cleanup before UPDATE");
+  }
   // Обновляем ТОЛЬКО известные ключи; created/source и любые неизвестные поля
   // (tier, relevance, last_accessed, phone, telegram, priority…) остаются как были.
   const updates: FmFields = { ...fields };

--- a/agent/tools/write_card.ts
+++ b/agent/tools/write_card.ts
@@ -5,6 +5,7 @@ import { join, relative, sep } from "node:path";
 import {
   acquireLock,
   atomicWrite,
+  hasH2Section,
   mergeCard,
   resolveCard,
 } from "../lib/card-store.js";
@@ -185,6 +186,9 @@ export default defineTool({
       if (replace_body || history_entry) {
         return { ok: false, error: "NOOP не принимает replace_body или history_entry." };
       }
+      if (!existsSync(file)) {
+        return { ok: false, error: `NOOP требует существующую карточку ${rel}.` };
+      }
       return { ok: true, file: rel, type, status: st, action: "noop", matchedBy: id.matchedBy };
     }
     if (replace_body && operation && operation !== "SUPERSEDE") {
@@ -215,7 +219,7 @@ export default defineTool({
       if ((effectiveOperation === "UPDATE" || effectiveOperation === "SUPERSEDE") && existing === undefined) {
         return { ok: false, error: `${effectiveOperation} требует существующую карточку ${rel}.` };
       }
-      const legacyHistoryInBody = /^##\s+History\s*$/im.test(body);
+      const legacyHistoryInBody = hasH2Section(body, "History");
       if (effectiveOperation === "SUPERSEDE" && !history_entry && !legacyHistoryInBody) {
         return {
           ok: false,

--- a/agent/tools/write_card.ts
+++ b/agent/tools/write_card.ts
@@ -89,13 +89,20 @@ function today(): string {
 
 export default defineTool({
   description:
-    "Создать или ДОПОЛНИТЬ типизированную карточку памяти в vault (существующая карточка " +
-    "сливается, а не затирается: неизвестные поля и старый текст сохраняются). " +
+    "Создать или обновить типизированную карточку памяти в vault. Явно выбери " +
+    "ADD, UPDATE, SUPERSEDE или NOOP; без operation старые вызовы определяются автоматически. " +
     "Используй ЭТО (не write_file) " +
     "для карточек — гарантирует валидный тип и схему. type строго один из: " +
     Object.keys(CARD_TYPE_DIR).join(", ") +
     ". Поля вне схемы недопустимы. Summary (день/неделя/…) НЕ создавай — их пишет ночной rollup.",
   inputSchema: z.object({
+    operation: z
+      .enum(["ADD", "UPDATE", "SUPERSEDE", "NOOP"])
+      .optional()
+      .describe(
+        "ADD создаёт новую карточку; UPDATE добавляет непротиворечивый факт в ## Log; " +
+          "SUPERSEDE заменяет текущую истину; NOOP ничего не пишет.",
+      ),
     type: z
       .preprocess(normalizeType, z.enum(CARD_TYPES))
       .describe("Тип карточки (строго из списка; алиасы вроде person/company → contact применяются автоматически)"),
@@ -116,6 +123,11 @@ export default defineTool({
       .optional()
       .describe("Вики-цели связей [[...]] (vault-пути или слаги), опционально"),
     body: z.string().min(1).describe("Тело карточки в markdown (контекст, факты)"),
+    history_entry: z
+      .string()
+      .min(1)
+      .optional()
+      .describe("Для SUPERSEDE: датированная строка о прежней истине, переносимая в ## History"),
     confidence: z
       .enum(["EXTRACTED", "INFERRED", "AMBIGUOUS"])
       .optional()
@@ -128,7 +140,20 @@ export default defineTool({
           "Без флага body дописывается, противоречащие факты так не исправить.",
       ),
   }),
-  async execute({ type, title, description, tags, status, domain, related, body, confidence, replace_body }) {
+  async execute({
+    operation,
+    type,
+    title,
+    description,
+    tags,
+    status,
+    domain,
+    related,
+    body,
+    history_entry,
+    confidence,
+    replace_body,
+  }) {
     // Валидация статуса против схемы типа (жёстко — иначе модель придумает статус).
     const allowed = SCHEMA.status[type] || ["active"];
     const st = status && allowed.includes(status) ? status : allowed[0];
@@ -140,8 +165,6 @@ export default defineTool({
     }
 
     const dir = join(VAULT(), "cards", CARD_TYPE_DIR[type]);
-    mkdirSync(dir, { recursive: true });
-
     // Идентичность: точный слаг → иначе карточка того же типа с таким же H1/name/aliases
     // (легаси-файлы с латинским слагом и кириллическим заголовком).
     const id = resolveCard(dir, title);
@@ -158,12 +181,47 @@ export default defineTool({
     const file = id.file;
     const rel = relative(VAULT(), file).split(sep).join("/");
 
+    if (operation === "NOOP") {
+      if (replace_body || history_entry) {
+        return { ok: false, error: "NOOP не принимает replace_body или history_entry." };
+      }
+      return { ok: true, file: rel, type, status: st, action: "noop", matchedBy: id.matchedBy };
+    }
+    if (replace_body && operation && operation !== "SUPERSEDE") {
+      return { ok: false, error: "replace_body допустим только для SUPERSEDE." };
+    }
+    if (history_entry && operation && operation !== "SUPERSEDE") {
+      return { ok: false, error: "history_entry допустим только для SUPERSEDE." };
+    }
+    if (operation === "SUPERSEDE" && !history_entry) {
+      return { ok: false, error: "SUPERSEDE требует history_entry с прежней истиной." };
+    }
+
+    mkdirSync(dir, { recursive: true });
+
     // Сбои лока/записи — структурированная ошибка, а не исключение: модель должна
     // увидеть внятное «занято/не записалось» и решить, что делать, а не уронить ход.
     let release: (() => void) | null = null;
     try {
       release = acquireLock(file);
       const existing = existsSync(file) ? readFileSync(file, "utf8") : undefined;
+      const effectiveOperation = operation ?? (replace_body ? "SUPERSEDE" : existing ? "UPDATE" : "ADD");
+      if (history_entry && effectiveOperation !== "SUPERSEDE") {
+        return { ok: false, error: "history_entry допустим только для SUPERSEDE." };
+      }
+      if (effectiveOperation === "ADD" && existing !== undefined) {
+        return { ok: false, error: `ADD отказан: карточка ${rel} уже существует.` };
+      }
+      if ((effectiveOperation === "UPDATE" || effectiveOperation === "SUPERSEDE") && existing === undefined) {
+        return { ok: false, error: `${effectiveOperation} требует существующую карточку ${rel}.` };
+      }
+      const legacyHistoryInBody = /^##\s+History\s*$/im.test(body);
+      if (effectiveOperation === "SUPERSEDE" && !history_entry && !legacyHistoryInBody) {
+        return {
+          ok: false,
+          error: "SUPERSEDE требует history_entry; legacy replace_body должен содержать ## History.",
+        };
+      }
       const { content, action } = mergeCard({
         existing,
         title,
@@ -180,8 +238,10 @@ export default defineTool({
         related,
         date: today(),
         replaceBody: replace_body === true,
+        operation: effectiveOperation,
+        historyEntry: history_entry,
       });
-      atomicWrite(file, content);
+      if (action !== "noop") atomicWrite(file, content);
       return { ok: true, file: rel, type, status: st, action, matchedBy: id.matchedBy };
     } catch (e) {
       return { ok: false, error: `Не удалось записать карточку ${rel}: ${(e as Error).message}` };

--- a/agent/tools/write_card.ts
+++ b/agent/tools/write_card.ts
@@ -127,6 +127,7 @@ export default defineTool({
     history_entry: z
       .string()
       .min(1)
+      .refine((value) => !/[\r\n]/.test(value), "history_entry должен быть одной строкой")
       .optional()
       .describe("Для SUPERSEDE: датированная строка о прежней истине, переносимая в ## History"),
     confidence: z

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -442,7 +442,6 @@
   while old ownerless markers keep the time-based compatibility rule.
 - Completion and cleanup mutate status only while holding the status lock and keep a
   reservation marked locally until its removal write succeeds.
-
 ## fix/reminder-node-runtime
 
 - Kept the security gate deterministic and dependency-free.
@@ -474,3 +473,21 @@
   note remains linkable while a missing `voice.ogg` attachment stays ignored.
 - The full Node matrix initially hit the existing deadline-probe timing test once;
   its isolated rerun and the complete 568-test rerun both passed.
+
+## Rollup card invariants (v0.3.11)
+
+- `write_card` now accepts an explicit `ADD | UPDATE | SUPERSEDE | NOOP` decision.
+  UPDATE owns one Log, SUPERSEDE owns Compiled Truth plus preserved History, and
+  relations enter through one canonical Related section.
+- Related identity ignores aliases and anchors. Links elsewhere in prose do not
+  suppress a relation, and `body` cannot provide its own Related heading.
+- SUPERSEDE replaces only Compiled Truth: old Log, History and Related content
+  survives, and newly supplied relations merge into that preserved graph structure.
+- `enforce.py` repairs only unambiguous drift under `cards/`: dated update blocks
+  migrate into Log, empty update headings disappear, and link-only Related blocks
+  merge idempotently. Prose-bearing duplicates are reported as compile candidates.
+- Raw daily transcripts and rollup summaries stay outside this cleanup scope.
+- TypeScript and Python section scanners ignore fenced code, so documentation
+  examples containing structural headings remain byte-identical.
+- The dbrain skill chooses semantic operations, rereads every touched card, and
+  consumes compile candidates; deterministic code keeps structural invariants.

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -482,10 +482,12 @@
 - Related identity ignores aliases and anchors. Links elsewhere in prose do not
   suppress a relation, and `body` cannot provide its own Related heading.
 - SUPERSEDE replaces only Compiled Truth: old Log, History and Related content
-  survives, and newly supplied relations merge into that preserved graph structure.
+  survives, newly supplied relations merge into that preserved graph structure, and
+  custom H2 sections survive unless the replacement explicitly supplies the same heading.
 - `enforce.py` repairs only unambiguous drift under `cards/`: dated update blocks
   migrate into Log, empty update headings disappear, and link-only Related blocks
-  merge idempotently. Prose-bearing duplicates are reported as compile candidates.
+  merge idempotently. Non-empty dated updates and ambiguous Markdown structures are
+  reported as semantic compile candidates; complex/fenced blocks remain byte-identical.
 - Raw daily transcripts and rollup summaries stay outside this cleanup scope.
 - TypeScript and Python section scanners ignore fenced code, so documentation
   examples containing structural headings remain byte-identical.

--- a/scripts/autograph/enforce.py
+++ b/scripts/autograph/enforce.py
@@ -9,6 +9,7 @@ Usage:
 """
 
 import json
+import re
 import sys
 from pathlib import Path
 from datetime import date
@@ -24,6 +25,159 @@ from common import (
 ENFORCE_MAX_FILE_BYTES = 10 * 1024 * 1024
 # cleanup.py owns bounded-memory repair; enforce only handles ordinary-sized cards.
 
+RELATED_HEADING_RE = re.compile(r'^##\s+Related\s*$', re.IGNORECASE)
+UPDATE_HEADING_RE = re.compile(
+    r'^##\s+(?:Обновление|Update)\s+(\d{4}-\d{2}-\d{2})\s*$', re.IGNORECASE)
+LOG_HEADING_RE = re.compile(r'^##\s+Log\s*$', re.IGNORECASE)
+H1_H2_RE = re.compile(r'^#{1,2}\s+')
+WIKILINK_RE = re.compile(r'\[\[([^\]]+)\]\]')
+
+
+def _outside_fences(lines: list[str]) -> list[bool]:
+    outside = [True] * len(lines)
+    fence_char = None
+    fence_len = 0
+    for index, line in enumerate(lines):
+        if fence_char:
+            outside[index] = False
+            close = re.match(r'^ {0,3}(`{3,}|~{3,})\s*$', line)
+            if close and close.group(1)[0] == fence_char and len(close.group(1)) >= fence_len:
+                fence_char = None
+                fence_len = 0
+            continue
+        opened = re.match(r'^ {0,3}(`{3,}|~{3,})(.*)$', line)
+        if not opened or (opened.group(1)[0] == '`' and '`' in opened.group(2)):
+            continue
+        outside[index] = False
+        fence_char = opened.group(1)[0]
+        fence_len = len(opened.group(1))
+    return outside
+
+
+def _sections(lines: list[str], matcher: re.Pattern) -> list[tuple[int, int, re.Match]]:
+    outside = _outside_fences(lines)
+    starts = [
+        (i, matcher.match(line.strip()))
+        for i, line in enumerate(lines)
+        if outside[i] and len(line) - len(line.lstrip(' ')) <= 3
+    ]
+    starts = [(i, match) for i, match in starts if match]
+    result = []
+    for start, match in starts:
+        end = len(lines)
+        for index in range(start + 1, len(lines)):
+            if (outside[index]
+                    and len(lines[index]) - len(lines[index].lstrip(' ')) <= 3
+                    and H1_H2_RE.match(lines[index].lstrip(' '))):
+                end = index
+                break
+        result.append((start, end, match))
+    return result
+
+
+def _replace_ranges(lines: list[str], ranges: list[tuple[int, int]],
+                    replacement: list[str], insert_at: int) -> list[str]:
+    by_start = {start: end for start, end in ranges}
+    output = []
+    index = 0
+    while index < len(lines):
+        end = by_start.get(index)
+        if end is not None:
+            if index == insert_at:
+                output.extend(replacement)
+            index = end
+            continue
+        output.append(lines[index])
+        index += 1
+    return output
+
+
+def _related_target(raw: str) -> str:
+    return raw.split('|', 1)[0].split('#', 1)[0].strip().lower()
+
+
+def cleanup_card_body(body: str) -> tuple[str, dict, bool]:
+    """Repair only unambiguous structural drift in a cards/** body."""
+    fixes = defaultdict(int)
+    compile_candidate = False
+    lines = body.split('\n')
+
+    # Legacy dated H2 updates become entries under one Log section. Empty update
+    # headings disappear. Existing Log content is preserved in source order.
+    updates = _sections(lines, UPDATE_HEADING_RE)
+    logs = _sections(lines, LOG_HEADING_RE)
+    if updates or len(logs) > 1:
+        combined = sorted(
+            [(start, end, 'update', match) for start, end, match in updates]
+            + [(start, end, 'log', match) for start, end, match in logs],
+            key=lambda item: item[0],
+        )
+        content = []
+        for start, end, kind, match in combined:
+            section_lines = [line for line in lines[start + 1:end] if line.strip()]
+            if kind == 'log':
+                content.extend(section_lines)
+                continue
+            if not section_lines:
+                fixes['empty_updates_removed'] += 1
+                continue
+            day = match.group(1)
+            if len(section_lines) == 1:
+                content.append(f'- {day}: {section_lines[0].strip()}')
+            else:
+                content.append(f'- {day}:')
+                content.extend(f'  {line}' for line in section_lines)
+            fixes['updates_migrated_to_log'] += 1
+
+        ranges = [(start, end) for start, end, _, _ in combined]
+        insert_at = combined[0][0]
+        keep_log = bool(content) or bool(logs)
+        replacement = ['## Log', *content] if keep_log else []
+        if len(logs) > 1:
+            fixes['log_sections_merged'] += len(logs) - 1
+        lines = _replace_ranges(lines, ranges, replacement, insert_at)
+
+    # Duplicate Related blocks are merged only when every non-empty line is a
+    # link-only list item. Prose-bearing duplicates stay byte-identical and are
+    # queued for the next semantic dbrain pass.
+    related = _sections(lines, RELATED_HEADING_RE)
+    if len(related) > 1:
+        safe = True
+        targets = []
+        seen = set()
+        duplicate_links = 0
+        for start, end, _ in related:
+            for line in lines[start + 1:end]:
+                if not line.strip():
+                    continue
+                matches = WIKILINK_RE.findall(line)
+                remainder = WIKILINK_RE.sub('', line)
+                remainder = re.sub(r'[-*·,;:\s]', '', remainder)
+                if not matches or remainder:
+                    safe = False
+                    break
+                for raw in matches:
+                    target = _related_target(raw)
+                    if not target or target in seen:
+                        duplicate_links += 1
+                        continue
+                    seen.add(target)
+                    targets.append(raw.strip())
+            if not safe:
+                break
+
+        if safe:
+            ranges = [(start, end) for start, end, _ in related]
+            replacement = ['## Related', *(f'- [[{target}]]' for target in targets)]
+            lines = _replace_ranges(lines, ranges, replacement, related[0][0])
+            fixes['related_sections_merged'] += len(related) - 1
+            fixes['related_links_deduped'] += duplicate_links
+        else:
+            compile_candidate = True
+
+    cleaned = '\n'.join(lines)
+    return cleaned, dict(fixes), compile_candidate
+
 
 def enforce(vault_dir: Path, schema: dict, apply=False, verbose=False):
     node_types = schema['node_types']
@@ -34,7 +188,7 @@ def enforce(vault_dir: Path, schema: dict, apply=False, verbose=False):
     stats = {
         'total': 0, 'valid': 0, 'fixed': 0, 'needs_review': 0,
         'no_fm': 0, 'skipped_oversize': 0,
-        'fixes': defaultdict(int), 'review_items': []
+        'fixes': defaultdict(int), 'review_items': [], 'compile_candidates': []
     }
     eligible_files = []
     for md in walk_vault(vault_dir):
@@ -58,6 +212,17 @@ def enforce(vault_dir: Path, schema: dict, apply=False, verbose=False):
 
         changed = False
         issues = []
+
+        if rp.startswith('cards/'):
+            cleaned_body, body_fixes, compile_candidate = cleanup_card_body(body)
+            if cleaned_body != body:
+                body = cleaned_body
+                changed = True
+            for name, count in body_fixes.items():
+                stats['fixes'][name] += count
+            if compile_candidate:
+                stats['compile_candidates'].append(rp)
+                issues.append('ambiguous duplicate Related sections')
 
         # --- TYPE ---
         t = fields.get('type', '')
@@ -248,6 +413,7 @@ def main():
         'skipped_oversize': stats['skipped_oversize'],
         'duplicates': len(dupes), 'mode': mode,
         'fixes': dict(stats['fixes']),
+        'compile_candidates': sorted(stats['compile_candidates']),
     }, indent=2))
     print(f"  Report: {out}")
 

--- a/scripts/autograph/enforce.py
+++ b/scripts/autograph/enforce.py
@@ -96,6 +96,30 @@ def _related_target(raw: str) -> str:
     return raw.split('|', 1)[0].split('#', 1)[0].strip().lower()
 
 
+def _simple_log_update_sections(
+        lines: list[str], sections: list[tuple[int, int, str, re.Match]]) -> bool:
+    """True only when Log/Update sections can be flattened without losing layout."""
+    outside = _outside_fences(lines)
+    markdown_block = re.compile(r'^(?:[-*+] |\d+[.)] |>|#{1,6}\s|\||`{3,}|~{3,})')
+    for start, end, kind, _ in sections:
+        indexes = list(range(start + 1, end))
+        while indexes and not lines[indexes[0]].strip():
+            indexes.pop(0)
+        while indexes and not lines[indexes[-1]].strip():
+            indexes.pop()
+        if any(not outside[index] for index in indexes):
+            return False
+        content = [lines[index] for index in indexes]
+        if any(not line.strip() for line in content):
+            return False
+        if kind == 'log':
+            if any(not re.match(r'^-\s+\S', line) for line in content):
+                return False
+        elif any(line != line.strip() or markdown_block.match(line) for line in content):
+            return False
+    return True
+
+
 def cleanup_card_body(body: str) -> tuple[str, dict, bool]:
     """Repair only unambiguous structural drift in a cards/** body."""
     fixes = defaultdict(int)
@@ -112,30 +136,44 @@ def cleanup_card_body(body: str) -> tuple[str, dict, bool]:
             + [(start, end, 'log', match) for start, end, match in logs],
             key=lambda item: item[0],
         )
-        content = []
-        for start, end, kind, match in combined:
-            section_lines = [line for line in lines[start + 1:end] if line.strip()]
-            if kind == 'log':
-                content.extend(section_lines)
-                continue
-            if not section_lines:
-                fixes['empty_updates_removed'] += 1
-                continue
-            day = match.group(1)
-            if len(section_lines) == 1:
-                content.append(f'- {day}: {section_lines[0].strip()}')
-            else:
-                content.append(f'- {day}:')
-                content.extend(f'  {line}' for line in section_lines)
-            fixes['updates_migrated_to_log'] += 1
+        nonempty_update = any(
+            any(line.strip() for line in lines[start + 1:end])
+            for start, end, kind, _ in combined if kind == 'update'
+        )
+        if nonempty_update:
+            # Moving chronology into Log cannot repair stale Compiled Truth. Queue
+            # the card for a semantic dbrain pass even when migration is safe.
+            compile_candidate = True
 
-        ranges = [(start, end) for start, end, _, _ in combined]
-        insert_at = combined[0][0]
-        keep_log = bool(content) or bool(logs)
-        replacement = ['## Log', *content] if keep_log else []
-        if len(logs) > 1:
-            fixes['log_sections_merged'] += len(logs) - 1
-        lines = _replace_ranges(lines, ranges, replacement, insert_at)
+        if not _simple_log_update_sections(lines, combined):
+            # Fences, nested blocks, indentation and paragraph breaks carry layout
+            # semantics. Leave the whole Log/Update cluster byte-identical.
+            compile_candidate = True
+        else:
+            content = []
+            for start, end, kind, match in combined:
+                section_lines = [line for line in lines[start + 1:end] if line.strip()]
+                if kind == 'log':
+                    content.extend(section_lines)
+                    continue
+                if not section_lines:
+                    fixes['empty_updates_removed'] += 1
+                    continue
+                day = match.group(1)
+                if len(section_lines) == 1:
+                    content.append(f'- {day}: {section_lines[0].strip()}')
+                else:
+                    content.append(f'- {day}:')
+                    content.extend(f'  {line}' for line in section_lines)
+                fixes['updates_migrated_to_log'] += 1
+
+            ranges = [(start, end) for start, end, _, _ in combined]
+            insert_at = combined[0][0]
+            keep_log = bool(content) or bool(logs)
+            replacement = ['## Log', *content] if keep_log else []
+            if len(logs) > 1:
+                fixes['log_sections_merged'] += len(logs) - 1
+            lines = _replace_ranges(lines, ranges, replacement, insert_at)
 
     # Duplicate Related blocks are merged only when every non-empty line is a
     # link-only list item. Prose-bearing duplicates stay byte-identical and are
@@ -222,7 +260,7 @@ def enforce(vault_dir: Path, schema: dict, apply=False, verbose=False):
                 stats['fixes'][name] += count
             if compile_candidate:
                 stats['compile_candidates'].append(rp)
-                issues.append('ambiguous duplicate Related sections')
+                issues.append('semantic card compile required')
 
         # --- TYPE ---
         t = fields.get('type', '')

--- a/scripts/autograph/tests/test_autograph.py
+++ b/scripts/autograph/tests/test_autograph.py
@@ -1036,6 +1036,16 @@ def main():
             "## Log\n## Update 2026-07-31\n```\n"
         )
         fenced_card.write_text(fenced_before)
+        complex_card = cleanup_vault / 'cards/notes/complex-log.md'
+        complex_before = (
+            "---\ntype: note\nstatus: active\ntags: [note, cleanup]\n"
+            "description: Complex Log fixture\n" + system_fields + "---\n"
+            "# Complex Log\n\nCurrent truth stays byte-identical.\n\n"
+            "## Log\n- 2026-07-20:\n  - nested item\n\n"
+            "```markdown\n## Update 2020-01-01\nexample only\n```\n\n"
+            "## Update 2026-08-01\nParagraph one.\n\nParagraph two.\n"
+        )
+        complex_card.write_text(complex_before)
         raw_file = cleanup_vault / 'daily/2026-07-31.md'
         raw_before = "# Raw\n\n## Обновление 2026-07-31\n\n## Related\n- [[hub]]\n"
         raw_file.write_text(raw_before)
@@ -1051,6 +1061,7 @@ def main():
                               str(cleanup_vault), str(schema_path), '--apply'])
         safe_after = safe_card.read_text()
         ambiguous_after = ambiguous_card.read_text()
+        complex_after = complex_card.read_text()
         cleanup_report = json.loads(
             (cleanup_vault / '.graph/enforce-report.json').read_text()
         )
@@ -1072,9 +1083,15 @@ def main():
              ambiguous_after.count('\n## Related\n') == 2
              and 'Keep this prose explanation' in ambiguous_after,
              ambiguous_after)
-        test("enforce reports prose-bearing card as compile candidate",
-             cleanup_report.get('compile_candidates') == ['cards/notes/ambiguous.md'],
+        test("enforce queues migrated updates and ambiguous structures for compile",
+             cleanup_report.get('compile_candidates') == [
+                 'cards/notes/ambiguous.md',
+                 'cards/notes/complex-log.md',
+                 'cards/notes/safe.md',
+             ],
              str(cleanup_report))
+        test("enforce leaves complex and fenced Log/Update sections byte-identical",
+             complex_after == complex_before, complex_after)
         test("enforce card cleanup never touches raw transcripts or summaries",
              raw_file.read_text() == raw_before and summary_file.read_text() == summary_before)
         test("enforce preserves structural headings inside fenced code byte-for-byte",
@@ -1082,11 +1099,13 @@ def main():
 
         safe_snapshot = safe_after
         ambiguous_snapshot = ambiguous_after
+        complex_snapshot = complex_after
         code, _, err = run([py, str(SCRIPTS_DIR / 'enforce.py'),
                             str(cleanup_vault), str(schema_path), '--apply'])
         test("second enforce card cleanup is byte-stable",
              code == 0 and safe_card.read_text() == safe_snapshot
-             and ambiguous_card.read_text() == ambiguous_snapshot,
+             and ambiguous_card.read_text() == ambiguous_snapshot
+             and complex_card.read_text() == complex_snapshot,
              err[:300])
 
         # --- discover.py ---

--- a/scripts/autograph/tests/test_autograph.py
+++ b/scripts/autograph/tests/test_autograph.py
@@ -998,6 +998,97 @@ def main():
              oversize_report.get('skipped_oversize') == 1,
              f"got: {oversize_report!r}")
 
+        _schema_cache.clear()
+        cleanup_vault = tmp / 'card-structure-vault'
+        (cleanup_vault / 'cards/notes').mkdir(parents=True)
+        (cleanup_vault / 'daily').mkdir()
+        (cleanup_vault / 'summaries/daily').mkdir(parents=True)
+        system_fields = (
+            f"domain: personal\nlast_accessed: {date.today().isoformat()}\n"
+            "tier: warm\nrelevance: 0.5\n"
+        )
+        safe_card = cleanup_vault / 'cards/notes/safe.md'
+        safe_card.write_text(
+            "---\ntype: note\nstatus: active\ntags: [note, cleanup]\n"
+            "description: Structural cleanup fixture\n" + system_fields + "---\n"
+            "# Safe card\n\nCurrent truth.\n\n"
+            "## Log\n- 2026-07-20: Earlier fact\n\n"
+            "## Обновление 2026-07-29\n\n"
+            "## Обновление 2026-07-30\nNew fact one.\n\n"
+            "## Update 2026-07-31\nNew fact two.\nSecond line.\n\n"
+            + "\n\n".join(
+                f"## Related\n- [[hub#part|Hub]]\n- [[sibling-{index}]]"
+                for index in range(8)
+            ) + "\n"
+        )
+        ambiguous_card = cleanup_vault / 'cards/notes/ambiguous.md'
+        ambiguous_card.write_text(
+            "---\ntype: note\nstatus: active\ntags: [note, cleanup]\n"
+            "description: Ambiguous Related fixture\n" + system_fields + "---\n"
+            "# Ambiguous\n\n## Related\n- [[hub]]\n\n"
+            "## Related\nKeep this prose explanation with [[other]].\n"
+        )
+        fenced_card = cleanup_vault / 'cards/notes/fenced.md'
+        fenced_before = (
+            "---\ntype: note\nstatus: active\ntags: [note, cleanup]\n"
+            "description: Fenced headings fixture\n" + system_fields + "---\n"
+            "# Fenced\n\n```markdown\n## Related\n- [[example]]\n"
+            "## Log\n## Update 2026-07-31\n```\n"
+        )
+        fenced_card.write_text(fenced_before)
+        raw_file = cleanup_vault / 'daily/2026-07-31.md'
+        raw_before = "# Raw\n\n## Обновление 2026-07-31\n\n## Related\n- [[hub]]\n"
+        raw_file.write_text(raw_before)
+        summary_file = cleanup_vault / 'summaries/daily/2026-07-31.md'
+        summary_before = (
+            "---\ntype: note\nstatus: active\ntags: [summary]\n"
+            "description: Summary scope fixture\n" + system_fields + "---\n"
+            "# Summary\n\n## Обновление 2026-07-31\nStill a summary section.\n"
+        )
+        summary_file.write_text(summary_before)
+
+        code, out, err = run([py, str(SCRIPTS_DIR / 'enforce.py'),
+                              str(cleanup_vault), str(schema_path), '--apply'])
+        safe_after = safe_card.read_text()
+        ambiguous_after = ambiguous_card.read_text()
+        cleanup_report = json.loads(
+            (cleanup_vault / '.graph/enforce-report.json').read_text()
+        )
+        test("enforce card cleanup exits 0", code == 0, err[:300])
+        test("enforce merges eight link-only Related sections",
+             safe_after.count('\n## Related\n') == 1, safe_after)
+        test("enforce deduplicates alias/anchor targets and keeps distinct links",
+             safe_after.count('[[hub#part|Hub]]') == 1
+             and all(f'[[sibling-{index}]]' in safe_after for index in range(8)),
+             safe_after)
+        test("enforce removes empty updates and migrates non-empty updates to one Log",
+             '## Обновление' not in safe_after and '## Update ' not in safe_after
+             and safe_after.count('\n## Log\n') == 1
+             and '- 2026-07-30: New fact one.' in safe_after
+             and '- 2026-07-31:' in safe_after
+             and '  Second line.' in safe_after,
+             safe_after)
+        test("enforce leaves prose-bearing duplicate Related untouched",
+             ambiguous_after.count('\n## Related\n') == 2
+             and 'Keep this prose explanation' in ambiguous_after,
+             ambiguous_after)
+        test("enforce reports prose-bearing card as compile candidate",
+             cleanup_report.get('compile_candidates') == ['cards/notes/ambiguous.md'],
+             str(cleanup_report))
+        test("enforce card cleanup never touches raw transcripts or summaries",
+             raw_file.read_text() == raw_before and summary_file.read_text() == summary_before)
+        test("enforce preserves structural headings inside fenced code byte-for-byte",
+             fenced_card.read_text() == fenced_before, fenced_card.read_text())
+
+        safe_snapshot = safe_after
+        ambiguous_snapshot = ambiguous_after
+        code, _, err = run([py, str(SCRIPTS_DIR / 'enforce.py'),
+                            str(cleanup_vault), str(schema_path), '--apply'])
+        test("second enforce card cleanup is byte-stable",
+             code == 0 and safe_card.read_text() == safe_snapshot
+             and ambiguous_card.read_text() == ambiguous_snapshot,
+             err[:300])
+
         # --- discover.py ---
         print("\n--- discover.py ---")
         _schema_cache.clear()

--- a/scripts/memory/instructions/dbrain-processor/SKILL.md
+++ b/scripts/memory/instructions/dbrain-processor/SKILL.md
@@ -55,7 +55,8 @@ Always pick `type` and `status` from `schema.json` → `node_types`. Never inven
 1. **CAPTURE** (`phases/capture.md`) — read the transcript, segment it, and decide
    what is noteworthy: which entities, decisions, ideas, and topics the day produced.
 2. **PROCESS** (`phases/process.md`) — create / update cards for the noteworthy items,
-   choosing type + description-snippet + tags + status; dedup against existing cards.
+   choosing exactly one `ADD | UPDATE | SUPERSEDE | NOOP` operation, then type +
+   description-snippet + tags + status; dedup against existing cards.
 3. **LINK** (`phases/link.md`) — wire every new card to its domain hub + 2–3 neighbors.
 4. **SUMMARIZE** (`phases/summarize.md`) — write the daily-summary card: the day's
    TOPICS plus a MOC linking up to the week, down to the created cards, and down to
@@ -76,6 +77,12 @@ uv run scripts/autograph/engine.py decay vault                        # recomput
 uv run scripts/autograph/graph.py health vault vault/schema.json      # confirm score
 ```
 
+Read `.graph/enforce-report.json` after `enforce.py`. Every path in
+`compile_candidates` needs semantic repair during the next dbrain pass: reread the
+card, decide its current truth, and use `write_card` to leave one coherent card.
+The mechanical pass deliberately refuses to guess when duplicate `## Related`
+sections contain prose.
+
 If `uv` / Python is unavailable, still produce the cards and summary (they are plain
 Markdown) and let the nightly doctor run the mechanical pass later.
 
@@ -89,6 +96,12 @@ Markdown) and let the nightly doctor run the mechanical pass later.
 - **tags:** 2–5, lowercase, kebab-case.
 - **Idempotent.** If the daily file already carries a processing marker and a
   `summaries/daily/YYYY-MM-DD.md` exists, only reconcile new entries; do not duplicate cards.
+- **One structure per card.** Exactly one `## Log` and one `## Related`; never emit
+  dated `## Обновление` / `## Update` headings. Pass relations only through the
+  `write_card.related` argument, never inside `body`.
+- **Verify writes.** Reread every created or updated card before finishing. Confirm
+  one Log, one Related, no empty/dated update headings, and that Compiled Truth says
+  what is true now. A failed invariant keeps the rollup unfinished.
 - **Quiet days are fine.** No noteworthy entities → still write a short daily-summary
   with topics and the MOC down to the raw transcript. Do not manufacture cards.
 

--- a/scripts/memory/instructions/dbrain-processor/phases/link.md
+++ b/scripts/memory/instructions/dbrain-processor/phases/link.md
@@ -10,25 +10,23 @@ Wire every card created/updated in Phase 2 into the graph. No orphans.
 
 1. **Hub link.** Determine the card's domain from its path via schema
    `domain_inference` (`cards/projects/` → work, `cards/notes/` → knowledge, etc.).
-   Add the domain hub to a `## Related` section:
-   ```markdown
-   ## Related
-   - [[cards/notes/_index|Knowledge]]
-   ```
+   Add the domain hub through the `write_card` tool's `related` argument, for
+   example `cards/notes/_index|Knowledge`. Never place a `## Related` heading in
+   `body`; the tool owns the section.
    The hub is the domain's `_index.md` (created/maintained by `moc.py generate`). If it
    does not exist yet, still link it — the mechanical pass will materialize it.
-2. **Neighbor links (2–3).** Find sibling cards of the same type+domain and link the
-   2–3 most relevant, each with a short context phrase:
-   ```markdown
-   - [[cards/projects/iva-memory|Iva memory]] — this decision implements its scheduler
-   ```
+2. **Neighbor links (2–3).** Find sibling cards of the same type+domain and pass the
+   2–3 most relevant targets through `related` (an Obsidian alias is allowed):
    Find siblings with:
    ```bash
    grep -rl "type: <type>" vault/cards/<kind>/
    uv run scripts/autograph/graph.py backlinks vault cards/<kind>/<hub> vault/schema.json
    ```
 3. **Back-reference.** When a card relates strongly to another, add the reciprocal link
-   on the neighbor too (keep the graph undirected where it makes sense).
+   on the neighbor too (keep the graph undirected where it makes sense). For a
+   relation-only UPDATE, reread the neighbor and pass a body fact that is already
+   present verbatim; the idempotence check prevents a new Log entry while `related`
+   is canonicalized.
 4. **Touch.** Mark the card as freshly accessed so decay treats it as active:
    ```bash
    uv run scripts/autograph/engine.py touch vault/cards/<kind>/<file>.md
@@ -37,7 +35,7 @@ Wire every card created/updated in Phase 2 into the graph. No orphans.
 ## Checklist per card
 
 - [ ] Hub linked in `## Related`?
-- [ ] ≥2 neighbor links with context phrases?
+- [ ] ≥2 neighbor links?
 - [ ] `description` ≠ title repeat?
 - [ ] `tags`: 2–5, lowercase, kebab-case?
 - [ ] `status` ∈ schema enum for the type?
@@ -46,3 +44,7 @@ Wire every card created/updated in Phase 2 into the graph. No orphans.
 
 All created/updated cards now have a populated `## Related`. Proceed to SUMMARIZE,
 which links the daily-summary down to these cards.
+
+Before proceeding, reread every touched card. Each must have exactly one
+`## Related`, at most one `## Log`, no dated update heading, and current Compiled
+Truth. Fix any violation now; do not defer it to the next nightly pass.

--- a/scripts/memory/instructions/dbrain-processor/phases/process.md
+++ b/scripts/memory/instructions/dbrain-processor/phases/process.md
@@ -15,13 +15,18 @@ For each item:
    ```bash
    grep -ril "<entity name or key phrase>" cards/
    ```
-   - Match found → **update** that card (sharpen description, add tags, bump status,
-     append a dated line under `## Log`). Do not create a duplicate.
-     - If the new fact **contradicts** a current value → **SUPERSEDE**: rewrite the current
-       value (Compiled Truth) and move the old one to `## History` with a date range.
-       See `references/classification.md` → "ADD / SUPERSEDE / NOOP".
-   - No match → **create** a new card (prefer the `write_card` tool — it enforces type/schema).
-   - Tag each card with `confidence: EXTRACTED|INFERRED` (see classification.md → "Confidence").
+   Then choose exactly one operation and pass it to `write_card`:
+   - No match → **ADD**. Create the card; ADD refuses an existing identity.
+   - Match, same fact already present → **NOOP**. Do not touch the file.
+   - Match, genuinely new and compatible fact → **UPDATE**. The tool appends one
+     dated bullet under the card's single `## Log`.
+   - Match, new fact contradicts current truth → **SUPERSEDE**. Pass the complete
+     new Compiled Truth in `body` and the displaced old fact in `history_entry`.
+     The tool rewrites current truth and preserves one append-only `## History`.
+   See `references/classification.md` → "ADD / UPDATE / SUPERSEDE / NOOP".
+   Never use `UPDATE` to hide a contradiction in chronology.
+   - Tag each written card with `confidence: EXTRACTED|INFERRED` (see
+     classification.md → "Confidence").
 2. **Path & filename.** Place by type (see SKILL layout table). Filenames are
    kebab-case slugs:
    - `cards/contacts/jane-doe.md`, `cards/projects/iva-memory.md`,
@@ -34,9 +39,12 @@ For each item:
    - `description` is a search snippet (what/why), never a title repeat.
    - `tags`: 2–5, lowercase, kebab-case.
    - `created: YYYY-MM-DD` and `source: daily/YYYY-MM-DD.md`.
-4. **Body.** A few sentences of context, then leave a `## Related` section for Phase 3.
-   Quote the transcript only as needed; link back with
-   `source: daily/YYYY-MM-DD.md` in frontmatter.
+4. **Body.** A few sentences of context. Never put `## Related` in `body`; collect
+   relation targets and pass them through the `related` argument. Quote the transcript
+   only as needed; link back with `source: daily/YYYY-MM-DD.md` in frontmatter.
+5. **Reread.** After each non-NOOP call, reread the returned file. Confirm current
+   truth is current, and that it contains at most one `## Log`, at most one
+   `## Related`, and no dated `## Обновление` / `## Update` heading.
 
 ## Title-as-claim (for notes & ideas)
 

--- a/scripts/memory/instructions/dbrain-processor/references/classification.md
+++ b/scripts/memory/instructions/dbrain-processor/references/classification.md
@@ -40,12 +40,15 @@ same person, same project, same decision being refined. Append a dated line unde
 `## Log` section and sharpen the `description`. Creating a near-duplicate is the most
 common mistake — grep first.
 
-## ADD / SUPERSEDE / NOOP (temporal conflict)
+## ADD / UPDATE / SUPERSEDE / NOOP (temporal conflict)
 
 For every fact, pick one operation:
 
 - **ADD** — genuinely new subject → create a card (prefer the `write_card` tool; it enforces
   the schema so you can't invent a type or field).
+- **UPDATE** — existing subject, new fact compatible with current truth → add it to
+  the card's single dated `## Log`. UPDATE never creates a card and never carries a
+  contradictory former/current pair.
 - **NOOP** — already captured and unchanged → do nothing.
 - **SUPERSEDE** — the new fact *contradicts* a current value on an existing card (job changed,
   moved city, status flipped). Do NOT just append: **rewrite** the card's current value
@@ -58,6 +61,10 @@ For every fact, pick one operation:
 
 The deterministic scan `.graph/supersede-candidates.json` lists same-entity cards with
 conflicting fields — resolve each by superseding the stale one.
+
+The mechanical report `.graph/enforce-report.json` may list `compile_candidates`
+whose duplicate Related sections contain prose. Reread and repair those cards
+semantically on the next dbrain pass; deterministic cleanup will not discard prose.
 
 ## Confidence
 

--- a/scripts/write-card.test.mjs
+++ b/scripts/write-card.test.mjs
@@ -249,7 +249,7 @@ test("явные UPDATE складываются в единственный Log
   assert.equal(read(created.file), before, "повтор факта должен быть byte-stable");
 });
 
-test("ADD не перезаписывает, UPDATE не создаёт, NOOP не пишет", async () => {
+test("ADD не перезаписывает, UPDATE не создаёт, NOOP не пишет и требует карточку", async () => {
   const base = {
     type: "note",
     title: "Границы операции",
@@ -288,8 +288,13 @@ test("ADD не перезаписывает, UPDATE не создаёт, NOOP н
     title: "NOOP без каталога",
     status: "active",
   });
-  assert.equal(noop.action, "noop");
+  assert.equal(noop.ok, false);
+  assert.match(noop.error, /NOOP требует существующую/);
   assert.equal(existsSync(projectDir), false, "NOOP не должен создавать даже каталог");
+
+  const existingNoop = await call({ ...base, operation: "NOOP" });
+  assert.equal(existingNoop.action, "noop");
+  assert.equal(read(created.file), before, "NOOP существующей карточки не меняет файл");
 });
 
 test("body с Related отклоняется без записи", async () => {
@@ -383,8 +388,9 @@ test("SUPERSEDE требует history_entry, заменяет truth и сохр
     description: "текущий владелец Alice",
     tags: ["note", "owner"],
     body:
-      "Current owner: Alice\n\n## Log\n- 2026-07-01: Ownership confirmed\n\n" +
-      "## History\n- 2025: Initial owner Carol",
+      "Current owner: Alice\n\n## Evidence\n\n```text\nowner: Alice\n```\n\n" +
+      "## Log\n- 2026-07-01: Ownership confirmed\n\n" +
+      "## History\n\n- 2025: Initial owner Carol\n  Continued detail\n",
     related: ["cards/contacts/alice"],
   };
   const created = await call(base);
@@ -397,6 +403,16 @@ test("SUPERSEDE требует history_entry, заменяет truth и сохр
   });
   assert.equal(rejected.ok, false);
   assert.match(rejected.error, /требует history_entry/);
+  assert.equal(read(created.file), before);
+
+  const fencedLegacy = await call({
+    ...base,
+    operation: undefined,
+    replace_body: true,
+    body: "Current owner: Bob\n\n```markdown\n## History\n- example only\n```",
+  });
+  assert.equal(fencedLegacy.ok, false);
+  assert.match(fencedLegacy.error, /legacy replace_body должен содержать ## History/);
   assert.equal(read(created.file), before);
 
   const replaced = await call({
@@ -416,10 +432,39 @@ test("SUPERSEDE требует history_entry, заменяет truth и сохр
   assert.equal(out.match(/^## Log$/gm).length, 1);
   assert.equal(out.match(/^## Related$/gm).length, 1);
   assert.match(out, /Initial owner Carol/);
+  assert.ok(
+    out.includes("## History\n\n- 2025: Initial owner Carol\n  Continued detail\n"),
+    "existing History must remain byte-for-byte before the appended entry",
+  );
   assert.match(out, /Current owner Alice/);
   assert.match(out, /Ownership confirmed/);
+  assert.match(out, /## Evidence\n\n```text\nowner: Alice\n```/);
   assert.match(out, /\[\[cards\/contacts\/alice\]\]/);
   assert.match(out, /\[\[cards\/contacts\/bob\]\]/);
+});
+
+test("SUPERSEDE заменяет явно названную custom-секцию и сохраняет остальные", async () => {
+  const base = {
+    operation: "ADD",
+    type: "note",
+    title: "Явная замена секции",
+    description: "проверка preserve replace semantics",
+    tags: ["note", "supersede"],
+    body: "Truth v1\n\n## Evidence\nold evidence\n\n## Notes\nkeep me",
+  };
+  const created = await call(base);
+  const result = await call({
+    ...base,
+    operation: "SUPERSEDE",
+    body: "Truth v2\n\n## Evidence\nnew evidence",
+    history_entry: "Truth v1",
+  });
+  assert.equal(result.action, "replaced");
+  const out = read(created.file);
+  assert.match(out, /Truth v2/);
+  assert.doesNotMatch(out, /old evidence/);
+  assert.match(out, /## Evidence\nnew evidence/);
+  assert.match(out, /## Notes\nkeep me/);
 });
 
 // ─── лок и атомарная запись ────────────────────────────────────────────────

--- a/scripts/write-card.test.mjs
+++ b/scripts/write-card.test.mjs
@@ -6,7 +6,16 @@
 import "./lib/ts-esm-hooks.mjs";
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, readdirSync, cpSync, rmSync } from "node:fs";
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -200,6 +209,217 @@ test("related дописываются в существующую секцию 
   assert.equal(out.match(/^## Related$/gm).length, 1);
   assert.equal(out.match(/\[\[majento\]\]/g).length, 1);
   assert.ok(out.includes("[[aimasters]]"));
+});
+
+test("явные UPDATE складываются в единственный Log без датированных H2", async () => {
+  const base = {
+    operation: "ADD",
+    type: "note",
+    title: "Единый журнал",
+    description: "проверка единственного журнала",
+    tags: ["note", "log"],
+    body: "Текущая выжимка.",
+    related: ["cards/notes/hub"],
+  };
+  const created = await call(base);
+  assert.equal(created.ok, true);
+  await call({
+    ...base,
+    operation: "UPDATE",
+    body: "Добавлен первый непротиворечивый факт.",
+  });
+  await call({
+    ...base,
+    operation: "UPDATE",
+    body: "Добавлен второй непротиворечивый факт.",
+  });
+  const out = read(created.file);
+  assert.equal(out.match(/^## Log$/gm).length, 1);
+  assert.equal(out.match(/^## (?:Обновление|Update) /gm), null);
+  assert.match(out, /^- \d{4}-\d{2}-\d{2}: Добавлен первый/m);
+  assert.match(out, /^- \d{4}-\d{2}-\d{2}: Добавлен второй/m);
+
+  const before = out;
+  const repeated = await call({
+    ...base,
+    operation: "UPDATE",
+    body: "Добавлен второй непротиворечивый факт.",
+  });
+  assert.equal(repeated.action, "updated");
+  assert.equal(read(created.file), before, "повтор факта должен быть byte-stable");
+});
+
+test("ADD не перезаписывает, UPDATE не создаёт, NOOP не пишет", async () => {
+  const base = {
+    type: "note",
+    title: "Границы операции",
+    description: "проверка контрактов операций",
+    tags: ["note", "operation"],
+    body: "Исходное содержимое.",
+  };
+  const created = await call({ ...base, operation: "ADD" });
+  const before = read(created.file);
+  const duplicate = await call({ ...base, operation: "ADD", body: "Нельзя записать." });
+  assert.equal(duplicate.ok, false);
+  assert.match(duplicate.error, /ADD отказан/);
+  assert.equal(read(created.file), before);
+
+  const notesDir = join(VAULT, "cards", "notes");
+  const countBeforeMissingUpdate = readdirSync(notesDir).length;
+  const missing = await call({
+    ...base,
+    operation: "UPDATE",
+    title: "Отсутствующая карточка для UPDATE",
+  });
+  assert.equal(missing.ok, false);
+  assert.match(missing.error, /UPDATE требует существующую/);
+  assert.equal(
+    readdirSync(notesDir).length,
+    countBeforeMissingUpdate,
+    "UPDATE missing must not create a second card",
+  );
+
+  const projectDir = join(VAULT, "cards", "projects");
+  assert.equal(existsSync(projectDir), false);
+  const noop = await call({
+    ...base,
+    operation: "NOOP",
+    type: "project",
+    title: "NOOP без каталога",
+    status: "active",
+  });
+  assert.equal(noop.action, "noop");
+  assert.equal(existsSync(projectDir), false, "NOOP не должен создавать даже каталог");
+});
+
+test("body с Related отклоняется без записи", async () => {
+  const base = {
+    operation: "ADD",
+    type: "note",
+    title: "Related только параметром",
+    description: "проверка запрета Related в body",
+    tags: ["note", "related"],
+    body: "Исходная истина.",
+  };
+  const created = await call(base);
+  const before = read(created.file);
+  const rejected = await call({
+    ...base,
+    operation: "UPDATE",
+    body: "Новый факт.\n\n## Related\n- [[wrong-place]]",
+  });
+  assert.equal(rejected.ok, false);
+  assert.match(rejected.error, /pass links through related/);
+  assert.equal(read(created.file), before);
+});
+
+test("fenced структурные заголовки остаются кодом", async () => {
+  const fenced = [
+    "Пример формата:",
+    "```markdown",
+    "## Related",
+    "## Log",
+    "## Update 2026-08-05",
+    "```",
+  ].join("\n");
+  const created = await call({
+    operation: "ADD",
+    type: "note",
+    title: "Пример fenced headings",
+    description: "структурные заголовки внутри code fence",
+    tags: ["note", "fence"],
+    body: fenced,
+    related: ["cards/notes/hub"],
+  });
+  assert.equal(created.ok, true);
+  const out = read(created.file);
+  assert.ok(out.includes(fenced), "code example must remain byte-identical");
+  assert.equal(out.match(/^## Related$/gm).length, 2, "one fenced example plus one real section");
+
+  await call({
+    operation: "UPDATE",
+    type: "note",
+    title: "Пример fenced headings",
+    description: "структурные заголовки внутри code fence",
+    tags: ["note", "fence"],
+    body: "Совместимый новый факт.",
+    related: ["cards/notes/hub#part|Hub"],
+  });
+  const updated = read(created.file);
+  assert.ok(updated.includes(fenced));
+  assert.equal(updated.match(/^## Log$/gm).length, 2, "one fenced example plus one real section");
+  assert.match(updated, /^- \d{4}-\d{2}-\d{2}: Совместимый новый факт\.$/m);
+});
+
+test("Related дедуплицирует target по alias/anchor и не считает ссылку в prose", async () => {
+  const base = {
+    operation: "ADD",
+    type: "note",
+    title: "Нормализация Related",
+    description: "проверка идентичности ссылок",
+    tags: ["note", "related"],
+    body: "В тексте уже упомянут [[cards/notes/hub]], но это не секция связей.",
+    related: ["cards/notes/hub#top|Hub"],
+  };
+  const created = await call(base);
+  await call({
+    ...base,
+    operation: "UPDATE",
+    body: "Ещё один факт.",
+    related: ["cards/notes/hub#other|Other", "cards/notes/sibling"],
+  });
+  const out = read(created.file);
+  assert.equal(out.match(/^## Related$/gm).length, 1);
+  assert.equal(out.match(/\[\[cards\/notes\/hub#/g).length, 1);
+  assert.equal(out.match(/\[\[cards\/notes\/hub\]\]/g).length, 1, "prose link remains separate");
+  assert.equal(out.match(/\[\[cards\/notes\/sibling\]\]/g).length, 1);
+});
+
+test("SUPERSEDE требует history_entry, заменяет truth и сохраняет History", async () => {
+  const base = {
+    operation: "ADD",
+    type: "note",
+    title: "Смена владельца",
+    description: "текущий владелец Alice",
+    tags: ["note", "owner"],
+    body:
+      "Current owner: Alice\n\n## Log\n- 2026-07-01: Ownership confirmed\n\n" +
+      "## History\n- 2025: Initial owner Carol",
+    related: ["cards/contacts/alice"],
+  };
+  const created = await call(base);
+  const before = read(created.file);
+  const rejected = await call({
+    ...base,
+    operation: "SUPERSEDE",
+    description: "текущий владелец Bob",
+    body: "Current owner: Bob",
+  });
+  assert.equal(rejected.ok, false);
+  assert.match(rejected.error, /требует history_entry/);
+  assert.equal(read(created.file), before);
+
+  const replaced = await call({
+    ...base,
+    operation: "SUPERSEDE",
+    description: "текущий владелец Bob",
+    body: "Current owner: Bob",
+    history_entry: "2026-01→08: Current owner Alice",
+    related: ["cards/contacts/bob"],
+  });
+  assert.equal(replaced.action, "replaced");
+  const out = read(created.file);
+  const current = out.split("## History")[0];
+  assert.match(current, /Current owner: Bob/);
+  assert.doesNotMatch(current, /Current owner: Alice/);
+  assert.equal(out.match(/^## History$/gm).length, 1);
+  assert.equal(out.match(/^## Log$/gm).length, 1);
+  assert.equal(out.match(/^## Related$/gm).length, 1);
+  assert.match(out, /Initial owner Carol/);
+  assert.match(out, /Current owner Alice/);
+  assert.match(out, /Ownership confirmed/);
+  assert.match(out, /\[\[cards\/contacts\/alice\]\]/);
+  assert.match(out, /\[\[cards\/contacts\/bob\]\]/);
 });
 
 // ─── лок и атомарная запись ────────────────────────────────────────────────

--- a/scripts/write-card.test.mjs
+++ b/scripts/write-card.test.mjs
@@ -159,6 +159,22 @@ test("description длиннее 500 символов отклоняется с 
   );
 });
 
+test("history_entry принимает только одну строку", () => {
+  assert.throws(
+    () =>
+      writeCard.inputSchema.parse({
+        operation: "SUPERSEDE",
+        type: "note",
+        title: "Многострочная история",
+        description: "проверка структурной безопасности history entry",
+        tags: ["note"],
+        body: "Новая истина",
+        history_entry: "Старая истина\n\n## Log\n- injected",
+      }),
+    /одной строкой/,
+  );
+});
+
 test("tags и domain квотируются, если содержат YAML-спецсимволы", async () => {
   const res = await call({
     type: "note",
@@ -316,6 +332,34 @@ test("body с Related отклоняется без записи", async () => {
   assert.equal(rejected.ok, false);
   assert.match(rejected.error, /pass links through related/);
   assert.equal(read(created.file), before);
+});
+
+test("UPDATE отклоняет H1/H2 и существующие legacy dated-секции без записи", async () => {
+  const base = {
+    operation: "ADD",
+    type: "note",
+    title: "Fail closed update",
+    description: "проверка структурных границ update",
+    tags: ["note", "update"],
+    body: "Текущая истина.",
+  };
+  const created = await call(base);
+  const before = read(created.file);
+  const heading = await call({
+    ...base,
+    operation: "UPDATE",
+    body: "Новый факт.\n\n## Next steps\nнеструктурированный хвост",
+  });
+  assert.equal(heading.ok, false);
+  assert.match(heading.error, /without H1\/H2 headings/);
+  assert.equal(read(created.file), before);
+
+  const legacy = `${before.trimEnd()}\n\n## Обновление 2026-08-01\nСтарый факт.\n`;
+  writeFileSync(join(VAULT, created.file), legacy);
+  const dated = await call({ ...base, operation: "UPDATE", body: "Ещё один факт." });
+  assert.equal(dated.ok, false);
+  assert.match(dated.error, /run semantic cleanup before UPDATE/);
+  assert.equal(read(created.file), legacy);
 });
 
 test("fenced структурные заголовки остаются кодом", async () => {

--- a/scripts/write-card.test.mjs
+++ b/scripts/write-card.test.mjs
@@ -467,6 +467,42 @@ test("SUPERSEDE заменяет явно названную custom-секцию
   assert.match(out, /## Notes\nkeep me/);
 });
 
+test("legacy replace_body требует непустой History prefix и добавляет только suffix", async () => {
+  const base = {
+    operation: "ADD",
+    type: "note",
+    title: "Legacy History prefix",
+    description: "проверка безопасной совместимости replace body",
+    tags: ["note", "legacy"],
+    body: "Truth v1\n\n## History\n\n- 2025-01-01: Truth v0",
+  };
+  const created = await call(base);
+  const before = read(created.file);
+
+  for (const body of [
+    "Truth v2\n\n## History\n",
+    "Truth v2\n\n## History\n\n- 2025-01-01: Different history\n- 2026-08-05: Truth v1",
+    "Truth v2\n\n## History\n\n- 2025-01-01: Truth v0",
+  ]) {
+    const rejected = await call({ ...base, operation: undefined, replace_body: true, body });
+    assert.equal(rejected.ok, false);
+    assert.equal(read(created.file), before);
+  }
+
+  const replaced = await call({
+    ...base,
+    operation: undefined,
+    replace_body: true,
+    body:
+      "Truth v2\n\n## History\n\n- 2025-01-01: Truth v0\n- 2026-08-05: Truth v1",
+  });
+  assert.equal(replaced.action, "replaced");
+  const out = read(created.file);
+  assert.equal(out.match(/2025-01-01: Truth v0/g).length, 1);
+  assert.equal(out.match(/2026-08-05: Truth v1/g).length, 1);
+  assert.match(out, /Truth v2/);
+});
+
 // ─── лок и атомарная запись ────────────────────────────────────────────────
 const { acquireLock, atomicWrite } = await import(join(REPO, "agent", "lib", "card-store.ts"));
 


### PR DESCRIPTION
## What\n- make ADD, UPDATE, SUPERSEDE and NOOP explicit card operations\n- keep one Log and Related, with alias/anchor-aware relation identity\n- preserve append-only History and custom sections during SUPERSEDE\n- repair only unambiguous card drift; queue semantic compile for stale or complex cases\n- strengthen the dbrain processor contract and reread invariants\n\n## Safety\n- NOOP requires an existing identity\n- history_entry is one line; legacy replace_body requires an exact History prefix plus a non-empty suffix\n- UPDATE rejects structural H1/H2 and legacy dated sections before writing\n- fenced/complex Markdown remains byte-identical\n- raw transcripts and summaries stay outside cleanup\n\n## Validation\n- Node: 578/578\n- Autograph: 300/300\n- typecheck: passed\n- build: passed\n- git diff check: clean\n\nCloses #133