### PR TITLE
rollup: resync stream cursor before send and refuse stale turn results

### DIFF
--- a/scripts/memory/rollup.ts
+++ b/scripts/memory/rollup.ts
@@ -334,6 +334,36 @@ const coreBeforeTurn = period === "daily" ? readCoreText(CORE_PATH) : "";
 const saved = loadSession();
 let sessionCreatedAt = saved?.createdAt ?? Date.now();
 let session = saved ? client.session(saved.state) : client.session();
+// Промпт строится один раз: он же — эталон для проверки, что result() вернул именно
+// наш ход (см. ниже «протухший результат»).
+const mainPrompt = buildPrompt(period, today);
+// Ресинк курсора ДО send(): eve-клиент (0.30.8) читает поток с сохранённого
+// streamIndex и отдаёт ПЕРВУЮ встреченную границу хода, не сверяя её с отправленным
+// сообщением. Отставший курсор (сервер умеет писать вторую терминальную тройку на
+// тот же turnId — её хвост остаётся непрочитанным) превращает result() в чтение
+// старого хода: инцидент 24.08.2026 — пять ночей подряд в Telegram уходил отчёт
+// пятидневной давности, а падение реального хода по квоте прошло незамеченным.
+// stream({follow:false}) дочитывает до хвоста и сдвигает session.state.streamIndex;
+// в норме курсор уже на хвосте и цикл не делает ни одной итерации. Зовём перед
+// КАЖДЫМ send в эту сессию (main, core-correction, format-feedback): вторая тройка
+// может появиться и после нашего же основного хода.
+async function drainStreamToTail(label: string): Promise<void> {
+  try {
+    for await (const _ of session.stream({ follow: false })) {
+      /* события не нужны — важен только сдвиг курсора */
+    }
+  } catch (e) {
+    console.error(
+      `rollup ${period}: ${label}: pre-send stream drain failed (${(e as Error).message}) — continuing with current cursor`,
+    );
+  }
+}
+if (saved) await drainStreamToTail("main-turn");
+// Нижняя граница времени для проверки принадлежности результата: события нашего хода
+// не могут быть старше старта скрипта (минус минута на всякий случай — часы у скрипта
+// и сервера одни, оба на этом хосте). Без неё повторный запуск в ту же дату принял бы
+// message.received первой попытки за свой: промпт уникален за дату, но не за попытку.
+const sentNotBefore = new Date(Date.now() - 60_000).toISOString();
 let result;
 let accepted = false;
 let sendRejected = false;
@@ -341,7 +371,7 @@ let acceptedTurnResult: Promise<MessageResult> | undefined;
 try {
   result = await guardedTurn(
     session,
-    buildPrompt(period, today),
+    mainPrompt,
     "main-turn",
     (turnResult) => {
       accepted = true;
@@ -383,16 +413,34 @@ try {
   sessionCreatedAt = Date.now();
   // Ровно одна попытка: второй сбой уходит наверх и роняет юнит с ненулевым кодом.
   try {
-    result = await guardedTurn(
-      session,
-      buildPrompt(period, today),
-      "main-turn",
-    );
+    result = await guardedTurn(session, mainPrompt, "main-turn");
   } catch (retryError) {
     if ((retryError as { code?: string }).code === "ROLLUP_TURN_TIMEOUT")
       await cancelTurnQuietly(session);
     throw retryError;
   }
+}
+// Страховка от протухшего результата (второй эшелон после ресинка выше): свой ход
+// опознаём по собственному message.received с точным текстом промпта — промпт содержит
+// дату и уникален за ночь. Чужой результат не доставляем и не сохраняем курсор:
+// сломанный курсор выбрасываем, следующая ночь начнёт свежую сессию.
+const ownTurn = result.events.some(
+  (ev) =>
+    ev.type === "message.received" &&
+    ev.data.message === mainPrompt &&
+    ev.meta.at >= sentNotBefore,
+);
+if (!ownTurn) {
+  console.error(
+    `rollup ${period}: result does not match the prompt just sent (stale stream cursor) — dropping session`,
+  );
+  logAbandoned(session.state, "stale-result");
+  try {
+    rmSync(SESSION_FILE, { force: true });
+  } catch {
+    /* курсор — кэш, его потеря не должна ронять ночь */
+  }
+  process.exit(1);
 }
 saveSession(session.state, sessionCreatedAt);
 
@@ -478,6 +526,7 @@ if (period === "daily") {
     // Таймаут здесь не заводит новую сессию: это просто «коррекция не удалась» — файл
     // перечитывается как есть, и дальше срабатывает существующая проверка капа.
     try {
+      await drainStreamToTail("core-correction");
       await guardedTurn(
         session,
         `Re-open ${CORE_PATH}: it is ${oldLength} characters, above the hard ${CORE_CAP}-character cap. ` +
@@ -577,6 +626,7 @@ if (REPORTS_TO_TELEGRAM[period]) {
     // Best-effort ход: отчёт уже доставлен, поэтому сбой или таймаут здесь только логируем —
     // ронять из-за подсказки о форматировании всю ночь незачем.
     try {
+      await drainStreamToTail("format-feedback");
       await guardedTurn(
         session,
         `The last report failed Telegram parse_mode=HTML (${r.error}) and went out as flat text. ` +


### PR DESCRIPTION
## Problem

The nightly rollup resumes one parked session for weeks. eve's client `result()` reads the event stream from the **saved** cursor and stops at the **first** turn boundary, without correlating it with the message just sent — reported upstream as vercel/eve#2461. Once the cursor lags behind the stream tail, every nightly `result()` returns the final message of an **old** turn in ~1s, the script delivers it and exits 0, while the real turn runs asynchronously and its report is never delivered.

Real incident (2026-08-19…24): five consecutive nights the Telegram report was a five-day-old replay («Обработан день 2026-08-18» delivered on the 24th), and a real turn failure (provider weekly quota) never surfaced — the script had already read an older successful result. The lag was seeded by the server writing a **second** terminal triple (`message.completed`/`step.completed`/`turn.completed`/`session.waiting`) for the same `turnId` on five turns (eve 0.29.5, a replayed non-checkpointed step; details and stream dump indexes in the eve issue) — the client stops at the first boundary, so each duplicate leaves one unread turn behind, and the lag then sustains itself forever.

## Fix — two layers

1. **Resync before send.** `drainStreamToTail()` drains `session.stream({ follow: false })` (documented to advance `state.streamIndex` to the tail) before **every** send into the parked session — main turn, CORE correction, format feedback. In the steady state the cursor is already at the tail and the loop does zero iterations.
2. **Ownership validation.** The nightly prompt is unique per date; after the turn, `result.events` must contain our own `message.received` with the exact prompt text **and** `meta.at` not older than process start (guards a re-run on the same date, where the prompt text alone would match the first attempt). On mismatch: log, `logAbandoned(state, "stale-result")`, drop the cursor file and exit 1 — a foreign report is never delivered, and the next night starts a fresh session instead of silently replaying the past.

## Verification

- Live on the lagged production session: the drain consumed exactly the 959-event backlog in ~2s and moved the cursor 4804 → 5763 (tail per `x-eve-stream-tail-index` + 1), read-only, no state written.
- Running in production since 2026-08-24; steady-state cost is zero (empty drain, always-true check).
- The path is shared by all four periods (daily/weekly/monthly/yearly).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved session handling to prevent older or stale responses from being reused.
  - Ensured saved stream data is processed before generating responses and applying corrections.
  - Added safeguards to detect mismatched results and clean up invalid session state.
  - Improved reliability for Telegram formatting feedback flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->