### PR TITLE
plugin: verify generated artifacts after trust rebuild

### DIFF
--- a/scripts/cli/plugin.test.ts
+++ b/scripts/cli/plugin.test.ts
@@ -12,6 +12,7 @@ import {
   mkdtempSync,
   readdirSync,
   readFileSync,
+  realpathSync,
   rmSync,
   statSync,
   symlinkSync,
@@ -21,6 +22,7 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test, { after } from "node:test";
+import { fileURLToPath } from "node:url";
 import { readLiveSkills } from "#lib/custom-skills.ts";
 import { PLUGIN_SCHEMA_URL } from "#lib/plugin-reader.ts";
 import {
@@ -37,10 +39,15 @@ import {
   marketplaceSlug,
 } from "../lib/marketplace.ts";
 import { createSystemdControl } from "../lib/systemd-control.ts";
+import { pluginConnectionFile } from "../lib/plugin-build.ts";
+import { createVersionStore } from "../lib/version-store.ts";
 import { leftoverPluginDirs } from "./plugin-cli-context.ts";
 import { createPluginCommands } from "./plugin.ts";
 import { createCliRuntime } from "./runtime.ts";
-import type { PluginVersionBuild } from "./version-update-command.ts";
+import {
+  createVersionUpdateCommand,
+  type PluginVersionBuild,
+} from "./version-update-command.ts";
 
 type Runtime = ReturnType<typeof createCliRuntime>;
 type Events = Array<[string, string]>;
@@ -59,6 +66,28 @@ const GIT_ENV: NodeJS.ProcessEnv = {
   GIT_COMMITTER_NAME: "iva-test",
   GIT_COMMITTER_EMAIL: "iva@test.local",
 };
+
+const REPO = join(dirname(fileURLToPath(import.meta.url)), "../..");
+
+const FINISH = `import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+const [home, name] = process.argv.slice(2);
+const { createVersionStore } = await import(process.env.IVA_TEST_STORE);
+const store = createVersionStore(home);
+const previous = store.currentName();
+if (process.env.IVA_TEST_ARTIFACT) {
+  const artifact = join(home, "versions", name, process.env.IVA_TEST_ARTIFACT);
+  mkdirSync(dirname(artifact), { recursive: true });
+  writeFileSync(artifact, "export default 1;\\n");
+}
+store.complete(name);
+store.activate(name);
+store.settle(name);
+writeFileSync(
+  process.env.IVA_UPDATE_OUTCOME,
+  JSON.stringify({ status: "updated", version: name, previous, custom: "applied", migrations: [], removed: [] }),
+);
+`;
 
 const worlds: string[] = [];
 
@@ -1870,11 +1899,11 @@ test("a name eve cannot mount is refused for code and fine for skills", async ()
   assert.deepEqual(build.calls, []);
 });
 
-test("a version that runs without the plugin's code is not a successful install", async () => {
+test("a version missing the plugin's artifacts is not a successful install", async () => {
   const root = home();
   const folder = codePlugin("carrier");
-  // The pipeline says it built something; the version that runs has no mount for the
-  // plugin. "installed" is a promise about the code that runs, so this is a failure.
+  // The pipeline says it built something; the active version has no mount for the
+  // plugin. "installed" is a promise about the artifacts that are there, so this is a failure.
   const build = buildStub({ status: "built", version: "0.3.24-abcdefabcdef" });
   const { cmdPlugin, data } = commands(root, undefined, undefined, {}, build);
 
@@ -1885,12 +1914,12 @@ test("a version that runs without the plugin's code is not a successful install"
   // failure reason from it aborts the install, whatever produced it.
   build.outcome = {
     status: "failed",
-    reason: "0.3.24-abcdefabcdef runs without the code of carrier",
+    reason: "0.3.24-abcdefabcdef is missing artifacts of carrier",
   };
   await cmdPlugin(["disable", "carrier"]);
   await assert.rejects(
     cmdPlugin(["enable", "carrier"]),
-    /carrier stays disabled: .*runs without the code of carrier/u,
+    /carrier stays disabled: .*is missing artifacts of carrier/u,
   );
   assert.equal((await readPluginsState(data)).plugins[0].enabled, false);
 });
@@ -2062,6 +2091,105 @@ function processPlugin(
   );
   write(folder, "sh.iva/services/web/server.mjs", "// server\n");
   return folder;
+}
+
+/** MCP-only Plugin: skills plus a stdio server, no eve Extension. */
+function mcpOnlyPlugin(name: string, server: string): string {
+  const folder = join(world("mcp-only"), name);
+  plantPlugin(folder, name);
+  write(
+    folder,
+    "mcp.json",
+    JSON.stringify({
+      $schema: "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+      mcpServers: {
+        [server]: { type: "stdio", command: "node", args: ["serve.mjs"] },
+      },
+    }),
+  );
+  return folder;
+}
+
+/**
+ * Managed installation with an active Version, so `iva plugin trust` goes through
+ * the real rebuild guard instead of buildStub.
+ */
+function managedPluginWorld(artifact: string): {
+  readonly home: string;
+  readonly version: string;
+  readonly data: string;
+  readonly units: Units;
+  readonly cmdPlugin: (argv: string[]) => Promise<void>;
+  readonly events: Events;
+} {
+  const dir = realpathSync(world("managed"));
+  const home = join(dir, "iva");
+  const upstream = join(dir, "upstream.git");
+  git(["init", "-q", "--bare", "--initial-branch=main", upstream], dir);
+  mkdirSync(home, { recursive: true });
+  write(
+    home,
+    "package.json",
+    `${JSON.stringify({ name: "iva", version: "0.3.19", type: "module" }, null, 2)}\n`,
+  );
+  write(home, "scripts/update-finish.ts", FINISH);
+  git(["init", "-q", "--initial-branch=main"], home);
+  git(["remote", "add", "origin", upstream], home);
+  git(["config", "iva.updateBranch", "main"], home);
+  git(["add", "-A"], home);
+  git(["commit", "-qm", "release"], home);
+  git(["push", "-q", "origin", "main"], home);
+  const sha = git(["rev-parse", "HEAD"], home);
+
+  const store = createVersionStore(home);
+  const active = `0.3.19-${sha.slice(0, 12)}`;
+  const versionDir = store.stage(active);
+  write(
+    versionDir,
+    "package.json",
+    `${JSON.stringify({ name: "iva", version: "0.3.19" })}\n`,
+  );
+  write(versionDir, "scripts/update-finish.ts", FINISH);
+  write(home, ".env", "");
+  store.linkState(versionDir);
+  store.complete(active);
+  store.activate(active);
+  store.settle(active);
+
+  const data = join(home, "data");
+  mkdirSync(data, { recursive: true });
+  const units = unitWorld();
+  const events: Events = [];
+  const base = createCliRuntime(versionDir);
+  const runtime: Runtime = {
+    ...base,
+    C: NO_COLOR,
+    hasSystemd: () => true,
+    systemd: units.control,
+    UNIT_DIR: units.dir,
+    ok: (message) => events.push(["ok", message]),
+    warn: (message) => events.push(["warn", message]),
+    bad: (message) => events.push(["bad", message]),
+    step: (message) => events.push(["step", message]),
+    readEnv: () => ({ MODEL_PROVIDER: "codex", CODEX_MODEL: "gpt-test" }),
+    dataDirAbs: () => data,
+    childEnv: {
+      ...GIT_ENV,
+      IVA_TEST_STORE: join(REPO, "scripts/lib/version-store.ts"),
+      IVA_TEST_ARTIFACT: artifact,
+    },
+  };
+  const updater = createVersionUpdateCommand(runtime, {
+    restartServices: () => {},
+  });
+  const { cmdPlugin } = createPluginCommands(runtime, {
+    buildVersion: (options) => updater.rebuild(options),
+    now: () => new Date("2026-08-17T12:00:00.000Z"),
+    log: () => {},
+    translate: (en) => en,
+    cwd: () => home,
+  });
+  return { home, version: active, data, units, cmdPlugin, events };
 }
 
 test("trust hands out ports and tokens, writes the units and starts them", async () => {
@@ -2320,6 +2448,30 @@ test("a trust whose version build fails leaves the plugin untrusted", async () =
 
   assert.equal((await readPluginsState(data)).plugins[0].trusted, false);
   assert.deepEqual(units.units(), [], "nothing runs for an untrusted plugin");
+});
+
+test("trust of an MCP-only Plugin keeps the generated connection, trusted flag and unit", async () => {
+  const name = "relay";
+  const server = "viewer";
+  const connection = pluginConnectionFile(name, server);
+  const iva = managedPluginWorld(connection);
+  const folder = mcpOnlyPlugin(name, server);
+
+  await iva.cmdPlugin(["add", folder]);
+  assert.equal((await readPluginsState(iva.data)).plugins[0].trusted, false);
+  assert.deepEqual(iva.units.units(), []);
+
+  await iva.cmdPlugin(["trust", name]);
+
+  const entry = (await readPluginsState(iva.data)).plugins[0];
+  assert.equal(entry.trusted, true, "trust must not roll back to untrusted");
+  const active = createVersionStore(iva.home).currentName();
+  assert.ok(active);
+  assert.ok(
+    existsSync(join(iva.home, "versions", active, connection)),
+    "generated connection must exist in the active Version",
+  );
+  assert.deepEqual(iva.units.units(), ["iva-mcp-relay-viewer.service"]);
 });
 
 test("a plugin whose MCP is all remote is not trusted by a question nobody asked", async () => {

--- a/scripts/cli/version-update-command.ts
+++ b/scripts/cli/version-update-command.ts
@@ -30,6 +30,7 @@ import {
   parseVersionName,
   writeJson,
 } from "../lib/version-store.ts";
+import { pluginsMissingArtifacts } from "../lib/plugin-build.ts";
 import {
   commandRunner,
   runVersionUpdate,
@@ -317,19 +318,17 @@ export function createVersionUpdateCommand(
   }
 
   /**
-   * Which enabled plugins have no code in the version that runs now. The end state is
-   * the only honest answer to "is the plugin installed": every earlier step reports on
-   * a tree that a later one may have rebuilt without it.
+   * Which enabled plugins have no artifacts in the version that is active now. The
+   * end state is the only honest answer to "is the plugin installed": every earlier
+   * step reports on a tree that a later one may have rebuilt without it.
    */
-  async function missingPluginCode(): Promise<string[]> {
+  async function missingPluginArtifacts(): Promise<string[]> {
     const store = createVersionStore(install.home);
     const active = store.currentName();
     const { plugins } = await versionOverlay(store.layout.data);
     if (!active || plugins.length === 0) return [];
     const dir = join(store.layout.versions, active);
-    return plugins
-      .filter((plugin) => !existsSync(join(dir, plugin.mount)))
-      .map((plugin) => plugin.name);
+    return pluginsMissingArtifacts(dir, plugins);
   }
 
   /**
@@ -357,14 +356,14 @@ export function createVersionUpdateCommand(
         reason: "fix MODEL_PROVIDER first: iva config",
       };
     if (outcome.status === "updated" || outcome.status === "current") {
-      // What the installation ended up running, not what the build reported about
+      // What the installation ended up with, not what the build reported about
       // itself: a version whose name carries a plugin may still have been built
-      // without it, and "installed" is a promise about the code that runs.
-      const missing = await missingPluginCode();
+      // without it, and "installed" is a promise about the artifacts that are there.
+      const missing = await missingPluginArtifacts();
       if (missing.length > 0)
         return {
           status: "failed",
-          reason: `${outcome.version} runs without the code of ${missing.join(", ")}`,
+          reason: `${outcome.version} is missing artifacts of ${missing.join(", ")}`,
         };
       return { status: "built", version: outcome.version };
     }

--- a/scripts/cli/version-update-rebuild.test.ts
+++ b/scripts/cli/version-update-rebuild.test.ts
@@ -38,6 +38,9 @@ if (process.env.IVA_TEST_MOUNT) {
   const mount = join(home, "versions", name, process.env.IVA_TEST_MOUNT);
   mkdirSync(dirname(mount), { recursive: true });
   writeFileSync(mount, "export default 1;\\n");
+  const directory = join(home, "versions", name, "plugins/trace");
+  mkdirSync(directory, { recursive: true });
+  writeFileSync(join(directory, "package.json"), "{}\\n");
 }
 store.complete(name);
 store.activate(name);
@@ -108,6 +111,7 @@ function world(t: TestContext): World {
     `${JSON.stringify({ name: "iva", version: "0.3.19" })}\n`,
   );
   write(versionDir, "scripts/update-finish.ts", FINISH);
+  write(home, ".env", "");
   store.linkState(versionDir);
   store.complete(active);
   store.activate(active);
@@ -188,12 +192,12 @@ test("a build that leaves the plugin's code out is reported as a failure", async
   const iva = world(t);
 
   // The new version is built, flipped and settled - and carries no mount for the
-  // plugin. Every step said yes; the installation still runs without the plugin's code.
+  // plugin. Every step said yes; the installation is still missing the plugin's artifacts.
   const outcome = await iva.rebuild();
 
   assert.deepEqual(outcome, {
     status: "failed",
-    reason: `${createVersionStore(iva.home).currentName() ?? ""} runs without the code of trace`,
+    reason: `${createVersionStore(iva.home).currentName() ?? ""} is missing artifacts of trace`,
   });
 });
 

--- a/scripts/lib/plugin-build.test.ts
+++ b/scripts/lib/plugin-build.test.ts
@@ -28,11 +28,15 @@ import {
   mountSource,
   namespaceProblem,
   namespaceTaken,
+  pluginArtifacts,
+  pluginArtifactsPresent,
   pluginConnectionFile,
   pluginConnectionName,
   pluginDirectory,
   pluginMount,
   pluginNamespace,
+  pluginsMissingArtifacts,
+  type CodePlugin,
 } from "./plugin-build.ts";
 
 const worlds: string[] = [];
@@ -455,4 +459,108 @@ test("any server name either maps to a connection eve accepts or is refused", ()
       },
     ),
   );
+});
+
+function codePluginFixture(opts: {
+  name: string;
+  extension: boolean;
+  servers?: readonly string[];
+}): CodePlugin {
+  const connections = (opts.servers ?? []).map((server) => ({
+    server,
+    name: pluginConnectionName(opts.name, server),
+    file: pluginConnectionFile(opts.name, server),
+    source: "",
+  }));
+  return {
+    name: opts.name,
+    root: `/data/custom/plugins/${opts.name}`,
+    namespace: pluginNamespace(opts.name),
+    mount: pluginMount(opts.name),
+    directory: pluginDirectory(opts.name),
+    digest: "x",
+    config: "",
+    extension: opts.extension,
+    connections,
+  };
+}
+
+function plantArtifact(dir: string, path: string): void {
+  write(dir, path, "export default 1;\n");
+}
+
+test("MCP-only plugin with its connection file passes pluginsMissingArtifacts", () => {
+  const dir = world();
+  const mcp = codePluginFixture({
+    name: "demo-mcp",
+    extension: false,
+    servers: ["demo"],
+  });
+  plantArtifact(dir, mcp.connections[0].file);
+  assert.deepEqual(pluginArtifacts(mcp), [mcp.connections[0].file]);
+  assert.equal(pluginArtifactsPresent(dir, mcp), true);
+  assert.deepEqual(pluginsMissingArtifacts(dir, [mcp]), []);
+});
+
+test("MCP-only plugin without its connection file is missing artifacts", () => {
+  const dir = world();
+  const mcp = codePluginFixture({
+    name: "demo-mcp",
+    extension: false,
+    servers: ["demo"],
+  });
+  assert.equal(pluginArtifactsPresent(dir, mcp), false);
+  assert.deepEqual(pluginsMissingArtifacts(dir, [mcp]), ["demo-mcp"]);
+});
+
+test("Plugin with eve Extension without its mount is missing artifacts", () => {
+  const dir = world();
+  // Mount is required of a Plugin with eve Extension, not of an MCP-only Plugin.
+  const extension = codePluginFixture({ name: "trace", extension: true });
+  plantArtifact(dir, join(extension.directory, "package.json"));
+  assert.deepEqual(pluginArtifacts(extension), [
+    extension.mount,
+    extension.directory,
+  ]);
+  assert.deepEqual(pluginsMissingArtifacts(dir, [extension]), ["trace"]);
+});
+
+test("Plugin with eve Extension without its built directory is missing artifacts", () => {
+  const dir = world();
+  const extension = codePluginFixture({ name: "trace", extension: true });
+  plantArtifact(dir, extension.mount);
+  assert.deepEqual(pluginsMissingArtifacts(dir, [extension]), ["trace"]);
+});
+
+test("mixed plugin without one connection file is missing artifacts", () => {
+  const dir = world();
+  const mixed = codePluginFixture({
+    name: "mixed",
+    extension: true,
+    servers: ["one", "two"],
+  });
+  plantArtifact(dir, mixed.mount);
+  plantArtifact(dir, join(mixed.directory, "package.json"));
+  plantArtifact(dir, mixed.connections[0].file);
+  assert.deepEqual(pluginsMissingArtifacts(dir, [mixed]), ["mixed"]);
+});
+
+test("mixed plugin with every artifact passes pluginsMissingArtifacts", () => {
+  const dir = world();
+  const mixed = codePluginFixture({
+    name: "mixed",
+    extension: true,
+    servers: ["one", "two"],
+  });
+  plantArtifact(dir, mixed.mount);
+  plantArtifact(dir, join(mixed.directory, "package.json"));
+  for (const connection of mixed.connections)
+    plantArtifact(dir, connection.file);
+  assert.deepEqual(pluginArtifacts(mixed), [
+    mixed.mount,
+    mixed.directory,
+    mixed.connections[0].file,
+    mixed.connections[1].file,
+  ]);
+  assert.deepEqual(pluginsMissingArtifacts(dir, [mixed]), []);
 });

--- a/scripts/lib/plugin-build.ts
+++ b/scripts/lib/plugin-build.ts
@@ -585,6 +585,30 @@ export function pluginArtifacts(plugin: CodePlugin): string[] {
   ];
 }
 
+/** Whether every required artifact of this plugin exists in a finished version. */
+export function pluginArtifactsPresent(
+  dir: string,
+  plugin: CodePlugin,
+): boolean {
+  return pluginArtifacts(plugin).every((artifact) =>
+    existsSync(join(dir, artifact)),
+  );
+}
+
+/**
+ * Names of plugins whose required artifacts are absent from a finished version.
+ * Same set `builtWith()` already uses: a mount is required only of a Plugin with
+ * eve Extension, and every generated connection file is required of an MCP server.
+ */
+export function pluginsMissingArtifacts(
+  dir: string,
+  plugins: readonly CodePlugin[],
+): string[] {
+  return plugins
+    .filter((plugin) => !pluginArtifactsPresent(dir, plugin))
+    .map((plugin) => plugin.name);
+}
+
 /** Take a plugin out of a staged version: the copy, the mount, its connections. */
 export function removePluginFromVersion(
   versionDir: string,

--- a/scripts/lib/version-update.ts
+++ b/scripts/lib/version-update.ts
@@ -23,7 +23,7 @@ import {
 import {
   buildPluginExtension,
   codePlugins,
-  pluginArtifacts,
+  pluginArtifactsPresent,
   disableCodePlugin,
   removePluginFromVersion,
   type CodePlugin,
@@ -238,9 +238,7 @@ export function builtWith(
   const carried = files.length > 0 || plugins.length > 0;
   return carried &&
     files.every((path) => sameFile(join(dir, path), join(customDir, path))) &&
-    plugins.every((plugin) =>
-      pluginArtifacts(plugin).every((path) => existsSync(join(dir, path))),
-    )
+    plugins.every((plugin) => pluginArtifactsPresent(dir, plugin))
     ? "applied"
     : "stock";
 }


### PR DESCRIPTION
MCP-only plugins are judged by generated connection files, not by a missing sh.iva mount. Extension plugins still require mount+directory. Mixed plugins must have every connection file.

Fixes #206.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of plugins with missing build artifacts.
  * Version updates now consistently identify missing connection files, mount directories, and built plugin directories.
  * MCP-only plugins now retain their generated connection files when trusted.
* **Tests**
  * Added coverage for MCP-only, extension, and mixed plugins to verify artifact validation across supported plugin types.
  * Added checks confirming trusted MCP-only plugins remain properly configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->