### PR TITLE
Add one-step repair for legacy dirty updates

### DIFF
--- a/repair.sh
+++ b/repair.sh
@@ -45,7 +45,8 @@ origin="$(git -C "$INSTALL_DIR" remote get-url origin)"
 if is_official_remote "$origin"; then
   is_official_remote "$REPO_URL" || die "repository URL is not github.com/smixs/iva"
 elif [ "${REPO_URL#/}" != "$REPO_URL" ] && [ "$origin" = "$REPO_URL" ] && [ -d "$REPO_URL" ]; then
-  git --git-dir="$REPO_URL" rev-parse --is-bare-repository >/dev/null 2>&1 || die "invalid local test repository"
+  [ "$(git --git-dir="$REPO_URL" rev-parse --is-bare-repository 2>/dev/null)" = "true" ] \
+    || die "invalid local test repository"
 else
   die "origin is not github.com/smixs/iva"
 fi
@@ -136,6 +137,7 @@ done < <(find "$INSTALL_DIR" -maxdepth 1 -type f -name '.env.*' -print0)
 
 mkdir -p -- "$candidate/data/update-recovery/$stamp"
 recovery="$candidate/data/update-recovery/$stamp"
+chmod 700 -- "$candidate/data/update-recovery" "$recovery"
 final_recovery="$INSTALL_DIR/data/update-recovery/$stamp"
 cp -- "$state_dir/changes.patch" "$recovery/changes.patch"
 cp -- "$state_dir/untracked.zlist" "$recovery/untracked.zlist"

--- a/repair.sh
+++ b/repair.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# One-time bridge from legacy, dirty Iva checkouts to the current updater.
+# User-facing entrypoint:
+#   curl -fsSL https://raw.githubusercontent.com/smixs/iva/main/repair.sh | bash
+
+REPO_URL="${IVA_REPAIR_REPO_URL:-https://github.com/smixs/iva.git}"
+BRANCH="${IVA_REPAIR_BRANCH:-main}"
+INSTALL_DIR="${IVA_INSTALL_DIR:-${HOME}/iva}"
+SKIP_RESTART="${IVA_REPAIR_SKIP_RESTART:-0}"
+
+say() { printf '%s\n' "$*"; }
+die() { printf 'Iva repair failed: %s\n' "$*" >&2; exit 1; }
+
+command -v git >/dev/null 2>&1 || die "git is required"
+command -v npm >/dev/null 2>&1 || die "npm is required"
+command -v node >/dev/null 2>&1 || die "Node.js is required"
+
+node_major="$(node -p 'process.versions.node.split(".")[0]')"
+[ "$node_major" -ge 24 ] || die "Node 24 or newer is required"
+[ -d "$INSTALL_DIR/.git" ] || die "Iva was not found at $INSTALL_DIR"
+
+INSTALL_DIR="$(cd "$INSTALL_DIR" && pwd -P)"
+HOME_DIR="$(cd "$HOME" && pwd -P)"
+PARENT_DIR="$(dirname "$INSTALL_DIR")"
+INSTALL_NAME="$(basename "$INSTALL_DIR")"
+[ "$INSTALL_DIR" != "/" ] || die "unsafe installation path"
+[ "$INSTALL_DIR" != "$HOME_DIR" ] || die "unsafe installation path"
+[ -f "$INSTALL_DIR/package.json" ] || die "package.json is missing"
+node -e 'const p=require(process.argv[1]); if(p.name!=="iva") process.exit(1)' \
+  "$INSTALL_DIR/package.json" || die "this is not an Iva installation"
+
+top="$(git -C "$INSTALL_DIR" rev-parse --show-toplevel)"
+[ "$(cd "$top" && pwd -P)" = "$INSTALL_DIR" ] || die "invalid Iva checkout"
+
+is_official_remote() {
+  case "$1" in
+    https://github.com/smixs/iva|https://github.com/smixs/iva.git|git@github.com:smixs/iva|git@github.com:smixs/iva.git|ssh://git@github.com/smixs/iva|ssh://git@github.com/smixs/iva.git) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+origin="$(git -C "$INSTALL_DIR" remote get-url origin)"
+if is_official_remote "$origin"; then
+  is_official_remote "$REPO_URL" || die "repository URL is not github.com/smixs/iva"
+elif [ "${REPO_URL#/}" != "$REPO_URL" ] && [ "$origin" = "$REPO_URL" ] && [ -d "$REPO_URL" ]; then
+  git --git-dir="$REPO_URL" rev-parse --is-bare-repository >/dev/null 2>&1 || die "invalid local test repository"
+else
+  die "origin is not github.com/smixs/iva"
+fi
+
+stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+candidate="$PARENT_DIR/.${INSTALL_NAME}.repair-candidate-${stamp}-$$"
+state_dir="$PARENT_DIR/.${INSTALL_NAME}.repair-state-${stamp}-$$"
+backup="$PARENT_DIR/${INSTALL_NAME}-backup-${stamp}"
+failed_candidate="$PARENT_DIR/.${INSTALL_NAME}.failed-repair-${stamp}"
+activated=0
+
+for path in "$candidate" "$state_dir" "$backup" "$failed_candidate"; do
+  [ ! -e "$path" ] && [ ! -L "$path" ] || die "repair path already exists: $path"
+done
+
+safe_remove() {
+  case "$1" in
+    "$PARENT_DIR"/."$INSTALL_NAME".repair-candidate-*|"$PARENT_DIR"/."$INSTALL_NAME".repair-state-*)
+      rm -rf -- "$1"
+      ;;
+    *) die "refusing to remove unexpected path: $1" ;;
+  esac
+}
+
+rollback() {
+  code="${1:-$?}"
+  trap - ERR INT TERM EXIT
+  if [ "$activated" = "1" ] && [ -d "$backup" ]; then
+    if [ -e "$INSTALL_DIR" ]; then
+      [ ! -e "$failed_candidate" ] || failed_candidate="${failed_candidate}-$$"
+      mv -- "$INSTALL_DIR" "$failed_candidate" || true
+    fi
+    mv -- "$backup" "$INSTALL_DIR" || true
+    if [ "$SKIP_RESTART" != "1" ]; then
+      node "$INSTALL_DIR/bin/iva.mjs" restart >/dev/null 2>&1 || true
+    fi
+  fi
+  [ ! -e "$candidate" ] || (safe_remove "$candidate") || true
+  [ ! -e "$state_dir" ] || (safe_remove "$state_dir") || true
+  exit "$code"
+}
+trap 'rollback $?' ERR
+trap 'rollback 130' INT
+trap 'rollback 143' TERM
+
+mkdir -m 700 -- "$state_dir"
+original_head="$(git -C "$INSTALL_DIR" rev-parse HEAD)"
+git -C "$INSTALL_DIR" diff --binary HEAD >"$state_dir/changes.patch"
+git -C "$INSTALL_DIR" ls-files --others --exclude-standard -z >"$state_dir/untracked.zlist"
+: >"$state_dir/persistent-conflicts.txt"
+
+say "Saving the current Iva..."
+git clone --quiet --branch "$BRANCH" --single-branch "$REPO_URL" "$candidate"
+target_head="$(git -C "$candidate" rev-parse HEAD)"
+
+# Persistent state is copied byte-for-byte. The full old installation is also kept as backup.
+for name in .env vault attachments; do
+  if [ -e "$INSTALL_DIR/$name" ] || [ -L "$INSTALL_DIR/$name" ]; then
+    rm -rf -- "${candidate:?}/$name"
+    cp -a -- "$INSTALL_DIR/$name" "$candidate/$name"
+  fi
+done
+if [ -e "$INSTALL_DIR/data" ] || [ -L "$INSTALL_DIR/data" ]; then
+  rm -rf -- "${candidate:?}/data"
+  if [ -d "$INSTALL_DIR/data" ]; then
+    mkdir -p -- "$candidate/data"
+    cp -a -- "$INSTALL_DIR/data/." "$candidate/data/"
+  else
+    cp -aL -- "$INSTALL_DIR/data" "$candidate/data"
+  fi
+fi
+for name in .workflow-data .eve/.workflow-data; do
+  if [ -e "$INSTALL_DIR/$name" ] || [ -L "$INSTALL_DIR/$name" ]; then
+    rm -rf -- "${candidate:?}/$name"
+    mkdir -p -- "$candidate/$name"
+    cp -a -- "$INSTALL_DIR/$name/." "$candidate/$name/"
+  fi
+done
+while IFS= read -r -d '' env_file; do
+  name="$(basename "$env_file")"
+  [ "$name" = ".env.example" ] && continue
+  if git -C "$candidate" ls-files --error-unmatch -- "$name" >/dev/null 2>&1; then
+    printf '%s\n' "$name (local environment file conflicts with a core file)" >>"$state_dir/persistent-conflicts.txt"
+    continue
+  fi
+  cp -a -- "$env_file" "$candidate/$name"
+done < <(find "$INSTALL_DIR" -maxdepth 1 -type f -name '.env.*' -print0)
+
+mkdir -p -- "$candidate/data/update-recovery/$stamp"
+recovery="$candidate/data/update-recovery/$stamp"
+final_recovery="$INSTALL_DIR/data/update-recovery/$stamp"
+cp -- "$state_dir/changes.patch" "$recovery/changes.patch"
+cp -- "$state_dir/untracked.zlist" "$recovery/untracked.zlist"
+: >"$recovery/conflicts.txt"
+: >"$recovery/restored-untracked.zlist"
+cat "$state_dir/persistent-conflicts.txt" >>"$recovery/conflicts.txt"
+
+# Apply every tracked local edit. Conflicting files stay clean in the new core and remain
+# available in the complete backup plus changes.patch.
+if [ -s "$state_dir/changes.patch" ]; then
+  if git -C "$candidate" apply --3way --index --whitespace=nowarn "$state_dir/changes.patch"; then
+    apply_code=0
+  else
+    apply_code=$?
+  fi
+  if [ "$apply_code" -ne 0 ]; then
+    mapfile -t conflicts < <(git -C "$candidate" diff --name-only --diff-filter=U)
+    if [ "${#conflicts[@]}" -gt 0 ]; then
+      printf '%s\n' "${conflicts[@]}" >>"$recovery/conflicts.txt"
+      git -C "$candidate" checkout HEAD -- "${conflicts[@]}"
+    else
+      git -C "$candidate" reset --hard HEAD >/dev/null
+      printf '%s\n' "changes.patch (could not be applied safely)" >>"$recovery/conflicts.txt"
+    fi
+  fi
+fi
+
+# Restore every untracked user file whose path is still free. A path now owned by the new
+# core is recorded as a conflict and preserved in the complete backup.
+while IFS= read -r -d '' relative; do
+  case "$relative" in
+    ""|/*|../*|*/../*)
+      printf '%s\n' "$relative (unsafe path)" >>"$recovery/conflicts.txt"
+      continue
+      ;;
+  esac
+  source_path="$INSTALL_DIR/$relative"
+  target_path="$candidate/$relative"
+  [ -e "$source_path" ] || [ -L "$source_path" ] || continue
+  if [ -e "$target_path" ] || [ -L "$target_path" ]; then
+    same=0
+    if [ -f "$source_path" ] && [ -f "$target_path" ] && cmp -s -- "$source_path" "$target_path"; then same=1; fi
+    if [ -L "$source_path" ] && [ -L "$target_path" ] && [ "$(readlink "$source_path")" = "$(readlink "$target_path")" ]; then same=1; fi
+    [ "$same" = "1" ] || printf '%s\n' "$relative" >>"$recovery/conflicts.txt"
+    continue
+  fi
+  mkdir -p -- "$(dirname "$target_path")"
+  cp -a -- "$source_path" "$target_path"
+  printf '%s\0' "$relative" >>"$recovery/restored-untracked.zlist"
+done <"$state_dir/untracked.zlist"
+
+cat >"$recovery/report.txt" <<EOF
+Iva repair: $stamp
+Previous HEAD: $original_head
+New HEAD: $target_head
+Complete backup: $backup
+Conflicting paths: $final_recovery/conflicts.txt
+EOF
+
+# Keep the running old process on its renamed directory while the replacement is built at
+# the original path expected by systemd and the global iva command.
+activated=1
+mv -- "$INSTALL_DIR" "$backup"
+chmod 700 "$backup"
+mv -- "$candidate" "$INSTALL_DIR"
+recovery="$final_recovery"
+
+say "Installing the new updater..."
+if (
+  cd "$INSTALL_DIR"
+  npm ci --no-audit --no-fund && npm run build
+); then
+  custom_build_ok=0
+else
+  custom_build_ok=$?
+fi
+
+if [ "$custom_build_ok" -ne 0 ]; then
+  say "A customization did not build; starting clean Iva and keeping every change in the backup."
+  git -C "$INSTALL_DIR" reset --hard HEAD >/dev/null
+  while IFS= read -r -d '' restored; do
+    [ -n "$restored" ] || continue
+    target="$INSTALL_DIR/$restored"
+    if [ -e "$target" ] || [ -L "$target" ]; then rm -rf -- "$target"; fi
+  done <"$recovery/restored-untracked.zlist"
+  (
+    cd "$INSTALL_DIR"
+    npm ci --no-audit --no-fund && npm run build
+  )
+fi
+
+if [ "$SKIP_RESTART" != "1" ]; then
+  node "$INSTALL_DIR/bin/iva.mjs" _install-units
+  node "$INSTALL_DIR/bin/iva.mjs" restart
+fi
+
+trap - ERR INT TERM
+activated=0
+safe_remove "$state_dir"
+
+say "Iva is repaired and updated."
+say "Your complete backup: $backup"
+say "Remove the backup manually after checking Iva."
+if [ -s "$recovery/conflicts.txt" ]; then
+  say "Files needing review: $recovery/conflicts.txt"
+fi

--- a/scripts/repair-shell.test.ts
+++ b/scripts/repair-shell.test.ts
@@ -208,8 +208,9 @@ void test("repair falls back to clean core when customized dependencies fail", (
       readFileSync(join(install, "data/settings.json"), "utf8"),
       '{"saved":true}\n',
     );
-    assert.throws(() =>
-      readFileSync(join(install, "scripts/custom-telegram-button.ts")),
+    assert.throws(
+      () => readFileSync(join(install, "scripts/custom-telegram-button.ts")),
+      { code: "ENOENT" },
     );
     assert.equal(readFileSync(`${npmState}.log`, "utf8"), "ci\nci\nbuild\n");
     const backup = output.match(/Your complete backup: (.+)/)?.[1];

--- a/scripts/repair-shell.test.ts
+++ b/scripts/repair-shell.test.ts
@@ -1,0 +1,224 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+  chmodSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const ROOT = fileURLToPath(new URL("../", import.meta.url));
+const LEGACY_HEAD = "9a1b00dcd0ac85eafc969ba863d0773012a3fc6e";
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+void test("repair bridges a dirty legacy install and preserves arbitrary files", () => {
+  const fixture = mkdtempSync(join(tmpdir(), "iva-repair-shell-"));
+  const remote = join(fixture, "remote.git");
+  const install = join(fixture, "iva");
+  const fakeBin = join(fixture, "bin");
+  try {
+    const target = git(ROOT, "rev-parse", "HEAD");
+    const repairBranch = "repair-test-target";
+    execFileSync("git", ["clone", "--quiet", "--bare", ROOT, remote]);
+    execFileSync(
+      "git",
+      ["--git-dir", remote, "update-ref", `refs/heads/${repairBranch}`, target],
+      { cwd: ROOT },
+    );
+    execFileSync("git", ["clone", "--quiet", remote, install]);
+    assert.doesNotThrow(
+      () => git(install, "cat-file", "-e", `${LEGACY_HEAD}^{commit}`),
+      `LEGACY_HEAD ${LEGACY_HEAD} is unreachable; run the test on a full clone`,
+    );
+    git(install, "checkout", "-B", "main", LEGACY_HEAD);
+    git(install, "config", "user.name", "Iva Repair Test");
+    git(install, "config", "user.email", "repair@example.invalid");
+
+    writeFileSync(
+      join(install, "docs/index.html"),
+      "<html>local docs</html>\n",
+    );
+    writeFileSync(
+      join(install, "scripts/telegram-poll.mjs"),
+      "// local Telegram buttons\n",
+    );
+    writeFileSync(
+      join(install, "agent/channels/eve.ts"),
+      `${readFileSync(join(install, "agent/channels/eve.ts"), "utf8")}\n// local compatible change\n`,
+    );
+    mkdirSync(join(install, "scripts"), { recursive: true });
+    writeFileSync(
+      join(install, "scripts/custom-telegram-button.ts"),
+      "export const customButton = true;\n",
+    );
+    mkdirSync(join(install, "agent/skills/my-skill"), { recursive: true });
+    writeFileSync(join(install, "agent/skills/my-skill/SKILL.md"), "# Mine\n");
+    writeFileSync(join(install, ".env"), "IVA_PORT=8723\n");
+    mkdirSync(join(install, "data"), { recursive: true });
+    writeFileSync(join(install, "data/settings.json"), '{"saved":true}\n');
+    mkdirSync(join(install, ".workflow-data"), { recursive: true });
+    writeFileSync(join(install, ".workflow-data/run.json"), '{"run":1}\n');
+    mkdirSync(join(install, ".eve/.workflow-data"), { recursive: true });
+    writeFileSync(join(install, ".eve/.workflow-data/eve.json"), '{"eve":1}\n');
+
+    mkdirSync(fakeBin);
+    const fakeNpm = join(fakeBin, "npm");
+    writeFileSync(
+      fakeNpm,
+      '#!/bin/sh\nif [ "$1" = "run" ] && [ "$2" = "build" ]; then mkdir -p .output/server; printf ok > .output/server/index.mjs; fi\nexit 0\n',
+    );
+    chmodSync(fakeNpm, 0o755);
+
+    const output = execFileSync("bash", [join(ROOT, "repair.sh")], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+        IVA_INSTALL_DIR: install,
+        IVA_REPAIR_REPO_URL: remote,
+        IVA_REPAIR_BRANCH: repairBranch,
+        IVA_REPAIR_SKIP_RESTART: "1",
+      },
+    });
+
+    assert.equal(git(install, "rev-parse", "HEAD"), target);
+    assert.equal(
+      readFileSync(join(install, ".env"), "utf8"),
+      "IVA_PORT=8723\n",
+    );
+    assert.equal(
+      readFileSync(join(install, "data/settings.json"), "utf8"),
+      '{"saved":true}\n',
+    );
+    assert.equal(
+      readFileSync(join(install, ".workflow-data/run.json"), "utf8"),
+      '{"run":1}\n',
+    );
+    assert.equal(
+      readFileSync(join(install, ".eve/.workflow-data/eve.json"), "utf8"),
+      '{"eve":1}\n',
+    );
+    assert.equal(
+      readFileSync(join(install, "scripts/custom-telegram-button.ts"), "utf8"),
+      "export const customButton = true;\n",
+    );
+    assert.equal(
+      readFileSync(join(install, "agent/skills/my-skill/SKILL.md"), "utf8"),
+      "# Mine\n",
+    );
+    assert.match(
+      readFileSync(join(install, "agent/channels/eve.ts"), "utf8"),
+      /local compatible change/,
+    );
+    assert.equal(
+      readFileSync(join(install, "docs/index.html"), "utf8"),
+      execFileSync("git", ["show", "HEAD:docs/index.html"], {
+        cwd: ROOT,
+        encoding: "utf8",
+      }),
+    );
+    assert.match(output, /Iva is repaired and updated\./);
+    const backup = output.match(/Your complete backup: (.+)/)?.[1];
+    assert.ok(backup);
+    assert.equal(
+      readFileSync(join(backup, "docs/index.html"), "utf8"),
+      "<html>local docs</html>\n",
+    );
+    assert.equal(
+      readFileSync(join(backup, "scripts/telegram-poll.mjs"), "utf8"),
+      "// local Telegram buttons\n",
+    );
+    const conflicts = readFileSync(
+      join(
+        install,
+        "data/update-recovery",
+        readdirSync(join(install, "data/update-recovery"))[0],
+        "conflicts.txt",
+      ),
+      "utf8",
+    );
+    assert.match(conflicts, /docs\/index\.html/);
+    assert.match(conflicts, /scripts\/telegram-poll\.mjs/);
+  } finally {
+    rmSync(fixture, { recursive: true, force: true });
+  }
+});
+
+void test("repair falls back to clean core when customized dependencies fail", () => {
+  const fixture = mkdtempSync(join(tmpdir(), "iva-repair-shell-fallback-"));
+  const remote = join(fixture, "remote.git");
+  const install = join(fixture, "iva");
+  const fakeBin = join(fixture, "bin");
+  const npmState = join(fixture, "npm-state");
+  try {
+    const target = git(ROOT, "rev-parse", "HEAD");
+    const repairBranch = "repair-test-target";
+    execFileSync("git", ["clone", "--quiet", "--bare", ROOT, remote]);
+    execFileSync(
+      "git",
+      ["--git-dir", remote, "update-ref", `refs/heads/${repairBranch}`, target],
+      { cwd: ROOT },
+    );
+    execFileSync("git", ["clone", "--quiet", remote, install]);
+    assert.doesNotThrow(
+      () => git(install, "cat-file", "-e", `${LEGACY_HEAD}^{commit}`),
+      `LEGACY_HEAD ${LEGACY_HEAD} is unreachable; run the test on a full clone`,
+    );
+    git(install, "checkout", "-B", "main", LEGACY_HEAD);
+    writeFileSync(
+      join(install, "scripts/custom-telegram-button.ts"),
+      "export const customButton = true;\n",
+    );
+    mkdirSync(join(install, "data"), { recursive: true });
+    writeFileSync(join(install, "data/settings.json"), '{"saved":true}\n');
+
+    mkdirSync(fakeBin);
+    const fakeNpm = join(fakeBin, "npm");
+    writeFileSync(
+      fakeNpm,
+      '#!/bin/sh\nset -eu\nstate=${IVA_TEST_NPM_STATE:?}\nif [ "$1" = "ci" ]; then printf "ci\\n" >> "$state.log"; if [ ! -e "$state.failed" ]; then : > "$state.failed"; exit 1; fi; exit 0; fi\nif [ "$1" = "run" ] && [ "$2" = "build" ]; then printf "build\\n" >> "$state.log"; mkdir -p .output/server; printf ok > .output/server/index.mjs; fi\n',
+    );
+    chmodSync(fakeNpm, 0o755);
+
+    const output = execFileSync("bash", [join(ROOT, "repair.sh")], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+        IVA_INSTALL_DIR: install,
+        IVA_REPAIR_REPO_URL: remote,
+        IVA_REPAIR_BRANCH: repairBranch,
+        IVA_REPAIR_SKIP_RESTART: "1",
+        IVA_TEST_NPM_STATE: npmState,
+      },
+    });
+
+    assert.equal(git(install, "rev-parse", "HEAD"), target);
+    assert.equal(
+      readFileSync(join(install, "data/settings.json"), "utf8"),
+      '{"saved":true}\n',
+    );
+    assert.throws(() =>
+      readFileSync(join(install, "scripts/custom-telegram-button.ts")),
+    );
+    assert.equal(readFileSync(`${npmState}.log`, "utf8"), "ci\nci\nbuild\n");
+    const backup = output.match(/Your complete backup: (.+)/)?.[1];
+    assert.ok(backup);
+    assert.equal(
+      readFileSync(join(backup, "scripts/custom-telegram-button.ts"), "utf8"),
+      "export const customButton = true;\n",
+    );
+  } finally {
+    rmSync(fixture, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add a standalone one-command bridge from legacy dirty installs to the current updater
- preserve the complete old installation, persistent state, session stores, arbitrary compatible code changes, and conflict recovery data
- fall back to a clean core when customized dependencies or builds fail

## Verification
- `node --test scripts/repair-shell.test.ts`
- `npm run typecheck`
- ESLint on `scripts/repair-shell.test.ts`
- CodeRabbit local review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые возможности**
  * Добавлен одноразовый сценарий восстановления устаревшей установки Iva.
  * Перед восстановлением автоматически создаётся полная резервная копия.
  * Сохраняются пользовательские данные и локальные изменения; конфликты фиксируются в отчёте.
  * При сбоях выполняется откат, а после успешного восстановления приложение пересобирается и перезапускается.

* **Тесты**
  * Добавлены интеграционные проверки обновления установки, сохранения данных, резервного копирования и восстановления после ошибок.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->