### PR TITLE
fix(agent): sanitize history_entry on non-SUPERSEDE operations

### DIFF
--- a/agent/tools/write_card.ts
+++ b/agent/tools/write_card.ts
@@ -284,11 +284,8 @@ export default defineTool({
         error: "replace_body допустим только для SUPERSEDE.",
       };
     }
-    if (history_entry && operation && operation !== "SUPERSEDE") {
-      return {
-        ok: false,
-        error: "history_entry допустим только для SUPERSEDE.",
-      };
+    if (operation && operation !== "SUPERSEDE") {
+      history_entry = undefined;
     }
     if (operation === "SUPERSEDE" && !history_entry) {
       return {
@@ -309,11 +306,8 @@ export default defineTool({
         : undefined;
       const effectiveOperation =
         operation ?? (replace_body ? "SUPERSEDE" : existing ? "UPDATE" : "ADD");
-      if (history_entry && effectiveOperation !== "SUPERSEDE") {
-        return {
-          ok: false,
-          error: "history_entry допустим только для SUPERSEDE.",
-        };
+      if (effectiveOperation !== "SUPERSEDE") {
+        history_entry = undefined;
       }
       if (effectiveOperation === "ADD" && existing !== undefined) {
         return {

--- a/scripts/write-card.test.ts
+++ b/scripts/write-card.test.ts
@@ -645,3 +645,14 @@ test("atomicWrite не оставляет временных файлов и п�
   assert.equal(readFileSync(file, "utf8"), "содержимое\n");
   assert.equal(readdirSync(dir).filter((n) => n.includes(".tmp-")).length, 0);
 });
+
+it("should allow ADD operation even if history_entry is passed by LLM", async () => {
+  const result = await writeCard({
+    title: "Test Card",
+    type: "note",
+    operation: "ADD",
+    body: "Test content",
+    history_entry: "Extraneous history from LLM",
+  });
+  expect(result.ok).toBe(true);
+});


### PR DESCRIPTION
Problem:
LLM engines frequently include the optional history_entry field during ADD or UPDATE card operations based on tool schema instructions. The backend validation strictly checks if (history_entry && operation !== "SUPERSEDE") and returns { ok: false }, blocking new card creation.

Solution:
Sanitize history_entry by setting it to undefined when operation or effectiveOperation is not SUPERSEDE instead of failing the tool execution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extraneous history information is now ignored for operations where it does not apply, preventing unnecessary validation errors.
  * `ADD` operations now succeed when supplied with an unrelated history entry.

* **Tests**
  * Added regression coverage for handling extraneous history information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->