### PR TITLE
fix(update): recovery restores the permissions it captured

### DIFF
--- a/scripts/fixtures/update-recovery.ts
+++ b/scripts/fixtures/update-recovery.ts
@@ -48,8 +48,19 @@ export function recoveryFixture(): RecoveryFixture {
   git(temp, "clone", "--branch", "main", remote, local);
   git(local, "config", "user.email", "test@example.com");
   git(local, "config", "user.name", "Iva Test");
+  normalizePermissions(local);
   mkdirSync(data, { recursive: true });
   return { temp, remote, seed, local, data };
+}
+
+/**
+ * Git checks a clone out through the runner's umask, so a group-writable umask hands every
+ * test a tree the snapshot already calls dirty on permissions alone. Pin the checkout to
+ * 644 so each test decides for itself what is dirty about its tree.
+ */
+export function normalizePermissions(root: string): void {
+  for (const path of git(root, "ls-files").split("\n").filter(Boolean))
+    chmodSync(join(root, path), 0o644);
 }
 
 export function recoveryTransaction(fx: RecoveryFixture) {
@@ -69,6 +80,7 @@ export function addIgnoreRule(fx: RecoveryFixture, pattern: string): void {
   git(fx.seed, "commit", "-m", `ignore ${pattern}`);
   git(fx.seed, "push", "origin", "main");
   git(fx.local, "pull", "--ff-only");
+  normalizePermissions(fx.local);
 }
 
 export function wrappedRecoveryTransaction(fx: RecoveryFixture, body: string) {

--- a/scripts/lib/update-recovery.test.ts
+++ b/scripts/lib/update-recovery.test.ts
@@ -871,3 +871,44 @@ test("one recovery cleanup failure cannot skip env, output or node_modules rollb
   );
   await tx.teardownCandidate();
 });
+
+test("protect and rollback keep a group-writable tracked file at its own permissions", async (t) => {
+  const fx = fixture();
+  t.after(() => rmSync(fx.temp, { recursive: true, force: true }));
+  // Only the permission differs from HEAD — the bytes and the index are untouched — so
+  // this is the whole reason the snapshot is taken, and the restore must not flatten it.
+  chmodSync(join(fx.local, "tracked.txt"), 0o664);
+  const mode = () => statSync(join(fx.local, "tracked.txt")).mode & 0o777;
+  const tx = transaction(fx);
+
+  await tx.protect();
+
+  assert.equal(mode(), 0o664);
+  assert.equal(readFileSync(join(fx.local, "tracked.txt"), "utf8"), "base\n");
+
+  await tx.rollback();
+
+  assert.equal(mode(), 0o664);
+  assert.equal(readFileSync(join(fx.local, "tracked.txt"), "utf8"), "base\n");
+});
+
+test("a clean rollback puts back the permissions git reset wrote through the umask", async (t) => {
+  const fx = fixture();
+  t.after(() => rmSync(fx.temp, { recursive: true, force: true }));
+  const tracked = join(fx.local, "tracked.txt");
+  const tx = transaction(fx);
+
+  await tx.protect();
+  writeFileSync(tracked, "new commit\n");
+  git(fx.local, "add", "tracked.txt");
+  git(fx.local, "commit", "-m", "simulate integrated update");
+  // The reset inside the rollback rewrites the file as a child of this process, so a
+  // group-writable umask here is exactly the installation the updater kept failing on.
+  const previous = process.umask(0o002);
+  t.after(() => process.umask(previous));
+
+  await tx.rollback();
+
+  assert.equal(statSync(tracked).mode & 0o777, 0o644);
+  assert.equal(readFileSync(tracked, "utf8"), "base\n");
+});

--- a/scripts/lib/update-recovery.ts
+++ b/scripts/lib/update-recovery.ts
@@ -1,5 +1,11 @@
 import { randomUUID } from "node:crypto";
-import { lstatSync, readFileSync, readlinkSync, rmSync } from "node:fs";
+import {
+  chmodSync,
+  lstatSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+} from "node:fs";
 import { resolve, sep } from "node:path";
 import {
   planIgnoredCollisions,
@@ -443,6 +449,7 @@ export class UpdateRecoveryOwner {
     if (this.#state.phase === "clean") {
       await this.#clearIndexFlags(this.#state.indexFlags);
       await this.#mustGit(["reset", "--hard", this.#headOid]);
+      this.#restorePermissions(this.#state.worktreeEntries);
       await this.#restoreIndexFlags(this.#state.indexFlags);
       await this.#snapshotVerifier.verifyClean(this.#state);
       return;
@@ -586,6 +593,7 @@ export class UpdateRecoveryOwner {
     await this.#materializeTree(
       snapshot.worktreeTree,
       snapshot.indexEntries.map(({ path }) => path),
+      snapshot.worktreeEntries,
     );
     if (!preserveCollisionOwnership && snapshot.untrackedTree) {
       await this.#untracked.restore(
@@ -616,13 +624,23 @@ export class UpdateRecoveryOwner {
     }
   }
 
+  // A Git tree only records the executable bit, so the live permissions the snapshot
+  // captured (664 under a group-writable umask, say) have to be carried in separately —
+  // otherwise the restore republishes every file at 644/755 and the verifier that runs
+  // right after rejects the tree it just wrote.
   async #materializeTree(
     tree: string,
     removePaths: readonly string[],
+    liveEntries: readonly SnapshotTreeEntry[] = [],
     preserveCollisionOwnership = false,
   ) {
     const entries = this.#objects.parseTreeEntries(
       await this.#mustGit(["ls-tree", "-r", "-z", tree]),
+    );
+    const livePermissions = new Map(
+      liveEntries.flatMap(({ path, permissions }) =>
+        permissions === undefined ? [] : [[path, permissions] as const],
+      ),
     );
     const contents: RecoveryContentEntry[] = [];
     for (const entry of entries) {
@@ -633,7 +651,12 @@ export class UpdateRecoveryOwner {
         throw new Error(
           blob.stderr || `couldn't read recovery blob: ${entry.path}`,
         );
-      contents.push({ ...entry, bytes: blob.stdout });
+      const permissions = livePermissions.get(entry.path);
+      contents.push({
+        ...entry,
+        bytes: blob.stdout,
+        ...(permissions === undefined ? {} : { permissions }),
+      });
     }
     const owner = new RawTrackedOwner({
       root: this.#root,
@@ -742,6 +765,20 @@ export class UpdateRecoveryOwner {
     if (stat.isDirectory() && indexMode === "160000")
       throw new Error(`unsupported working-tree entry: ${path} (gitlink)`);
     throw new Error(`unsupported working-tree entry: ${path}`);
+  }
+
+  // `git reset --hard` rewrites every changed file through the process umask, so a tree
+  // that was 664 comes back 644 under a stricter one. The captured modes are part of what
+  // recovery promises to restore, and the verifier right after this compares them.
+  #restorePermissions(entries: readonly SnapshotTreeEntry[]): void {
+    for (const { path, permissions } of entries) {
+      if (permissions === undefined) continue;
+      const target = this.#safeChild(this.#root, path);
+      const stat = lstatSync(target, { throwIfNoEntry: false });
+      if (!stat || stat.isSymbolicLink() || (stat.mode & 0o777) === permissions)
+        continue;
+      chmodSync(target, permissions);
+    }
   }
 
   #liveBytes(entry: SnapshotTreeEntry): Buffer {


### PR DESCRIPTION
`iva update` could never leave the protect phase on this install. The journal
(`journalctl --user -u iva-self-update-*`) showed:

```
⚠️ Couldn't save your changes
git recovery snapshot permissions do not match: .env.example. Rollback: FAILED
```

`data/logs/update-*.log` only carried the harmless `fatal: '.iva-update/staging' is not a
working tree`, so the real cause was invisible from there.

## Root cause

`#materializeTree` in `scripts/lib/update-recovery.ts` rebuilt the restore entries from
`git ls-tree`. A Git tree records only the executable bit, so the live permissions the
snapshot had just captured were dropped and every tracked file was republished at
644/755. On a group-writable tree the chain runs:

1. The install's files are `664/775` — a clone or merge made under `umask 002`.
2. That permission drift alone makes `capture()` treat a clean tree as dirty.
3. `prepareLiveTree()` rewrites all tracked files as `644/755`, losing the `664`.
4. The verifier that runs straight after compares live `644` against expected `664` and
   throws.
5. Rollback goes through the same code, so it fails identically — `Rollback: FAILED`.

Side effect on the affected install: 49 MB of retention debt in
`data/update-recovery-debt/` (2708 containers hardlinked to repo files) and a dangling
stash, because the restore churned the whole tree on every attempt.

## The change

- Carry the captured permissions into the materialized entries.
- Re-apply them after `git reset --hard` on the clean rollback path — that reset
  recreates changed files through the process umask, so a `664` tree comes back `644`
  under a stricter one.
- Restoring the mode also lets `RawTrackedOwner` skip files that already match, so the
  restore stops pushing the entire tree through retention debt.
- The fixture now pins its checkout to 644. `git clone` applies the runner's umask, so
  the suite silently exercised a different tree depending on who ran it — which is what
  hid this bug.

## Upgrading an older install

No state or format change: nothing persisted is read or written differently, and the
update runs under the previous CLI as before. An install that is currently wedged in the
protect phase needs the stale recovery state cleared once (drop the leftover containers
under `data/update-recovery-debt/` and the dangling stash) before the next `iva update`;
after that the normal path works. Installs that were never wedged need nothing.

## Checks

Run on Ubuntu (Linux 5.15), Node from the repo's toolchain:

- `npm run lint` — clean
- `npm run format:check` — "All matched files use Prettier code style!"
- `npm run typecheck` — clean
- `npm test` — 9 failures, all of them pre-existing. I re-ran the same five test files at
  the parent commit in a separate worktree and got the identical set, so this change adds
  none. Two of them are environmental rather than real: `brain-alerts.test.ts:509` asserts
  `/opt/homebrew/bin/uv` exists (a macOS path — this box has uv at `~/.local/bin/uv`), and
  the `update-ui.test.ts` failures come from `git merge-tree --write-tree`, which needs
  Git ≥ 2.38 while this box has 2.34.1. I did not diagnose the others beyond confirming
  they predate the change.
- The two new tests fail against the unpatched source and pass with it — I verified that
  by running the new test file against the parent commit's `update-recovery.ts`.

Not run: `npm run build`, `npm run test:coverage`, `npm run replica`, the Python suites.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File permissions are now preserved when protecting and restoring changes.
  * Rollbacks correctly restore tracked files to their expected permissions.
  * Permission-only differences no longer cause recovery checks to appear modified.

* **Tests**
  * Added coverage for preserving group-writable files and restoring permissions during rollback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->