### PR TITLE
fix: preserve agent summary after isolated build

### DIFF
--- a/scripts/build-isolation.test.ts
+++ b/scripts/build-isolation.test.ts
@@ -25,6 +25,7 @@ const REPO = join(dirname(fileURLToPath(import.meta.url)), "..");
 const CORE = `import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 mkdirSync(join(process.cwd(), ".output"), { recursive: true });
+mkdirSync(join(process.cwd(), ".eve"), { recursive: true });
 writeFileSync(
   join(process.cwd(), ".output/app.mjs"),
   "import " + JSON.stringify(join(process.cwd(), "agent/agent.ts")) + ";\\n",
@@ -32,6 +33,10 @@ writeFileSync(
 writeFileSync(
   join(process.cwd(), ".output/data-dir.txt"),
   process.env.ASSISTANT_DATA_DIR ?? "",
+);
+writeFileSync(
+  join(process.cwd(), ".eve/agent-summary.json"),
+  JSON.stringify({ skills: [{ name: "mine", description: "stock" }] }),
 );
 `;
 
@@ -133,6 +138,20 @@ test("the staging build receives the installation's canonical data directory", (
   assert.equal(
     readFileSync(join(version, ".output/data-dir.txt"), "utf8"),
     join(home, "runtime"),
+  );
+});
+
+test("the staging build promotes eve's agent summary", () => {
+  const home = join(world(), "iva");
+  const version = join(home, "versions/0.3.15-0123456789ab");
+  mkdirSync(version, { recursive: true });
+  plantTree(version);
+
+  const built = build(version);
+  assert.equal(built.status, 0, built.output);
+  assert.deepEqual(
+    JSON.parse(readFileSync(join(version, ".eve/agent-summary.json"), "utf8")),
+    { skills: [{ name: "mine", description: "stock" }] },
   );
 });
 

--- a/scripts/build-isolation.test.ts
+++ b/scripts/build-isolation.test.ts
@@ -112,18 +112,26 @@ function git(cwd: string, args: readonly string[]): string {
 function build(
   root: string,
   configuredDataDir?: string,
+  nodeImport?: string,
 ): { status: number | null; output: string } {
-  const result = spawnSync(process.execPath, [join(root, "scripts/build.ts")], {
-    cwd: root,
-    encoding: "utf8",
-    env: {
-      ...process.env,
-      NO_COLOR: "1",
-      ...(configuredDataDir === undefined
-        ? {}
-        : { ASSISTANT_DATA_DIR: configuredDataDir }),
+  const result = spawnSync(
+    process.execPath,
+    [
+      ...(nodeImport ? ["--import", nodeImport] : []),
+      join(root, "scripts/build.ts"),
+    ],
+    {
+      cwd: root,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        NO_COLOR: "1",
+        ...(configuredDataDir === undefined
+          ? {}
+          : { ASSISTANT_DATA_DIR: configuredDataDir }),
+      },
     },
-  });
+  );
   return { status: result.status, output: `${result.stdout}${result.stderr}` };
 }
 
@@ -152,6 +160,46 @@ test("the staging build promotes eve's agent summary", () => {
   assert.deepEqual(
     JSON.parse(readFileSync(join(version, ".eve/agent-summary.json"), "utf8")),
     { skills: [{ name: "mine", description: "stock" }] },
+  );
+});
+
+test("backup cleanup cannot roll back the promoted build", () => {
+  const home = join(world(), "iva");
+  const version = join(home, "versions/0.3.15-0123456789ab");
+  mkdirSync(version, { recursive: true });
+  plantTree(version);
+  mkdirSync(join(version, ".output"), { recursive: true });
+  mkdirSync(join(version, ".eve"), { recursive: true });
+  writeFileSync(join(version, ".output/app.mjs"), "old output\n");
+  writeFileSync(
+    join(version, ".eve/agent-summary.json"),
+    JSON.stringify({ skills: [{ name: "old", description: "old" }] }),
+  );
+  const failCleanup = join(version, "fail-cleanup.mjs");
+  writeFileSync(
+    failCleanup,
+    `import fs from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
+const rmSync = fs.rmSync;
+fs.rmSync = (path, options) => {
+  if (String(path).includes("agent-summary.iva-build-backup-"))
+    throw new Error("forced summary backup cleanup failure");
+  return rmSync(path, options);
+};
+syncBuiltinESMExports();
+`,
+  );
+
+  const built = build(version, undefined, failCleanup);
+  assert.equal(built.status, 0, built.output);
+  assert.match(built.output, /build artifact cleanup deferred/u);
+  assert.deepEqual(
+    JSON.parse(readFileSync(join(version, ".eve/agent-summary.json"), "utf8")),
+    { skills: [{ name: "mine", description: "stock" }] },
+  );
+  assert.notEqual(
+    readFileSync(join(version, ".output/app.mjs"), "utf8"),
+    "old output\n",
   );
 });
 

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -111,13 +111,39 @@ function restoreOutput(backup: string | null): void {
   if (backup && existsSync(backup)) renameSync(backup, join(ROOT, ".output"));
 }
 
+function promoteAgentSummary(staging: string): string | null {
+  const built = join(staging, ".eve/agent-summary.json");
+  const liveDir = join(ROOT, ".eve");
+  const live = join(liveDir, "agent-summary.json");
+  mkdirSync(liveDir, { recursive: true });
+  const backup = existsSync(live)
+    ? join(liveDir, `agent-summary.iva-build-backup-${Date.now()}.json`)
+    : null;
+  if (backup) renameSync(live, backup);
+  try {
+    renameSync(built, live);
+  } catch (error) {
+    if (backup && existsSync(backup)) renameSync(backup, live);
+    throw error;
+  }
+  return backup;
+}
+
+function restoreAgentSummary(backup: string | null): void {
+  rmSync(join(ROOT, ".eve/agent-summary.json"), { force: true });
+  if (backup && existsSync(backup))
+    renameSync(backup, join(ROOT, ".eve/agent-summary.json"));
+}
+
 export function buildWithCustomLayer(): void {
   mkdirSync(BUILD_ROOT, { recursive: true });
   const staging = mkdtempSync(join(BUILD_ROOT, "staging-"));
   let materialized: MaterializedCustomLayer | null = null;
   let invalidRecoveryDir: string | null = null;
   let outputBackup: string | null = null;
-  let promoted = false;
+  let summaryBackup: string | null = null;
+  let outputPromoted = false;
+  let summaryPromoted = false;
   try {
     copySourceTree(staging);
     if (existsSync(join(ROOT, "node_modules")))
@@ -189,7 +215,11 @@ export function buildWithCustomLayer(): void {
       agentRoot: materialized?.runtimeRoot,
     });
     outputBackup = promoteOutput(staging);
-    promoted = true;
+    outputPromoted = true;
+    if (existsSync(join(staging, ".eve/agent-summary.json"))) {
+      summaryBackup = promoteAgentSummary(staging);
+      summaryPromoted = true;
+    }
     if (materialized) {
       commitCustomLayer(materialized);
       materialized = null;
@@ -198,9 +228,11 @@ export function buildWithCustomLayer(): void {
       process.stderr.write(
         `custom layer is invalid; built core only; recovery: ${invalidRecoveryDir}\n`,
       );
+    if (summaryBackup) rmSync(summaryBackup, { force: true });
     if (outputBackup) rmSync(outputBackup, { recursive: true, force: true });
   } catch (error) {
-    if (promoted) restoreOutput(outputBackup);
+    if (summaryPromoted) restoreAgentSummary(summaryBackup);
+    if (outputPromoted) restoreOutput(outputBackup);
     if (materialized) discardCustomLayer(materialized);
     throw error;
   } finally {

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -228,8 +228,13 @@ export function buildWithCustomLayer(): void {
       process.stderr.write(
         `custom layer is invalid; built core only; recovery: ${invalidRecoveryDir}\n`,
       );
-    if (summaryBackup) rmSync(summaryBackup, { force: true });
-    if (outputBackup) rmSync(outputBackup, { recursive: true, force: true });
+    try {
+      if (summaryBackup) rmSync(summaryBackup, { force: true });
+      if (outputBackup) rmSync(outputBackup, { recursive: true, force: true });
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      process.stderr.write(`build artifact cleanup deferred: ${detail}\n`);
+    }
   } catch (error) {
     if (summaryPromoted) restoreAgentSummary(summaryBackup);
     if (outputPromoted) restoreOutput(outputBackup);


### PR DESCRIPTION
## Problem

`npm run build` runs `eve build` in `.iva-build/staging-*`. Eve writes `.eve/agent-summary.json` there, but the isolated build wrapper promotes only `.output` and then removes staging.

As a result, a successful install or Telegram update leaves `/menu → Skills` with:

```
Skill list is unavailable — .eve/agent-summary.json not found
```

## Change

- promote Eve's `agent-summary.json` into the live `.eve` directory when the build produces it;
- keep the previous summary as a rollback backup and restore it together with `.output` if a later build step fails;
- add a regression test for the isolated version-build path.

No menu fallback and no parsing of Eve's internal discovery manifest are added.

## Verification

- `node --test scripts/build-isolation.test.ts scripts/lib/custom-layer.test.ts` — 18/18 pass
- `npm run typecheck` — pass
- ESLint and Prettier on the changed files — pass
- `npm run build` — pass; the promoted summary contains 9 stock skills
- isolated `scripts/cli/version-update-telegram.test.ts` — 9/9 pass

A full local WSL run completed 2365/2371. Five failures reproduce unchanged on the parent commit (missing local `uv`/Python support plus the existing setup-wizard timeout). The sixth was a concurrent Node test-runner deserialization failure and passes 9/9 when rerun in isolation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Build results now preserve agent summary information alongside generated output.
  - Existing summaries are retained during successful builds and restored if a build fails.
- **Reliability**
  - Cleanup issues after a successful build no longer undo promoted build artifacts.
- **Tests**
  - Added coverage for summary preservation and independent recovery of build results when failures occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->