### PR TITLE
fix: carry packages/ into the custom-layer runtime snapshot

### DIFF
--- a/scripts/lib/custom-layer.test.ts
+++ b/scripts/lib/custom-layer.test.ts
@@ -77,6 +77,11 @@ function fixture(t: TestContext): {
     'export const runtimeValue = "ready";\n',
   );
   write(root, "scripts/core.ts", "export {};\n");
+  write(
+    root,
+    "packages/data-dir/index.ts",
+    'export const resolveDataDir = () => "data";\n',
+  );
   git(root, "add", ".");
   git(root, "commit", "-m", "base");
   const base = git(root, "rev-parse", "HEAD");
@@ -246,6 +251,14 @@ test("materialization applies clean three-way merges and advances the manifest a
     ),
     'export const runtimeValue = "ready";\n',
     "stable runtime keeps the external source dependency imported by agent/provider.ts",
+  );
+  assert.equal(
+    readFileSync(
+      join(result.runtimeRoot, "packages/data-dir/index.ts"),
+      "utf8",
+    ),
+    'export const resolveDataDir = () => "data";\n',
+    "stable runtime keeps packages/ imported by agent/lib/data-dir.ts",
   );
 });
 

--- a/scripts/lib/custom-layer.ts
+++ b/scripts/lib/custom-layer.ts
@@ -579,6 +579,15 @@ export function materializeCustomLayer({
           recursive: true,
           preserveTimestamps: true,
         });
+      // Since 0.3.24 agent/lib/data-dir.ts reaches one level further out:
+      // `../../packages/data-dir/index.ts`. Without packages/ in the snapshot
+      // Eve cannot bundle the promoted agent and the service crash-loops.
+      const rootPackages = join(root, "packages");
+      if (existsSync(rootPackages))
+        cpSync(rootPackages, join(stagedRuntime, "packages"), {
+          recursive: true,
+          preserveTimestamps: true,
+        });
       renameSync(stagedRuntime, runtimeRoot);
     } catch (error) {
       rmSync(stagedRuntime, { recursive: true, force: true });


### PR DESCRIPTION
## Bug

0.3.24 moved the data-dir helper into a workspace package: `agent/lib/data-dir.ts` now imports `../../packages/data-dir/index.ts`. The custom-layer runtime snapshot (`data/custom/runtimes/<rev>-<digest>/`) still copies only `agent/` and `scripts/`, so the import points outside the snapshot.

## Repro

1. Any install with a non-empty custom layer — e.g. one skill in `data/custom/agent/skills/`.
2. Update to 0.3.24 (or just `npm run build`): the build materializes the runtime snapshot and points the bundle's `agentRoot` at it.
3. On the next service start Eve fails to bundle the promoted agent and the service crash-loops:

```
[UNRESOLVED_IMPORT] Could not resolve '../../packages/data-dir/index.ts'
  in data/custom/runtimes/<rev>-<digest>/agent/lib/data-dir.ts
```

A stock install is unaffected (no custom layer → no snapshot), which is probably why it slipped through.

## Fix

Copy `packages/` into the staged runtime next to the existing `scripts/` carry-over, with the same `existsSync` guard for minimal fixture trees. Added a test asserting the snapshot keeps `packages/data-dir/index.ts`; it fails on current main and passes with the fix (13/13 in `custom-layer.test.ts`).

Hit in production on my install right after updating to v0.3.24; verified the fix live — service starts cleanly and the snapshot now contains `agent/`, `scripts/`, `packages/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Runtime snapshots now preserve available package files, ensuring promoted agents retain the dependencies they need to run correctly.
  - Improved materialization behavior keeps package content in stable runtime outputs.

- **Tests**
  - Added coverage verifying that package files are included in generated runtime snapshots and remain available after materialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->