### PR TITLE
fix: drop the recovery stash on a failed update, not just a successful one

### DIFF
--- a/scripts/lib/update-recovery.test.ts
+++ b/scripts/lib/update-recovery.test.ts
@@ -141,6 +141,26 @@ test("rollback restores raw bytes without clean, smudge or eol filters", async (
   assert.deepEqual(state(), before);
 });
 
+test("a clean rollback drops the recovery stash, matching commit's cleanup", async (t) => {
+  const fx = fixture();
+  t.after(() => rmSync(fx.temp, { recursive: true, force: true }));
+  const trackedPath = join(fx.local, "tracked.txt");
+  const dirtyContent = "dirty modification\n";
+  writeFileSync(trackedPath, dirtyContent);
+  const tx = transaction(fx);
+
+  await tx.protect();
+
+  const stashBefore = git(fx.local, "stash", "list", "--format=%H");
+  assert.notEqual(stashBefore, "");
+
+  await tx.rollback();
+
+  const stashAfter = git(fx.local, "stash", "list", "--format=%H");
+  assert.equal(stashAfter, "");
+  assert.equal(readFileSync(trackedPath, "utf8"), dirtyContent);
+});
+
 test("rollback restores assume-unchanged and skip-worktree flags with hidden bytes", async (t) => {
   const fx = fixture();
   t.after(() => rmSync(fx.temp, { recursive: true, force: true }));

--- a/scripts/lib/update-safety.ts
+++ b/scripts/lib/update-safety.ts
@@ -775,6 +775,14 @@ export function createUpdateTransaction({
         }
         await recoveryOwner.rollback();
         stashApplied = hadLocalChanges;
+        // Without this the recovery stash from protect() survives a failed
+        // /update and accumulates in `git stash list`. commit() (the success
+        // path) already drops it through the same dropExactStash — rollback()
+        // did not keep that symmetry.
+        await recoveryOwner.cleanup(
+          dropExactStash,
+          resources.recoveryExcludedPaths,
+        );
       }
     } catch (error) {
       capture(error);


### PR DESCRIPTION
## What

`rollback()` restored files from the recovery stash created in `protect()` but never
dropped the stash afterward. `commit()`, the success path, already calls
`recoveryOwner.cleanup()` to drop it. Every failed update left an orphaned stash behind,
and orphaned stashes accumulate silently across unrelated failures — an old one can later
get mistaken for the current recovery point and applied by hand, regressing the install to
whatever it captured. That's what happened on my own install: an 8-day-old orphaned stash
got applied over `main`, silently regressing production several versions back.

## Upgrade note

An install already carrying orphaned stashes from past failed updates is not touched by
this fix — it only stops new ones from accumulating. Existing stray stashes still need a
manual `git stash list` / `git stash drop` in the install directory.

## Tests

Added a regression test in `scripts/lib/update-recovery.test.ts`: a clean rollback must
leave the recovery stash list empty, the same as a clean commit already does.

Confirmed red without the fix, green with it, in a container with git 2.39 (this
machine's own git, 2.25.1, can't run the shared fixture's `git init -b`, a pre-existing
environment limitation unrelated to this change — same limitation blocks the full local
suite here too).

## Checks run

- `npx eslint scripts/lib/update-safety.ts scripts/lib/update-recovery.test.ts` — clean
- `npx prettier --check` on both files — clean
- `npm run typecheck` — clean
- `node --test scripts/lib/update-recovery.test.ts` (git 2.39 container) — 19/19 pass,
  including the new test; one pre-existing unrelated failure in a different test
  (`git merge-tree --merge-base` unsupported by that container's git) also present without
  this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Recovery stashes are now automatically removed when an update is rolled back, preventing stale entries from remaining after failed updates.

* **Tests**
  * Added coverage to verify rollback cleanup while preserving tracked file changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->