### PR TITLE
bridge: bounded 503 retries stop pinning the poll loop

### DIFF
--- a/scripts/cli/doctor.test.ts
+++ b/scripts/cli/doctor.test.ts
@@ -100,6 +100,77 @@ async function doctorOutput(root: string): Promise<{
   return { events, summaryLogs };
 }
 
+async function bridgeBacklogEvents(
+  root: string,
+  {
+    now,
+    queue,
+    queueRaw,
+    statuses = [],
+  }: {
+    now: number;
+    queue?: unknown;
+    queueRaw?: string;
+    statuses?: Array<{
+      chatKey: string;
+      status: { status?: string; updatedAt?: number };
+    }>;
+  },
+): Promise<Array<[string, string]>> {
+  const data = join(root, "data");
+  const units = join(root, "units");
+  mkdirSync(data, { recursive: true });
+  mkdirSync(units, { recursive: true });
+  writeFileSync(join(units, "iva.service"), "[Service]\n");
+  if (queueRaw !== undefined) {
+    writeFileSync(join(data, "telegram-queue.json"), queueRaw);
+  } else if (queue !== undefined) {
+    writeFileSync(join(data, "telegram-queue.json"), JSON.stringify(queue));
+  }
+  const events: Array<[string, string]> = [];
+  const systemd = createSystemdControl({
+    run: (args) => {
+      if (args[0] === "is-enabled") return { code: 0, out: "enabled" };
+      if (args[0] === "is-active") return { code: 0, out: "active" };
+      return { code: 1, out: "" };
+    },
+  });
+  const runtime: CliRuntime = {
+    ...createCliRuntime(root),
+    UNIT_DIR: units,
+    SERVICES: [],
+    TIMERS: [],
+    C: NO_COLOR,
+    ok: (message) => events.push(["ok", message]),
+    warn: (message) => events.push(["warn", message]),
+    bad: (message) => events.push(["bad", message]),
+    readEnv: completeEnv,
+    dataDirAbs: () => data,
+    hasSystemd: () => true,
+    systemd,
+    cap: (command) =>
+      command === "ss"
+        ? {
+            code: 0,
+            out: "LISTEN 0 511 127.0.0.1:8723 0.0.0.0:*",
+            err: "",
+          }
+        : { code: 1, out: "", err: "" },
+  };
+  await createDoctorCommand(runtime, lifecycle(), {
+    nodeVersion: "24.19.0",
+    now: () => now,
+    telegramInboxFile: join(data, "telegram-inbox.json"),
+    telegramQueueFile: join(data, "telegram-queue.json"),
+    listChatStatusesImpl: () => statuses,
+    log: () => undefined,
+    exit: () => undefined,
+  })();
+  return events.filter(([, message]) =>
+    message.startsWith("bridge backlog:"),
+  );
+}
+
 test("non-systemd doctor preserves exact counter and exit semantics", async (t) => {
   const root = await sandbox(t);
   writeFileSync(join(root, ".env"), "present=true\n");
@@ -138,6 +209,82 @@ test("non-systemd doctor preserves exact counter and exit semantics", async (t) 
     ["Summary: 5 ok · 0 warn · 0 fixed · 0 fail"],
   ]);
   assert.deepEqual(exitCodes, [0]);
+});
+
+test("doctor warns about an old Telegram bridge backlog item", async (t) => {
+  const root = await sandbox(t);
+  writeFileSync(join(root, ".env"), "present=true\n");
+
+  assert.deepEqual(
+    await bridgeBacklogEvents(root, {
+      now: 1_000_000,
+      queue: {
+        version: 1,
+        queues: {
+          "1:": [
+            {
+              version: 1,
+              updateId: 212,
+              enqueuedAt: 340_000,
+              update: { update_id: 212 },
+            },
+          ],
+        },
+      },
+    }),
+    [
+      [
+        "warn",
+        "bridge backlog: oldest item 11m old — check: journalctl --user -u iva-telegram-poll; use /stop or iva restart",
+      ],
+    ],
+  );
+});
+
+test("doctor reports a clear bridge backlog when queue files are missing", async (t) => {
+  const root = await sandbox(t);
+  writeFileSync(join(root, ".env"), "present=true\n");
+
+  assert.deepEqual(await bridgeBacklogEvents(root, { now: 1_000_000 }), [
+    ["ok", "bridge backlog: clear"],
+  ]);
+});
+
+test("doctor warns when a Telegram bridge queue file is corrupt", async (t) => {
+  const root = await sandbox(t);
+  writeFileSync(join(root, ".env"), "present=true\n");
+  const queueFile = join(root, "data", "telegram-queue.json");
+  const events = await bridgeBacklogEvents(root, {
+    now: 1_000_000,
+    queueRaw: "{not json",
+  });
+
+  assert.equal(events.length, 1);
+  assert.equal(events[0]?.[0], "warn");
+  assert.ok(events[0]?.[1].startsWith("bridge backlog:"));
+  assert.ok(events[0]?.[1].includes(`${queueFile} unreadable`));
+  assert.equal(
+    events.some(([, message]) => message === "bridge backlog: clear"),
+    false,
+  );
+});
+
+test("doctor treats a running chat without updatedAt as stuck", async (t) => {
+  const root = await sandbox(t);
+  writeFileSync(join(root, ".env"), "present=true\n");
+
+  assert.deepEqual(
+    await bridgeBacklogEvents(root, {
+      now: 1_000_000,
+      statuses: [{ chatKey: "1:", status: { status: "running" } }],
+    }),
+    [
+      [
+        "warn",
+        "bridge backlog: 1 stuck chat(s) — check: journalctl --user -u iva-telegram-poll; use /stop or iva restart",
+      ],
+    ],
+  );
 });
 
 test("doctor accepts a custom embedding endpoint for hybrid memory search", async (t) => {

--- a/scripts/cli/doctor.ts
+++ b/scripts/cli/doctor.ts
@@ -1,5 +1,13 @@
 import { existsSync, readFileSync, readdirSync, statfsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { join } from "node:path";
+import { listChatStatuses, RUN_STALE_MS } from "#lib/run-status.ts";
+import {
+  loadQueueFile,
+  queueKeys,
+  TELEGRAM_QUEUE_ACK_PENDING_SUFFIX,
+  type TelegramQueueDocument,
+} from "../lib/telegram-queue.ts";
 import { pluginDirectory, pluginMount } from "../lib/plugin-build.ts";
 import { tryLoadPluginCore } from "../lib/plugin-core.ts";
 import { leftoverPluginDirs, pluginReadProblem } from "./plugin-cli-context.ts";
@@ -35,6 +43,9 @@ type DoctorDependencies = {
   readonly exit?: (code: number) => unknown;
   readonly log?: (...args: unknown[]) => void;
   readonly nodeVersion?: string;
+  readonly telegramInboxFile?: string;
+  readonly telegramQueueFile?: string;
+  readonly listChatStatusesImpl?: typeof listChatStatuses;
 };
 
 type RollupEntry = {
@@ -93,6 +104,7 @@ export function createDoctorCommand(
   const log =
     dependencies.log ?? ((...args: unknown[]) => console.log(...args));
   const nodeVersion = dependencies.nodeVersion ?? process.versions.node;
+  const listStatuses = dependencies.listChatStatusesImpl ?? listChatStatuses;
 
   return async function cmdDoctor(): Promise<void> {
     let okN = 0;
@@ -105,6 +117,12 @@ export function createDoctorCommand(
     // Одна выкладка данных на весь прогон: каталог не меняется под ногами, а
     // каждый лишний вызов — это ещё одно чтение .env ради того же ответа.
     const dataDirectory = dataDirAbs(env);
+    const telegramInboxFile =
+      dependencies.telegramInboxFile ??
+      join(dataDirectory, "telegram-inbox.json");
+    const telegramQueueFile =
+      dependencies.telegramQueueFile ??
+      join(dataDirectory, "telegram-queue.json");
 
     // 1. Node ≥24
     const major = parseInt(nodeVersion.split(".")[0], 10);
@@ -465,6 +483,95 @@ export function createDoctorCommand(
           warnN++;
         }
       }
+    }
+
+    // The queue loader normally repairs pending/corrupt files. Doctor only observes them,
+    // so its injected file operations suppress recovery and quarantine writes.
+    const loadBridgeQueue = async (file: string) => {
+      const raw = await readFile(file, "utf8");
+      if (raw.length === 0) return null;
+      return (
+        await loadQueueFile(file, {
+          strict: true,
+          readFileImpl: async (candidate, encoding) => {
+            if (candidate.endsWith(TELEGRAM_QUEUE_ACK_PENDING_SUFFIX)) {
+              throw Object.assign(new Error("pending recovery is read-only"), {
+                code: "ENOENT",
+              });
+            }
+            if (candidate === file) return raw;
+            return readFile(candidate, encoding);
+          },
+          renameImpl: () => Promise.resolve(),
+        })
+      ).document;
+    };
+    const bridgeDocuments: TelegramQueueDocument[] = [];
+    let bridgeUnreadable = false;
+    for (const file of [telegramInboxFile, telegramQueueFile]) {
+      try {
+        const document = await loadBridgeQueue(file);
+        if (document) bridgeDocuments.push(document);
+      } catch (error) {
+        if (
+          (error as NodeJS.ErrnoException | null | undefined)?.code === "ENOENT"
+        ) {
+          continue;
+        }
+        warn(
+          `bridge backlog: ${file} unreadable — check: journalctl --user -u iva-telegram-poll`,
+        );
+        warnN++;
+        bridgeUnreadable = true;
+      }
+    }
+    let statuses: ReturnType<typeof listChatStatuses> = [];
+    try {
+      statuses = listStatuses();
+    } catch {
+      // A missing or unreadable run-status directory contributes no stale chats.
+    }
+    const checkedAt = now();
+    const stuckChats = statuses.filter(
+      ({ status }) =>
+        status.status === "running" &&
+        (typeof status.updatedAt !== "number" ||
+          checkedAt - status.updatedAt > RUN_STALE_MS),
+    ).length;
+    let itemCount = 0;
+    let oldestEnqueuedAt: number | null = null;
+    for (const document of bridgeDocuments) {
+      for (const key of queueKeys(document)) {
+        for (const item of document.queues[key]) {
+          itemCount++;
+          if (
+            typeof item.enqueuedAt === "number" &&
+            Number.isFinite(item.enqueuedAt) &&
+            (oldestEnqueuedAt === null || item.enqueuedAt < oldestEnqueuedAt)
+          ) {
+            oldestEnqueuedAt = item.enqueuedAt;
+          }
+        }
+      }
+    }
+    const oldestAgeMs =
+      itemCount > 0 && oldestEnqueuedAt !== null
+        ? checkedAt - oldestEnqueuedAt
+        : 0;
+    if (stuckChats > 0 || oldestAgeMs > 600_000) {
+      const details = [
+        ...(stuckChats > 0 ? [`${stuckChats} stuck chat(s)`] : []),
+        ...(oldestAgeMs > 600_000
+          ? [`oldest item ${Math.round(oldestAgeMs / 60_000)}m old`]
+          : []),
+      ].join(", ");
+      warn(
+        `bridge backlog: ${details} — check: journalctl --user -u iva-telegram-poll; use /stop or iva restart`,
+      );
+      warnN++;
+    } else if (!bridgeUnreadable) {
+      ok("bridge backlog: clear");
+      okN++;
     }
 
     // 6. Vault + git origin (report only — we don't initiate git operations)

--- a/scripts/poller/deliver.test.ts
+++ b/scripts/poller/deliver.test.ts
@@ -1,0 +1,58 @@
+/* eslint-disable @typescript-eslint/require-await -- Async fetch double preserves the production boundary. */
+import assert from "node:assert/strict";
+import { setImmediate as waitForImmediate } from "node:timers/promises";
+import test from "node:test";
+
+process.env.TELEGRAM_BOT_TOKEN = "73002:test-token";
+process.env.TELEGRAM_ALLOWED_USER_IDS = "42";
+process.env.TELEGRAM_POLL_SETTLE_MS = "0";
+
+const { deliver } = await import("./deliver.ts");
+
+void test("direct acceptance 503 exhausts three attempts and notifies retained once", async (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  t.mock.method(console, "log", () => undefined);
+  const originalFetch = globalThis.fetch;
+  let deliveryAttempts = 0;
+  let retainedNotifications = 0;
+  globalThis.fetch = async (input) => {
+    const url = input instanceof Request ? input.url : String(input);
+    if (url.endsWith("/sendMessage")) {
+      retainedNotifications++;
+      return Response.json({ ok: true });
+    }
+    assert.match(url, /\/eve\/v1\/telegram\/accepted$/u);
+    deliveryAttempts++;
+    return new Response(null, { status: 503 });
+  };
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const pending = deliver(
+    {
+      update_id: 212,
+      message: {
+        message_id: 212,
+        date: 1,
+        chat: { id: 1, type: "private" },
+        from: { id: 42, is_bot: false },
+        text: "hello",
+      },
+    },
+    {
+      timeoutMs: 90_000,
+      retryAcceptanceTimeout: false,
+      boundedAttempts: 3,
+    },
+  );
+
+  await waitForImmediate();
+  t.mock.timers.tick(1_000);
+  await waitForImmediate();
+  t.mock.timers.tick(2_000);
+
+  assert.equal(await pending, false);
+  assert.equal(deliveryAttempts, 3);
+  assert.equal(retainedNotifications, 1);
+});

--- a/scripts/poller/deliver.ts
+++ b/scripts/poller/deliver.ts
@@ -27,6 +27,7 @@ export type DeliverOptions = {
   queueReceipt?: boolean;
   retry?: boolean;
   retryAcceptanceTimeout?: boolean;
+  boundedAttempts?: number;
   timeoutMs?: number;
   onAcceptanceFailure?: (details: Record<string, unknown>) => Promise<unknown>;
 };
@@ -56,6 +57,7 @@ async function deliver(
     queueReceipt: requestedQueueReceipt,
     retry = true,
     retryAcceptanceTimeout = retry,
+    boundedAttempts = BOUNDED_ATTEMPTS,
     timeoutMs,
     onAcceptanceFailure,
   }: DeliverOptions = {},
@@ -148,15 +150,15 @@ async function deliver(
         return false;
       }
       if (cls === "bounded") {
-        if (attempt < BOUNDED_ATTEMPTS) {
+        if (attempt < boundedAttempts) {
           log(
-            `deliver: eve replied ${res.status} (attempt ${attempt}/${BOUNDED_ATTEMPTS}) — retrying (may be transient)`,
+            `deliver: eve replied ${res.status} (attempt ${attempt}/${boundedAttempts}) — retrying (may be transient)`,
           );
           await sleep(wait);
           continue;
         }
         log(
-          `deliver: eve replied ${res.status} ${BOUNDED_ATTEMPTS} times; giving up this pass; durable owner retains update ${String(update.update_id)}`,
+          `deliver: eve replied ${res.status} ${boundedAttempts} times; giving up this pass; durable owner retains update ${String(update.update_id)}`,
         );
         await notifyDeliverProblem("retained", res.status);
         return false;
@@ -201,15 +203,15 @@ async function deliver(
         return false;
       }
       if (acceptanceTimeout) {
-        if (attempt < BOUNDED_ATTEMPTS) {
+        if (attempt < boundedAttempts) {
           log(
-            `deliver: acceptance timed out (attempt ${attempt}/${BOUNDED_ATTEMPTS}) — retrying`,
+            `deliver: acceptance timed out (attempt ${attempt}/${boundedAttempts}) — retrying`,
           );
           await sleep(wait);
           continue;
         }
         log(
-          `deliver: acceptance timed out ${BOUNDED_ATTEMPTS} times; giving up this pass; durable owner retains update ${String(update.update_id)}`,
+          `deliver: acceptance timed out ${boundedAttempts} times; giving up this pass; durable owner retains update ${String(update.update_id)}`,
         );
         await notifyDeliverProblem("retained", "timeout");
         return false;

--- a/scripts/poller/inbox.test.ts
+++ b/scripts/poller/inbox.test.ts
@@ -70,6 +70,10 @@ function inboxDocument(
   );
 }
 
+function promotionBackoff() {
+  return new Map<string, { failures: number; nextAttemptAt: number }>();
+}
+
 function callback(updateId: number, fromId = 42): TelegramQueueUpdate {
   return {
     update_id: updateId,
@@ -227,6 +231,7 @@ void test("promotion publishes the delivery item before removing raw ownership",
   let document = inboxDocument(update(101, "first"), update(102, "second"));
   const events: string[] = [];
   const remaining = await promoteReadyInbox({
+    backoff: promotionBackoff(),
     now: () => 1_000,
     collectorOptions: { quietMs: 800 },
     loadImpl: () => Promise.resolve(document),
@@ -250,6 +255,7 @@ void test("failed promotion keeps every raw part for retry", async () => {
   let acknowledgements = 0;
   assert.equal(
     await promoteReadyInbox({
+      backoff: promotionBackoff(),
       now: () => 1_000,
       collectorOptions: { quietMs: 800 },
       loadImpl: () => Promise.resolve(document),
@@ -259,9 +265,58 @@ void test("failed promotion keeps every raw part for retry", async () => {
         return Promise.resolve();
       },
     }),
-    2,
+    0,
   );
   assert.equal(acknowledgements, 0);
+});
+
+void test("rejected inbox promotion backs off the key until its next attempt", async () => {
+  const document = inboxDocument(update(101, "retry me"));
+  const backoff = promotionBackoff();
+  let currentNow = 1_000;
+  let routes = 0;
+  const promote = () =>
+    promoteReadyInbox({
+      backoff,
+      now: () => currentNow,
+      collectorOptions: { quietMs: 0 },
+      loadImpl: () => Promise.resolve(document),
+      routeImpl: () => {
+        routes++;
+        return Promise.resolve("rejected");
+      },
+    });
+
+  assert.equal(await promote(), 0);
+  assert.equal(routes, 1);
+  currentNow = 15_999;
+  assert.equal(await promote(), 0);
+  assert.equal(routes, 1);
+  currentNow = 16_000;
+  assert.equal(await promote(), 0);
+  assert.equal(routes, 2);
+});
+
+void test("successful inbox promotion clears prior backoff state", async () => {
+  let document = inboxDocument(update(101, "deliver me"));
+  const backoff = promotionBackoff();
+  backoff.set("1::42", { failures: 2, nextAttemptAt: 1_000 });
+
+  assert.equal(
+    await promoteReadyInbox({
+      backoff,
+      now: () => 1_000,
+      collectorOptions: { quietMs: 0 },
+      loadImpl: () => Promise.resolve(document),
+      routeImpl: () => Promise.resolve("delivered"),
+      acknowledgeImpl: (key, updateId) => {
+        document = removeQueueHead(document, key, updateId);
+        return Promise.resolve();
+      },
+    }),
+    0,
+  );
+  assert.equal(backoff.has("1::42"), false);
 });
 
 void test("callback rejection, downstream drop, and enqueue failure all retain inbox ownership", async () => {
@@ -270,6 +325,7 @@ void test("callback rejection, downstream drop, and enqueue failure all retain i
     let acknowledgements = 0;
     assert.equal(
       await promoteReadyInbox({
+        backoff: promotionBackoff(),
         now: () => 0,
         loadImpl: () => Promise.resolve(document),
         routeImpl: () => Promise.resolve(result),
@@ -278,7 +334,7 @@ void test("callback rejection, downstream drop, and enqueue failure all retain i
           return Promise.resolve();
         },
       }),
-      1,
+      0,
     );
     assert.equal(acknowledgements, 0, result);
   }
@@ -288,6 +344,7 @@ void test("a terminally dropped update leaves the inbox instead of looping forev
   let document = inboxDocument(update(101, "reply to a closed session"));
   const routed: number[] = [];
   const remaining = await promoteReadyInbox({
+    backoff: promotionBackoff(),
     now: () => 1_000,
     collectorOptions: { quietMs: 800 },
     loadImpl: () => Promise.resolve(document),
@@ -333,10 +390,12 @@ void test("property: terminal results never loop while transient results never l
         );
         const deliveries: number[] = [];
         const attempts = new Map<number, number>();
+        const backoff = promotionBackoff();
 
         for (let pass = 0; pass < passes; pass++) {
           await promoteReadyInbox({
-            now: () => 1_000,
+            backoff,
+            now: () => pass * 300_001,
             collectorOptions: { quietMs: 0 },
             loadImpl: () => Promise.resolve(document),
             routeImpl: (candidate) => {

--- a/scripts/poller/inbox.ts
+++ b/scripts/poller/inbox.ts
@@ -24,6 +24,13 @@ import { routeMessageUpdate, type RouteMessageResult } from "./routing.ts";
 
 export const TELEGRAM_INBOX_FILE = join(DATA_DIR, "telegram-inbox.json");
 
+type InboxPromotionBackoff = {
+  failures: number;
+  nextAttemptAt: number;
+};
+
+const inboxPromotionBackoff = new Map<string, InboxPromotionBackoff>();
+
 export type InboxCollectorOptions = {
   quietMs?: unknown;
   mediaQuietMs?: unknown;
@@ -212,6 +219,7 @@ export async function promoteReadyInbox({
   routeImpl = routeMessageUpdate,
   acknowledgeImpl = (key: string, updateId: number) =>
     acknowledgeQueueHead(TELEGRAM_INBOX_FILE, key, updateId, { strict: true }),
+  backoff = inboxPromotionBackoff,
 }: {
   now?: () => number;
   collectorOptions?: InboxCollectorOptions;
@@ -220,13 +228,16 @@ export async function promoteReadyInbox({
   >;
   routeImpl?: (update: TelegramQueueUpdate) => Promise<RouteMessageResult>;
   acknowledgeImpl?: (key: string, updateId: number) => Promise<unknown>;
+  backoff?: Map<string, InboxPromotionBackoff>;
 } = {}): Promise<number> {
   const snapshot = await loadImpl();
   for (const key of queueKeys(snapshot)) {
+    const attemptAt = now();
+    if (attemptAt < (backoff.get(key)?.nextAttemptAt ?? 0)) continue;
     const batch = selectReadyInboxBatch(
       key,
       snapshot.queues[key],
-      now(),
+      attemptAt,
       collectorOptions,
     );
     if (!batch) continue;
@@ -238,11 +249,25 @@ export async function promoteReadyInbox({
       routed !== "delivered" &&
       routed !== "terminal-drop"
     ) {
+      const failures = (backoff.get(key)?.failures ?? 0) + 1;
+      backoff.set(key, {
+        failures,
+        nextAttemptAt:
+          now() + Math.min(15_000 * 2 ** (failures - 1), 300_000),
+      });
       continue;
     }
+    backoff.delete(key);
     for (const updateId of batch.updateIds) {
       await acknowledgeImpl(key, updateId);
     }
   }
-  return queueCount(await loadImpl());
+  const remaining = await loadImpl();
+  return queueKeys(remaining).reduce(
+    (count, key) =>
+      now() < (backoff.get(key)?.nextAttemptAt ?? 0)
+        ? count
+        : count + queueCount(remaining, key),
+    0,
+  );
 }

--- a/scripts/poller/routing.ts
+++ b/scripts/poller/routing.ts
@@ -171,6 +171,9 @@ async function deliverDirectUpdate(
     onAcceptanceFailure,
     timeoutMs: DIRECT_ACCEPTANCE_TIMEOUT_MS,
     retryAcceptanceTimeout: false,
+    // The durable inbox retries this path; inline retries only cover a brief startup race.
+    // Before issue #212, 30 attempts could block the single-threaded loop for minutes.
+    boundedAttempts: 3,
   });
   // Reply на сообщение бота, чья сессия закрыта: eve не смогла ни продолжить её, ни
   // начать новый ход. Апдейт умирает здесь — владелец снимет его с хранения, иначе

--- a/scripts/telegram-poll-queue-durable.test.ts
+++ b/scripts/telegram-poll-queue-durable.test.ts
@@ -609,21 +609,18 @@ test("a direct acceptance timeout rejects once and returns to Telegram polling",
   );
 });
 
-test("a retained acceptance failure retries without repeating its alert", (t: TestContext) => {
+test("a retained acceptance failure stays owned and alerts once", (t: TestContext) => {
   const dataDir = makeDataDir(t, "direct-timeout-alert-throttle");
   writeFileSync(join(dataDir, "alert-state.json"), "{corrupt\n");
   const result = runHarness("direct-timeout-twice", dataDir, "none", {
     directAcceptanceTimeoutMs: "25",
   });
 
-  assert.deepEqual(result.deliveryRoutes, [
-    "/eve/v1/telegram/accepted",
-    "/eve/v1/telegram/accepted",
-  ]);
+  assert.deepEqual(result.deliveryRoutes, ["/eve/v1/telegram/accepted"]);
   assert.deepEqual(
     result.failureNotices.map(({ chat_id, text }) => [chat_id, text]),
     [["1", "Couldn't process the message - repeat it or use /new"]],
-    "the durable retry remains live but one unresolved problem alerts only once",
+    "the first failure must alert once even when persisted alert state is corrupt",
   );
   assert.deepEqual(ownedUpdates(result), [
     { location: "inbox", updateId: 101 },

--- a/scripts/telegram-poll.test.ts
+++ b/scripts/telegram-poll.test.ts
@@ -24,6 +24,7 @@ type AcceptanceFailure = {
 type DeliverOptions = {
   timeoutMs?: number;
   retryAcceptanceTimeout?: boolean;
+  boundedAttempts?: number;
   onAcceptanceFailure: (failure: AcceptanceFailure) => Promise<void>;
 };
 type RouteOptions = {
@@ -320,6 +321,7 @@ test("a direct acceptance timeout is rejected after one cleanup and notification
         deliveries++;
         assert.equal(options.timeoutMs, 90_000);
         assert.equal(options.retryAcceptanceTimeout, false);
+        assert.equal(options.boundedAttempts, 3);
         current = {
           status: "running",
           generation: 5,


### PR DESCRIPTION
## Problem

When eve wedges, the acceptance route replies HTTP 503 ("webhook dispatched, but `Eve.send()` never resolved"). The bridge is single-threaded, and direct delivery retried that 503 up to 30 times with backoff up to 15s — about 5.7 minutes during which `getUpdates` and out-of-band commands (`/stop`, `/new`) were completely stalled. After giving up, the durable inbox re-promoted the same update on the next pass (1-second poll), restarting the 5.7-minute stall in an endless loop.

User-visible symptoms (issue #212): the bot hangs, "Working…" messages appear and vanish (each delivery attempt spawns an early status that `clearFailedDirectIngress` then deletes), the Stop button never shows (it is attached on `turn.started`, which never arrives), and `iva doctor` reports no anomalies because it only checked `systemd is-active` and the listening socket.

## Changes

- **`scripts/poller/deliver.ts`** — new `boundedAttempts` option (default keeps the old 30) applied to both the bounded-status and acceptance-timeout retry branches.
- **`scripts/poller/routing.ts`** — direct message delivery passes `boundedAttempts: 3`: the durable inbox is the real retry mechanism (same rationale as the queue replay path); inline retries only need to cover a brief startup race. The callback path, the config class (60s), and `drainReadyQueueHeads` are untouched.
- **`scripts/poller/inbox.ts`** — per-key promotion backoff: a rejected key waits `min(15s · 2^(failures−1), 5 min)` before re-promotion, is excluded from the pending count (so it no longer forces the 1-second poll), and its state clears on `delivered`/`queued`/`terminal-drop`. In-memory by design — durable ownership stays on disk.
- **`scripts/cli/doctor.ts`** — new read-only "bridge backlog" check: warns on chats stuck in `running` past `RUN_STALE_MS` (including records without a valid `updatedAt`), on queued/inboxed items older than 10 minutes, and on unreadable queue files; missing or empty files stay ok. Paths resolve from the same `.env`-based data directory as every other doctor check; recovery/quarantine writes are suppressed.

Out of scope, intentionally: the agent-side reason eve wedges (worth its own issue if it recurs after this lands), the Stop button for never-started turns (`/stop` works out-of-band once the loop is no longer pinned), and the update-offer flow (offer-only is by design, see `docs/cli.md`).

## Verification

- `node --test` over the six affected test files: **114/114 pass**, including the restored `direct-timeout-twice` integration test, which was mutation-checked: disabling the backoff makes it fail with two delivery routes.
- `tsgo` and `eslint` clean.
- New tests: direct 503 gives up after 3 attempts and fires the retained notice once; a rejected inbox key backs off, is not counted as pending, and clears on success; doctor warns on stale queue items, corrupt queue files, and running chats without `updatedAt`.

Fixes #212

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added doctor diagnostics for Telegram bridge backlogs, including stale, missing, corrupt, or stuck queue states.
  - Added clear status reporting when no backlog issues are detected.

- **Bug Fixes**
  - Improved notification delivery reliability by limiting repeated acceptance retries and retaining failed notifications safely.
  - Added exponential backoff for repeatedly failing inbox routing, reducing unnecessary retry activity.
  - Ensured successful delivery clears prior retry delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->