### PR TITLE
fix: reject invalid model providers

### DIFF
--- a/agent/hooks/usage.ts
+++ b/agent/hooks/usage.ts
@@ -1,5 +1,6 @@
 import { defineHook } from "eve/hooks";
 import { appendUsage, subagentTurnId } from "../../scripts/lib/usage.ts";
+import { resolveModelProvider } from "../lib/model-provider.ts";
 
 // Учёт фактического расхода токенов. ОДИН хук ловит весь расход одного eve-агента без
 // двойного счёта: основной чат (channel.kind="telegram") и фоновые джобы через eve/client —
@@ -11,19 +12,8 @@ import { appendUsage, subagentTurnId } from "../../scripts/lib/usage.ts";
 // КАЖДОМ шаге модели, включая tool-call раунды. Относительный импорт scripts/lib работает
 // в бандле (см. transcript.ts).
 
-const PROVIDER = process.env.MODEL_PROVIDER ?? "ollama";
-// Модель/провайдер не приходят в событие — берём из env (та же логика, что в agent/agent.ts).
-const MODEL =
-  PROVIDER === "codex"
-    ? (process.env.CODEX_MODEL ?? "gpt-5.5")
-    : PROVIDER === "openrouter"
-      ? (process.env.OPENROUTER_MODEL ?? "openai/gpt-5.1")
-      : PROVIDER === "opencode"
-        ? (process.env.OPENCODE_MODEL ?? "deepseek-v4-pro").replace(
-            /^opencode-go\//,
-            "",
-          )
-        : (process.env.OLLAMA_MODEL ?? "deepseek-v4-pro");
+// Модель/провайдер не приходят в событие — используем тот же строгий выбор, что и runtime.
+const { name: PROVIDER, model: MODEL } = resolveModelProvider();
 
 interface StepData {
   stepIndex: number;

--- a/agent/lib/model-provider.test.ts
+++ b/agent/lib/model-provider.test.ts
@@ -1,0 +1,143 @@
+/* eslint-disable @typescript-eslint/no-floating-promises -- Node's test runner owns registrations. */
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  MODEL_PROVIDER_NAMES,
+  resolveModelProvider,
+} from "./model-provider.ts";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
+}
+
+test("model provider selection defaults to Ollama", () => {
+  assert.deepEqual(resolveModelProvider({}), {
+    name: "ollama",
+    model: "deepseek-v4-pro",
+    compatibleReasoning: true,
+  });
+});
+
+test("model provider selection preserves each supported provider identity", () => {
+  assert.deepEqual(
+    resolveModelProvider({
+      MODEL_PROVIDER: "ollama",
+      OLLAMA_MODEL: "ollama-model",
+    }),
+    { name: "ollama", model: "ollama-model", compatibleReasoning: true },
+  );
+  assert.deepEqual(
+    resolveModelProvider({
+      MODEL_PROVIDER: "opencode",
+      OPENCODE_MODEL: "opencode-go/opencode-model",
+    }),
+    { name: "opencode", model: "opencode-model", compatibleReasoning: true },
+  );
+  assert.deepEqual(
+    resolveModelProvider({
+      MODEL_PROVIDER: "openrouter",
+      OPENROUTER_MODEL: "vendor/router-model",
+    }),
+    {
+      name: "openrouter",
+      model: "vendor/router-model",
+      compatibleReasoning: false,
+    },
+  );
+  assert.deepEqual(
+    resolveModelProvider({
+      MODEL_PROVIDER: "codex",
+      CODEX_MODEL: "codex-model",
+    }),
+    { name: "codex", model: "codex-model", compatibleReasoning: false },
+  );
+});
+
+test("model provider selection rejects values that would split runtime identity", () => {
+  assert.deepEqual(MODEL_PROVIDER_NAMES, [
+    "ollama",
+    "opencode",
+    "openrouter",
+    "codex",
+  ]);
+  for (const value of ["ollmaa", " ollama", "ollama ", "OLLAMA", ""]) {
+    assert.throws(
+      () => resolveModelProvider({ MODEL_PROVIDER: value }),
+      new RegExp(
+        `Invalid MODEL_PROVIDER ${JSON.stringify(value)}; expected one of: ollama, opencode, openrouter, codex`,
+      ),
+    );
+  }
+});
+
+test("runtime configuration and usage share the resolved provider identity", (t) => {
+  const dataDir = mkdtempSync(join(tmpdir(), "iva-provider-usage-"));
+  t.after(() => rmSync(dataDir, { recursive: true, force: true }));
+  const root = fileURLToPath(new URL("../..", import.meta.url));
+  const script = `
+    const provider = await import("./agent/provider.ts");
+    const usage = (await import("./agent/hooks/usage.ts")).default;
+    usage.events["step.completed"](
+      { data: { stepIndex: 1, turnId: "turn_1", usage: { inputTokens: 2, outputTokens: 3 } } },
+      { session: { id: "session_1" }, channel: { kind: "test" } },
+    );
+    console.log(JSON.stringify({
+      name: provider.providerName,
+      model: provider.providerConfig.textModel,
+      effort: provider.compatibleThinkingEffort,
+    }));
+  `;
+  const result = spawnSync(
+    process.execPath,
+    ["--input-type=module", "--eval", script],
+    {
+      cwd: root,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        ASSISTANT_DATA_DIR: dataDir,
+        MODEL_PROVIDER: "opencode",
+        OPENCODE_MODEL: "opencode-go/test-model",
+        THINKING_EFFORT: "high",
+      },
+    },
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout.trim()), {
+    name: "opencode",
+    model: "test-model",
+    effort: "high",
+  });
+  const usage: unknown = JSON.parse(
+    readFileSync(join(dataDir, "usage.jsonl"), "utf8"),
+  );
+  assert.equal(isRecord(usage), true);
+  if (!isRecord(usage)) return;
+  assert.equal(usage.provider, "opencode");
+  assert.equal(usage.model, "test-model");
+});
+
+test("runtime startup rejects an invalid provider before choosing a config", () => {
+  const root = fileURLToPath(new URL("../..", import.meta.url));
+  const result = spawnSync(
+    process.execPath,
+    ["--input-type=module", "--eval", 'await import("./agent/provider.ts")'],
+    {
+      cwd: root,
+      encoding: "utf8",
+      env: { ...process.env, MODEL_PROVIDER: "ollmaa" },
+    },
+  );
+
+  assert.notEqual(result.status, 0);
+  assert.match(
+    result.stderr,
+    /Invalid MODEL_PROVIDER "ollmaa"; expected one of: ollama, opencode, openrouter, codex/,
+  );
+});

--- a/agent/lib/model-provider.ts
+++ b/agent/lib/model-provider.ts
@@ -1,0 +1,48 @@
+type Env = Readonly<Record<string, string | undefined>>;
+
+export const MODEL_PROVIDER_NAMES = [
+  "ollama",
+  "opencode",
+  "openrouter",
+  "codex",
+] as const;
+
+export type ModelProviderName = (typeof MODEL_PROVIDER_NAMES)[number];
+
+type ModelProviderSelection = {
+  name: ModelProviderName;
+  model: string;
+  compatibleReasoning: boolean;
+};
+
+const PROVIDERS = new Set<string>(MODEL_PROVIDER_NAMES);
+
+export function resolveModelProvider(
+  env: Env = process.env,
+): ModelProviderSelection {
+  const raw = env.MODEL_PROVIDER ?? "ollama";
+  if (!PROVIDERS.has(raw)) {
+    throw new Error(
+      `Invalid MODEL_PROVIDER ${JSON.stringify(raw)}; expected one of: ${MODEL_PROVIDER_NAMES.join(", ")}`,
+    );
+  }
+
+  const name = raw as ModelProviderName;
+  const model =
+    name === "codex"
+      ? (env.CODEX_MODEL ?? "gpt-5.5")
+      : name === "openrouter"
+        ? (env.OPENROUTER_MODEL ?? "openai/gpt-5.1")
+        : name === "opencode"
+          ? (env.OPENCODE_MODEL ?? "deepseek-v4-pro").replace(
+              /^opencode-go\//,
+              "",
+            )
+          : (env.OLLAMA_MODEL ?? "deepseek-v4-pro");
+
+  return {
+    name,
+    model,
+    compatibleReasoning: name === "ollama" || name === "opencode",
+  };
+}

--- a/agent/provider.ts
+++ b/agent/provider.ts
@@ -5,6 +5,7 @@ import {
   codexAuthHeaders,
 } from "../scripts/lib/codex-oauth.ts";
 import { EFFORTS } from "../scripts/lib/model-catalog.ts";
+import { resolveModelProvider } from "./lib/model-provider.ts";
 
 type WrappableModel = Parameters<typeof wrapLanguageModel>[0]["model"];
 
@@ -16,7 +17,8 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 // ollama/opencode/openrouter — OpenAI-совместимы (chat/completions, статичный ключ из .env).
 // codex — личная подписка OpenAI (ChatGPT): Responses API + OAuth-токен (data/codex-auth.json,
 // `iva login`). Здесь же зашита vision-модель провайдера — её зовёт agent/vision.ts.
-const PROVIDER = process.env.MODEL_PROVIDER ?? "ollama";
+const selectedProvider = resolveModelProvider();
+const PROVIDER = selectedProvider.name;
 
 const PROVIDERS = {
   ollama: {
@@ -24,7 +26,6 @@ const PROVIDERS = {
     // подставляет сюда локальный mock-провайдер (scripts/lib/mock-openai-server.ts).
     baseURL: process.env.OLLAMA_BASE_URL ?? "https://ollama.com/v1",
     apiKey: process.env.OLLAMA_API_KEY,
-    textModel: process.env.OLLAMA_MODEL ?? "deepseek-v4-pro",
     contextWindow: Number(process.env.OLLAMA_CONTEXT_WINDOW ?? 131072),
     // Дешёвая мультимодалка того же провайдера (проверено на проде: принимает image_url, http 200).
     // Ollama Cloud снимает теги с раздачи: gemma3:12b отвечает 410 "retired at 2026-07-15" —
@@ -37,10 +38,6 @@ const PROVIDERS = {
     baseURL: "https://opencode.ai/zen/go/v1",
     apiKey: process.env.OPENCODE_API_KEY,
     // Эндпоинт ждёт bare-ID — срезаем внутренний UI-префикс "opencode-go/" из дефолта и старых .env.
-    textModel: (process.env.OPENCODE_MODEL ?? "deepseek-v4-pro").replace(
-      /^opencode-go\//,
-      "",
-    ),
     contextWindow: Number(process.env.OPENCODE_CONTEXT_WINDOW ?? 131072),
     // gemini-3-flash выпал из каталога Go (401 "Model gemini-3-flash is not supported") — теперь
     // qwen3.7-plus: отвечает 200 и кладёт описание в message.content. У glm-5.2/minimax-m3 текст
@@ -52,7 +49,6 @@ const PROVIDERS = {
     apiKey: process.env.OPENROUTER_API_KEY,
     // Слаг модели вида vendor/model (напр. anthropic/claude-sonnet-4.5) — задаётся мастером.
     // Дефолт — лишь заглушка на случай ручного .env; мастер всегда перезапишет живой проверкой.
-    textModel: process.env.OPENROUTER_MODEL ?? "openai/gpt-5.1",
     contextWindow: Number(process.env.OPENROUTER_CONTEXT_WINDOW ?? 131072),
     // Дешёвая гарантированно-мультимодальная модель для картинок (как qwen3.7-plus у opencode):
     // vision работает независимо от выбранной текстовой модели (та может быть text-only).
@@ -61,7 +57,6 @@ const PROVIDERS = {
   codex: {
     baseURL: CODEX_BASE_URL,
     apiKey: undefined, // авторизация — OAuth-токен подписки, не статичный ключ (см. codexFetch)
-    textModel: process.env.CODEX_MODEL ?? "gpt-5.5",
     contextWindow: Number(process.env.CODEX_CONTEXT_WINDOW ?? 272000),
     // gpt-5* мультимодальны — картинки идут через ту же подписку (см. agent/vision.ts).
     visionModel: process.env.CODEX_MODEL ?? "gpt-5.5",
@@ -69,8 +64,10 @@ const PROVIDERS = {
 } as const;
 
 export const providerName = PROVIDER;
-export const providerConfig =
-  PROVIDERS[PROVIDER as keyof typeof PROVIDERS] ?? PROVIDERS.ollama;
+export const providerConfig = {
+  ...PROVIDERS[PROVIDER],
+  textModel: selectedProvider.model,
+};
 
 // THINKING_EFFORT (.env, пишут /model и /think в Telegram): reasoning-усилие модели.
 // Codex получает его через providerOptions.openai.reasoningEffort ниже. Ollama Cloud
@@ -84,7 +81,7 @@ export const thinkingEffort = EFFORTS.includes(effortRaw)
 const COMPATIBLE_EFFORTS = ["low", "medium", "high"] as const;
 type CompatibleEffort = (typeof COMPATIBLE_EFFORTS)[number];
 export const compatibleThinkingEffort: CompatibleEffort | undefined =
-  (PROVIDER === "ollama" || PROVIDER === "opencode") &&
+  selectedProvider.compatibleReasoning &&
   (COMPATIBLE_EFFORTS as readonly string[]).includes(effortRaw)
     ? (effortRaw as CompatibleEffort)
     : undefined;

--- a/scripts/cli/doctor.test.ts
+++ b/scripts/cli/doctor.test.ts
@@ -246,3 +246,33 @@ test("opencode diagnostics preserve required-key order", async (t) => {
     ".env incomplete, missing: OPENCODE_API_KEY, OPENCODE_MODEL, DEEPGRAM_API_KEY, TELEGRAM_BOT_TOKEN, TELEGRAM_ALLOWED_USER_IDS, ASSISTANT_BEARER — run: iva config",
   );
 });
+
+test("doctor rejects an invalid model provider instead of diagnosing Ollama", async (t) => {
+  const root = await sandbox(t);
+  writeFileSync(join(root, ".env"), "MODEL_PROVIDER=ollmaa\n");
+  const failures: string[] = [];
+  const runtime: CliRuntime = {
+    ...createCliRuntime(root),
+    C: NO_COLOR,
+    ok: () => undefined,
+    warn: () => undefined,
+    bad: (message) => failures.push(message),
+    readEnv: () => ({ MODEL_PROVIDER: "ollmaa" }),
+    hasSystemd: () => false,
+  };
+
+  await createDoctorCommand(runtime, lifecycle(), {
+    nodeVersion: "24.0.0",
+    log: () => undefined,
+    exit: () => undefined,
+  })();
+
+  assert.equal(
+    failures[0],
+    'Invalid MODEL_PROVIDER "ollmaa"; expected one of: ollama, opencode, openrouter, codex — run: iva config',
+  );
+  assert.equal(
+    failures.some((message) => message.includes("OLLAMA_")),
+    false,
+  );
+});

--- a/scripts/cli/doctor.ts
+++ b/scripts/cli/doctor.ts
@@ -85,35 +85,45 @@ export function createDoctorCommand(
       bad(".env missing — run: iva config");
       badN++;
     } else {
-      const provider = env.MODEL_PROVIDER || "ollama";
       // codex — доступ по OAuth-токену (data/codex-auth.json), у ollama/opencode — API-ключ в .env.
-      const providerKeys: Record<string, readonly string[]> = {
+      const providerKeys = {
         ollama: ["OLLAMA_API_KEY", "OLLAMA_MODEL"],
         opencode: ["OPENCODE_API_KEY", "OPENCODE_MODEL"],
         openrouter: ["OPENROUTER_API_KEY", "OPENROUTER_MODEL"],
         codex: ["CODEX_MODEL"],
-      };
-      const required = [
-        ...(providerKeys[provider] || providerKeys.ollama),
-        "DEEPGRAM_API_KEY",
-        "TELEGRAM_BOT_TOKEN",
-        "TELEGRAM_ALLOWED_USER_IDS",
-        "ASSISTANT_BEARER",
-      ];
-      const missing = required.filter((key) => !(env[key] || "").trim());
-      if (
-        provider === "codex" &&
-        !existsSync(join(dataDirAbs(env), "codex-auth.json"))
-      )
-        missing.push("OpenAI sign-in (iva login)");
-      if (!missing.length) {
-        ok(`.env filled in (provider: ${provider})`);
-        okN++;
-      } else {
+      } as const;
+      const rawProvider = env.MODEL_PROVIDER ?? "ollama";
+      const provider = Object.hasOwn(providerKeys, rawProvider)
+        ? (rawProvider as keyof typeof providerKeys)
+        : undefined;
+      if (!provider) {
         bad(
-          `.env incomplete, missing: ${missing.join(", ")} — run: iva config`,
+          `Invalid MODEL_PROVIDER ${JSON.stringify(rawProvider)}; expected one of: ${Object.keys(providerKeys).join(", ")} — run: iva config`,
         );
         badN++;
+      } else {
+        const required = [
+          ...providerKeys[provider],
+          "DEEPGRAM_API_KEY",
+          "TELEGRAM_BOT_TOKEN",
+          "TELEGRAM_ALLOWED_USER_IDS",
+          "ASSISTANT_BEARER",
+        ];
+        const missing = required.filter((key) => !(env[key] || "").trim());
+        if (
+          provider === "codex" &&
+          !existsSync(join(dataDirAbs(env), "codex-auth.json"))
+        )
+          missing.push("OpenAI sign-in (iva login)");
+        if (!missing.length) {
+          ok(`.env filled in (provider: ${provider})`);
+          okN++;
+        } else {
+          bad(
+            `.env incomplete, missing: ${missing.join(", ")} — run: iva config`,
+          );
+          badN++;
+        }
       }
       // old .env without IVA_PORT (or with :3000) — migrate right here
       if (migrateEnv()) fixN++;

--- a/scripts/coverage-policy.test.ts
+++ b/scripts/coverage-policy.test.ts
@@ -8,9 +8,9 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 const ROOT = fileURLToPath(new URL("../", import.meta.url));
-const EXPECTED_PRODUCTION_COUNT = 139;
+const EXPECTED_PRODUCTION_COUNT = 140;
 const EXPECTED_INVENTORY_SHA256 =
-  "7aad32e3ca2ad44c0f913754f1af07f00598ebb7a10a46a23d6d634d8a1ac5a0";
+  "31fb8a5d14daaa163164909f6e3880affb590947e6718e3744cf460e473ac48b";
 
 // Node's native include globs filter loaded modules; they do not load untouched files.
 // This test pins the exact production path inventory and a separately measured 29-path

--- a/scripts/lib/menu/status.test.ts
+++ b/scripts/lib/menu/status.test.ts
@@ -124,3 +124,29 @@ test("status does not edit an expired menu after the asynchronous probe settles"
   await new Promise((resolve) => setImmediate(resolve));
   assert.equal(edits, 0);
 });
+
+test("status surfaces an invalid model provider instead of presenting Ollama", async () => {
+  const { root, envPath } = await fixture();
+  await writeFile(envPath, "MODEL_PROVIDER=ollmaa\nOLLAMA_MODEL=wrong-model\n");
+  const state: StatusState = { chatId: 1, userId: "2", screen: "st" };
+  const context: StatusContext = {
+    deps: {
+      root,
+      envPath,
+      dataDir: join(root, "data"),
+      probeUserbotHealth: async () => ({ state: "off" }),
+    },
+    flows: {
+      get: () => null,
+      screen: async () => undefined,
+    },
+    getLang: () => "en",
+    tr: (en) => en,
+    btn: (text, callbackData) => ({ text, callback_data: callbackData }),
+    backRow: () => [{ text: "Back", callback_data: "iva_menu:r:o" }],
+  };
+
+  const view = await status.default.render(state, context);
+  assert.match(view.text, /Model: invalid \(ollmaa\) · \?/);
+  assert.doesNotMatch(view.text, /Model: ollama|wrong-model/);
+});

--- a/scripts/lib/menu/status.ts
+++ b/scripts/lib/menu/status.ts
@@ -88,12 +88,11 @@ function usageToday(
 
 // Собирает быстрые поля (без медленной пробы) — переиспользуется первым рендером и async-edit'ом.
 function fastFields(env: Env, ctx: MenuContext) {
-  const provider =
-    typeof env.MODEL_PROVIDER === "string" &&
-    Object.hasOwn(CATALOG, env.MODEL_PROVIDER)
-      ? env.MODEL_PROVIDER
-      : "ollama";
-  const cat = CATALOG[provider as keyof typeof CATALOG];
+  const configuredProvider = env.MODEL_PROVIDER ?? "ollama";
+  const providerIsValid = Object.hasOwn(CATALOG, configuredProvider);
+  const cat = providerIsValid
+    ? CATALOG[configuredProvider as keyof typeof CATALOG]
+    : undefined;
   const searchProv =
     typeof env.SEARCH_PROVIDER === "string" &&
     Object.hasOwn(SEARCH_CATALOG, env.SEARCH_PROVIDER)
@@ -102,9 +101,11 @@ function fastFields(env: Env, ctx: MenuContext) {
   const searchCat = SEARCH_CATALOG[searchProv as keyof typeof SEARCH_CATALOG];
   return {
     version: version(ctx.deps.root),
-    provider,
-    model: env[cat.modelVar] || cat.def,
-    effort: (env.THINKING_EFFORT || "").toLowerCase(),
+    provider: providerIsValid
+      ? configuredProvider
+      : `invalid (${configuredProvider})`,
+    model: cat ? env[cat.modelVar] || cat.def : "?",
+    effort: cat ? (env.THINKING_EFFORT || "").toLowerCase() : "",
     searchProv,
     hasKey: Boolean(searchCat && env[searchCat.keyVar]),
     lang: ctx.getLang(),


### PR DESCRIPTION
## What this changes

Invalid `MODEL_PROVIDER` values now fail at runtime startup instead of retaining an unknown provider identity while silently borrowing Ollama configuration. Runtime model configuration and usage accounting share one typed resolver, while `iva doctor` and the status menu report the invalid value directly.

## Why

Closes #161. A typo such as `MODEL_PROVIDER=ollmaa` previously created split state: requests used Ollama settings, but reasoning and usage paths continued to identify the provider as `ollmaa`. That hid the configuration error and could route requests to an unintended endpoint.

The missing value remains backward-compatible and defaults to Ollama; all four documented exact values preserve their existing defaults. Unknown, empty, padded, and case-changed values now fail closed with the accepted names. The main risk is stricter handling of previously tolerated invalid configuration; `iva doctor` and the status view provide the recovery path (`iva config`).

## How it was verified

- [x] `npm run lint` / `npm run format:check`
- [x] `npm run typecheck`
- [x] `npm test` — 811 passed, 4 platform-specific tests skipped, 0 failed
- [ ] Ran it against a live bot (not run; no live provider credentials were used)

Additional checks:

- `npm run test:coverage` — passed (76.87% lines, 78.78% branches, 73.10% functions; the new resolver is 100% covered)
- `npm run build` — passed
- `npm run replica` — exited successfully; it printed the repository's known session-resume warning
- Python 3.12 autograph tests — 343 passed
- Python security-defense tests — 45 passed
- Reproducible `uv pip compile` lock check — no diff
- Userbot dependency sync, guardrails, health tests, and byte-compilation — passed

## This PR touches

- [x] `agent/` — takes effect only after `npm run build`
- [ ] The update path or a persisted format (`data/settings.json`, vault layout) —
      the upgrade path from older versions is described above
- [x] Something user-visible

## I confirm

- [x] Docs updated for any user-visible change (`docs/`, and `docs/ru/` if that page
      exists in Russian — or said above that it is still pending). The existing English and Russian configuration docs already enumerate the four exact accepted values, so no docs edit is needed.
- [x] No secrets, no machine-specific absolute paths, no files from `data/`,
      `attachments/` or a vault


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые возможности**
  * Добавлен единый выбор поставщика и модели с поддержкой Ollama, OpenCode, OpenRouter и Codex.
  * Для каждого поставщика определяются модель по умолчанию и совместимость с режимом рассуждений.
  * Добавлена поддержка проверки конфигурации Codex через файл авторизации.

* **Исправления**
  * Некорректные значения поставщика теперь отклоняются с понятным перечнем допустимых вариантов.
  * Статус конфигурации корректно отображает недействительного поставщика и неизвестную модель.
  * Устранено автоматическое подменение неверной конфигурации настройками Ollama.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->