### PR TITLE
fix(telegram): do not re-arm idle interruption notices

### DIFF
--- a/scripts/lib/wf-store.test.ts
+++ b/scripts/lib/wf-store.test.ts
@@ -145,7 +145,7 @@ void test("global reset plan includes workflow and all Telegram control-state ta
   ]);
 });
 
-void test("update rewrite expires valid chats and preserves cleanup fields", () => {
+void test("update rewrite expires running chats and preserves cleanup fields", () => {
   const dataDir = mkdtempSync(join(tmpdir(), "wf-store-run-status-"));
   const dir = join(dataDir, "run-status.d");
   const file = join(dir, "chat.json");
@@ -155,7 +155,7 @@ void test("update rewrite expires valid chats and preserves cleanup fields", () 
     file,
     JSON.stringify({
       generation: 1,
-      status: "idle",
+      status: "running",
       updatedAt: Date.now(),
       sessionId: "session-to-reset",
       statusMessageId: 4242,
@@ -186,4 +186,37 @@ void test("update rewrite expires valid chats and preserves cleanup fields", () 
   );
   assert.equal(statSync(file).mode & 0o777, 0o600);
   assert.equal(readFileSync(damagedFile, "utf8"), "{not json");
+});
+
+void test("update rewrite leaves terminal chats alone and does not re-arm a notice", () => {
+  const dataDir = mkdtempSync(join(tmpdir(), "wf-store-idle-status-"));
+  const dir = join(dataDir, "run-status.d");
+  mkdirSync(dir);
+  const records = {
+    idle: {
+      generation: 4,
+      status: "idle",
+      updatedAt: 1234,
+      resetAt: 1233,
+    },
+    failed: {
+      generation: 5,
+      status: "failed",
+      updatedAt: 2345,
+      sessionId: "finished-session",
+    },
+  } as const;
+  for (const [name, record] of Object.entries(records))
+    writeFileSync(join(dir, `${name}.json`), JSON.stringify(record), {
+      mode: 0o600,
+    });
+
+  rewriteRunStatusesForUpdate(dataDir);
+  rewriteRunStatusesForUpdate(dataDir);
+
+  for (const [name, record] of Object.entries(records))
+    assert.deepEqual(
+      JSON.parse(readFileSync(join(dir, `${name}.json`), "utf8")),
+      record,
+    );
 });

--- a/scripts/lib/wf-store.ts
+++ b/scripts/lib/wf-store.ts
@@ -115,7 +115,7 @@ function writeRunStatusAtomicSync(path: string, value: unknown): void {
   }
 }
 
-/** Make every saved chat immediately reapable after an update clears sessions. */
+/** Make only interrupted runs immediately reapable after an update clears sessions. */
 export function rewriteRunStatusesForUpdate(dataDir: string): void {
   const dir = join(dataDir, "run-status.d");
   let names: string[];
@@ -137,6 +137,10 @@ export function rewriteRunStatusesForUpdate(dataDir: string): void {
         Array.isArray(parsed)
       )
         continue;
+      // An update interrupts an in-flight turn, not an idle or terminal chat. Rewriting
+      // every saved record re-arms the stale-run notification after every plugin build,
+      // even when the owner has sent nothing and there is no session to reset.
+      if ((parsed as { status?: unknown }).status !== "running") continue;
       writeRunStatusAtomicSync(file, {
         ...parsed,
         status: "running",

--- a/scripts/update-finish.test.ts
+++ b/scripts/update-finish.test.ts
@@ -66,7 +66,7 @@ test("update quarantines session state and rewrites chat status in place", (t) =
   writeFileSync(
     join(data, "run-status.d/chat.json"),
     JSON.stringify({
-      status: "idle",
+      status: "running",
       updatedAt: 123,
       statusMessageId: 42,
       sessionId: "old-session",


### PR DESCRIPTION
## Summary

- expire only `running` Telegram chat statuses when an update retires workflow sessions
- preserve `idle` and terminal statuses across version/plugin rebuilds
- add regression coverage for repeated rewrites so a completed chat cannot be re-armed for another stale-run notice

## Problem

Every managed version rebuild calls `rewriteRunStatusesForUpdate()`. The function currently rewrites every saved chat record to `status: "running"` with `updatedAt: 0`, including chats that were already idle and had no active session.

When the Telegram poller starts, its stale-run reaper consumes those synthetic running records and sends:

> The previous turn was interrupted - repeat your request or use /new

Repeated plugin builds therefore produce repeated interruption notices even when the owner sent no request and no turn was interrupted.

## Fix

Only records that were already `running` are made immediately reapable. Those are the records whose in-flight turns can actually be interrupted by workflow-store quarantine. Idle and terminal records remain unchanged.

## Verification

- `node --test scripts/lib/wf-store.test.ts scripts/update-finish.test.ts scripts/telegram-poll.test.ts` — 74 passed
- `npm run typecheck` — passed
- `npm run lint` — passed
- `npm run format:check` — passed
- `npm run build` — passed

The full test suite was also attempted on the reporting host. Patch-related tests passed; unrelated environment-sensitive tests failed because that host has a restrictive umask, a pending-reboot marker, and no `uv` in the test PATH.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated workflow status handling so only interrupted, running chats are reactivated during updates.
  - Preserved terminal chat states, including idle and failed records, across repeated updates.
  - Retained existing cleanup information when running chats are reactivated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->