### PR TITLE
fix(cli): do not reorder PATH when NODE_BIN_DIR is already on it

### DIFF
--- a/scripts/cli/runtime.test.ts
+++ b/scripts/cli/runtime.test.ts
@@ -267,17 +267,17 @@ test("childEnv keeps the caller's PATH order when NODE_BIN_DIR is already on it"
     process.env.PATH = originalPath;
   });
   const nodeBinDir = dirname(process.execPath);
-  const stubBin = "/tmp/iva-stub-bin";
-  process.env.PATH = `${stubBin}:${nodeBinDir}:/bin`;
+  // Both fixture entries live under the sandbox, so neither can accidentally
+  // equal nodeBinDir on a machine that keeps node somewhere unusual.
+  const stubBin = join(root, "stub-bin");
+  const tailBin = join(root, "tail-bin");
+  process.env.PATH = `${stubBin}:${nodeBinDir}:${tailBin}`;
 
   const entries = (createCliRuntime(root).childEnv.PATH ?? "").split(":");
 
-  assert.equal(
-    entries[0],
-    stubBin,
-    "a stub earlier in PATH must keep winning over the system bin dir",
-  );
-  assert.equal(entries.filter((entry) => entry === nodeBinDir).length, 1);
+  // The whole array, not just the head: a dropped or reordered tail entry is
+  // the same defect as a stub that stops winning.
+  assert.deepEqual(entries, [stubBin, nodeBinDir, tailBin]);
 });
 
 test("childEnv prepends NODE_BIN_DIR when PATH does not carry it", async (t) => {

--- a/scripts/cli/runtime.test.ts
+++ b/scripts/cli/runtime.test.ts
@@ -259,3 +259,38 @@ test("writeEnvVars deduplicates CRLF input and writes one atomic LF record", asy
   );
   assert.equal(statSync(runtime.ENV_PATH).mode & 0o777, 0o600);
 });
+
+test("childEnv keeps the caller's PATH order when NODE_BIN_DIR is already on it", async (t) => {
+  const root = await sandbox(t);
+  const originalPath = process.env.PATH;
+  t.after(() => {
+    process.env.PATH = originalPath;
+  });
+  const nodeBinDir = dirname(process.execPath);
+  const stubBin = "/tmp/iva-stub-bin";
+  process.env.PATH = `${stubBin}:${nodeBinDir}:/bin`;
+
+  const entries = (createCliRuntime(root).childEnv.PATH ?? "").split(":");
+
+  assert.equal(
+    entries[0],
+    stubBin,
+    "a stub earlier in PATH must keep winning over the system bin dir",
+  );
+  assert.equal(entries.filter((entry) => entry === nodeBinDir).length, 1);
+});
+
+test("childEnv prepends NODE_BIN_DIR when PATH does not carry it", async (t) => {
+  const root = await sandbox(t);
+  const originalPath = process.env.PATH;
+  t.after(() => {
+    process.env.PATH = originalPath;
+  });
+  const nodeBinDir = dirname(process.execPath);
+  process.env.PATH = "/nonexistent-a:/nonexistent-b";
+
+  assert.equal(
+    createCliRuntime(root).childEnv.PATH,
+    `${nodeBinDir}:/nonexistent-a:/nonexistent-b`,
+  );
+});

--- a/scripts/cli/runtime.ts
+++ b/scripts/cli/runtime.ts
@@ -38,9 +38,19 @@ export function createCliRuntime(root: string) {
   const NPM = existsSync(join(NODE_BIN_DIR, "npm"))
     ? join(NODE_BIN_DIR, "npm")
     : "npm";
+  // Child processes need the same node/npm the CLI itself runs on, so NODE_BIN_DIR goes
+  // in front — but only when PATH does not already contain it. Prepending it a second
+  // time silently reorders PATH: with a system Node in /usr/bin, /usr/bin jumps ahead of
+  // whatever the caller put first, so a stub placed earlier in PATH stops winning. That
+  // is how `scripts/cli/services-entrypoints.test.ts` reached the real systemctl instead
+  // of its own fake and drove live user units.
+  const pathEntries = (process.env.PATH || "").split(":").filter(Boolean);
   const childEnv: NodeJS.ProcessEnv = {
     ...process.env,
-    PATH: `${NODE_BIN_DIR}:${process.env.PATH || ""}`,
+    PATH: (pathEntries.includes(NODE_BIN_DIR)
+      ? pathEntries
+      : [NODE_BIN_DIR, ...pathEntries]
+    ).join(":"),
   };
 
   const SERVICES = ["iva.service", "iva-telegram-poll.service"];


### PR DESCRIPTION
## The bug

`createCliRuntime` prepends the directory of the running node to the `PATH` it hands to child processes:

```ts
PATH: `${NODE_BIN_DIR}:${process.env.PATH || ""}`,
```

When that directory is already on `PATH` — the usual case for a system Node in `/usr/bin` — prepending it again reorders `PATH` behind the caller's back. Anything the caller deliberately put first now loses to `/usr/bin`.

`scripts/cli/services-entrypoints.test.ts` depends on exactly that ordering: it writes a fake `systemctl` into a temp `bin/` and sets `PATH: ${fakeBin}:/usr/bin:/bin`. On a machine where node lives in `/usr/bin`, the runtime turns that into `/usr/bin:${fakeBin}:...`, the real `systemctl` wins, and the lifecycle commands under test (`start`/`stop`/`restart`/`reset`) act on live user units instead of the fixture.

On the install where I hit this, running the suite stopped the running assistant — the tests were driving the real `iva.service`.

## The fix

Prepend `NODE_BIN_DIR` only when `PATH` does not already contain it. Child processes still get the same node/npm the CLI runs on; the caller's ordering is left alone.

## Tests

Two unit tests on `childEnv.PATH`, no processes spawned, no systemd involved:

- `childEnv keeps the caller's PATH order when NODE_BIN_DIR is already on it` — **fails without the fix** (the stub dir is no longer first, and the node bin dir appears twice);
- `childEnv prepends NODE_BIN_DIR when PATH does not carry it` — pins the original intent.

## Checks run locally

`prettier --check`, `eslint`, `tsgo`, `git diff --check` — clean. Full `node --test`: 795 tests, 783 pass. The 12 failures are in the update flows and are environmental — `git init -b` needs git ≥ 2.28 and this machine has 2.25.1; they fail identically on an untouched `v0.3.13` checkout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Исправления**
  - Исправлено формирование переменной `PATH` для дочерних процессов.
  - Каталог Node.js больше не дублируется, если уже присутствует в `PATH`.
  - Существующий порядок каталогов сохраняется; отсутствующий каталог Node.js добавляется в начало.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->